### PR TITLE
Do to set empty work

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -614,11 +614,11 @@ private:
 		//genesis.prep();
 
 		genesis.setDifficulty(u256(1) << 63);
-		f.setWork(genesis);
 		if (_m == MinerType::CL)
 			f.start("opencl", false);
 		else if (_m == MinerType::CUDA)
 			f.start("cuda", false);
+		f.setWork(genesis);
 
 		map<uint64_t, WorkingProgress> results;
 		uint64_t mean = 0;
@@ -677,12 +677,12 @@ private:
 		//genesis.prep();
 
 		genesis.setDifficulty(u256(1) << difficulty);
-		f.setWork(genesis);
 
 		if (_m == MinerType::CL)
 			f.start("opencl", false);
 		else if (_m == MinerType::CUDA)
 			f.start("cuda", false);
+		f.setWork(genesis);
 
 		int time = 0;
 

--- a/libdevcore/Worker.h
+++ b/libdevcore/Worker.h
@@ -41,7 +41,7 @@ enum class WorkerState
 
 class Worker
 {
-protected:
+public:
 	Worker(std::string const& _name): m_name(_name) {}
 
 	Worker(Worker const&) = delete;
@@ -55,11 +55,11 @@ protected:
 	/// Stop worker thread; causes call to stopWorking().
 	void stopWorking();
 
-	virtual void workLoop() = 0;
-
 	bool shouldStop() const { return m_state != WorkerState::Started; }
 
 private:
+	virtual void workLoop() = 0;
+
 	std::string m_name;
 
 	mutable Mutex x_work;						///< Lock for the network existance.

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -143,7 +143,14 @@ void CLMiner::workLoop()
 	// take local copy of work since it may end up being overwritten by kickOff/pause.
 	try {
 		const WorkPackage w = work();
-		cllog << "Set work. Header" << w.header << "target" << w.boundary.hex().substr(0, 12);
+
+		if (!w)
+		{
+			cllog << "No work. Pause.";
+			return;
+		}
+
+		cllog << "Set work. Header" << w.header << "target" << w.boundary.hex();
 		if (m_seed != w.seed)
 		{
 			if (s_dagLoadMode == DAG_LOAD_MODE_SEQUENTIAL)

--- a/libethcore/EthashCUDAMiner.cpp
+++ b/libethcore/EthashCUDAMiner.cpp
@@ -125,6 +125,9 @@ void EthashCUDAMiner::workLoop()
 	// take local copy of work since it may end up being overwritten by kickOff/pause.
 	try {
 		WorkPackage w = work();
+		if (!w)
+			return;
+
 		cnote << "set work; seed: " << "#" + w.seed.hex().substr(0, 8) + ", target: " << "#" + w.boundary.hex().substr(0, 12);
 		if (!m_miner || m_minerSeed != w.seed)
 		{
@@ -162,7 +165,7 @@ void EthashCUDAMiner::workLoop()
 			light = EthashAux::light(w.seed);
 			//bytesConstRef dagData = dag->data();
 			bytesConstRef lightData = light->data();
-			
+
 			m_miner->init(light->light, lightData.data(), lightData.size(), device, (s_dagLoadMode == DAG_LOAD_MODE_SINGLE), &s_dagInHostMemory);
 			s_dagLoadIndex++;
 

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -100,8 +100,12 @@ public:
 		}
 		for (unsigned i = start; i < ins; ++i)
 		{
+			// TODO: Improve miners creation, use unique_ptr.
 			m_miners.push_back(std::shared_ptr<Miner>(m_sealers[_sealer].create(*this, i)));
-			m_miners.back()->setWork(m_work);
+
+			// Start miners' threads. They should pause waiting for new work
+			// package.
+			m_miners.back()->startWorking();
 		}
 		m_isMining = true;
 		m_lastSealer = _sealer;

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -155,6 +155,7 @@ public:
 			Guard l(x_work);
 			m_work = _work;
 		}
+		assert(!!_work);
 		if (!!_work)
 		{
 			pause();


### PR DESCRIPTION
The farm sometimes sends empty work package to miners. The setWork() has magic side effects of restarting miners. We want to get rid of this -- miners should not be restarted this way.