### PR TITLE
Make OpenCL default work size consistently the same as CUDA

### DIFF
--- a/libethash-cl/ethash_cl_miner.cpp
+++ b/libethash-cl/ethash_cl_miner.cpp
@@ -45,8 +45,8 @@
 
 using namespace std;
 
-unsigned const ethash_cl_miner::c_defaultLocalWorkSize = 64;
-unsigned const ethash_cl_miner::c_defaultGlobalWorkSizeMultiplier = 4096; // * CL_DEFAULT_LOCAL_WORK_SIZE
+unsigned const ethash_cl_miner::c_defaultLocalWorkSize = 128;
+unsigned const ethash_cl_miner::c_defaultGlobalWorkSizeMultiplier = 8192; // * CL_DEFAULT_LOCAL_WORK_SIZE
 
 // TODO: If at any point we can use libdevcore in here then we should switch to using a LogChannel
 #define ETHCL_LOG(_contents) std::cout << "[OpenCL] " << _contents << std::endl


### PR DESCRIPTION
Update OpenCL defaults to the same as CUDA. Reasons:
- After this fix my AMD Tonga card no longer TDRs running ethminer --benchmark
- Currently m_localWorkSize (MinerAux.h) has different values for OpenCL if ETH_ETHASHCUDA is defined

I believe this will also fix https://github.com/ethereum-mining/ethminer/issues/78
