### PR TITLE
OpenCL: Single search buffer to lower latency

### DIFF
--- a/libethash-cl/ethash_cl_miner.cpp
+++ b/libethash-cl/ethash_cl_miner.cpp
@@ -412,7 +412,7 @@ bool ethash_cl_miner::init(
 
 		m_searchKernel.setArg(1, m_header);
 		m_searchKernel.setArg(2, m_dag);
-		m_searchKernel.setArg(5, ~0u);
+		m_searchKernel.setArg(5, ~0u);  // Pass this to stop the compiler unrolling the loops.
 
 		// create mining buffers
 		for (unsigned i = 0; i != c_bufferCount; ++i)
@@ -473,7 +473,6 @@ void ethash_cl_miner::search(uint8_t const* header, uint64_t target, search_hook
 
 		m_queue.finish();
 
-		// pass these to stop the compiler unrolling the loops
 		m_searchKernel.setArg(4, target);
 		
 		unsigned buf = 0;

--- a/libethash-cl/ethash_cl_miner.h
+++ b/libethash-cl/ethash_cl_miner.h
@@ -27,7 +27,7 @@
 class ethash_cl_miner
 {
 private:
-	enum { c_maxSearchResults = 63, c_bufferCount = 1 };
+	enum { c_maxSearchResults = 63 };
 
 public:
 	struct search_hook
@@ -84,7 +84,7 @@ private:
 	cl::Buffer m_dag;
 	cl::Buffer m_light;
 	cl::Buffer m_header;
-	cl::Buffer m_searchBuffer[c_bufferCount];
+	cl::Buffer m_searchBuffer;
 	unsigned m_globalWorkSize;
 
 	/// The local work size for the search

--- a/libethash-cl/ethash_cl_miner.h
+++ b/libethash-cl/ethash_cl_miner.h
@@ -27,7 +27,7 @@
 class ethash_cl_miner
 {
 private:
-	enum { c_maxSearchResults = 63 };
+	enum { c_maxSearchResults = 1 };
 
 public:
 	struct search_hook

--- a/libethash-cl/ethash_cl_miner.h
+++ b/libethash-cl/ethash_cl_miner.h
@@ -27,7 +27,7 @@
 class ethash_cl_miner
 {
 private:
-	enum { c_maxSearchResults = 63, c_bufferCount = 2 };
+	enum { c_maxSearchResults = 63, c_bufferCount = 1 };
 
 public:
 	struct search_hook

--- a/libethash-cl/ethash_cl_miner.h
+++ b/libethash-cl/ethash_cl_miner.h
@@ -40,7 +40,6 @@ public:
 	};
 
 	ethash_cl_miner() = default;
-	~ethash_cl_miner();
 
 	static bool searchForAllDevices(unsigned _platformId, std::function<bool(cl::Device const&)> _callback);
 	static void doForAllDevices(unsigned _platformId, std::function<void(cl::Device const&)> _callback);
@@ -63,7 +62,6 @@ public:
 		unsigned _platformId,
 		unsigned _deviceId
 		);
-	void finish();
 	void search(uint8_t const* _header, uint64_t _target, search_hook& _hook, uint64_t _startN);
 
 	/* -- default values -- */


### PR DESCRIPTION
Simplify sync with OpenCL by removing pending workset queue.
I've noticed 0.1% performance improvement.