### PR TITLE
describe the steps necessary to build on Ubuntu 17.04;

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This project uses [CMake] and [Hunter] package manager.
    mkdir build; cd build
    ```
 
-1. Configure the project with CMake. Check out additional
+2. Configure the project with CMake. Check out additional
    [configuration options](#cmake-configuration-options).
 
    ```sh
@@ -106,14 +106,14 @@ This project uses [CMake] and [Hunter] package manager.
     -DCMAKE_CXX_FLAGS="-fPIC"
    ```
 
-1. Build the project using [CMake Build Tool Mode]. This is a portable variant
+3. Build the project using [CMake Build Tool Mode]. This is a portable variant
    of `make`.
 
    ```sh
    cmake --build .
    ```
 
-1. _(Optional, Linux only)_ Install the built executable.
+4. _(Optional, Linux only)_ Install the built executable.
 
    ```sh
    sudo make install

--- a/README.md
+++ b/README.md
@@ -78,21 +78,33 @@ This project uses [CMake] and [Hunter] package manager.
    mkdir build; cd build
    ```
 
-2. Configure the project with CMake. Check out additional
+1. Configure the project with CMake. Check out additional
    [configuration options](#cmake-configuration-options).
 
    ```sh
    cmake ..
    ```
+   e.g. incantation for Ubuntu 17.04 "Zesty" with CUDA, without CL, and addressing the
+   problems of requiring an older version of gcc and error "relocation R_X86_64_32S
+   against.bss' can not be used when making a shared object" mentioned in [this
+   issue](https://github.com/ethereum-mining/ethminer/issues/38).
+   ```sh
+   sudo apt install nvidia-{cuda-toolkit,opencl-dev} g{cc,++}-4.9 && \
+   cmake .. \
+    -DETHASHCUDA=ON \
+    -DETHASHCL=OFF \
+    -DCUDA_NVCC_FLAGS="-ccbin gcc-4.9" \
+    -DCMAKE_CXX_FLAGS="-fPIC"
+   ```
 
-3. Build the project using [CMake Build Tool Mode]. This is a portable variant
+1. Build the project using [CMake Build Tool Mode]. This is a portable variant
    of `make`.
 
    ```sh
    cmake --build .
    ```
 
-4. _(Optional, Linux only)_ Install the built executable.
+1. _(Optional, Linux only)_ Install the built executable.
 
    ```sh
    sudo make install
@@ -125,7 +137,6 @@ cmake .. -DETHASHCUDA=ON -DETHASHCL=OFF
 - `-DETHASHCL=ON` - enable OpenCL mining, `ON` by default,
 - `-DETHASHCUDA=ON` - enable CUDA mining, `OFF` by default,
 - `-DETHSTRATUM=ON` - build with Stratum protocol support, `ON` by default.
-
 
 ## Maintainer
 

--- a/README.md
+++ b/README.md
@@ -84,10 +84,19 @@ This project uses [CMake] and [Hunter] package manager.
    ```sh
    cmake ..
    ```
-   e.g. incantation for Ubuntu 17.04 "Zesty" with CUDA, without CL, and addressing the
+   e.g. incantation for Ubuntu 17.04 "Zesty" without CL, and addressing the
    problems of requiring an older version of gcc and error "relocation R_X86_64_32S
    against.bss' can not be used when making a shared object" mentioned in [this
    issue](https://github.com/ethereum-mining/ethminer/issues/38).
+   ```sh
+   sudo apt install nvidia-opencl-dev g{cc,++}-4.9 && \
+   cmake .. \
+    -DETHASHCL=OFF \
+    -DCUDA_NVCC_FLAGS="-ccbin gcc-4.9" \
+    -DCMAKE_CXX_FLAGS="-fPIC"
+   ```
+
+   Alternatively, the same as above with CUDA enabled:
    ```sh
    sudo apt install nvidia-{cuda-toolkit,opencl-dev} g{cc,++}-4.9 && \
    cmake .. \

--- a/README.md
+++ b/README.md
@@ -89,20 +89,20 @@ This project uses [CMake] and [Hunter] package manager.
    against.bss' can not be used when making a shared object" mentioned in [this
    issue](https://github.com/ethereum-mining/ethminer/issues/38).
    ```sh
-   sudo apt install nvidia-opencl-dev g{cc,++}-4.9 && \
+   sudo apt install nvidia-opencl-dev g{cc,++}-5 && \
    cmake .. \
     -DETHASHCL=OFF \
-    -DCUDA_NVCC_FLAGS="-ccbin gcc-4.9" \
+    -DCUDA_NVCC_FLAGS="-ccbin gcc-5" \
     -DCMAKE_CXX_FLAGS="-fPIC"
    ```
 
    Alternatively, the same as above with CUDA enabled:
    ```sh
-   sudo apt install nvidia-{cuda-toolkit,opencl-dev} g{cc,++}-4.9 && \
+   sudo apt install nvidia-{cuda-toolkit,opencl-dev} g{cc,++}-5 && \
    cmake .. \
     -DETHASHCUDA=ON \
     -DETHASHCL=OFF \
-    -DCUDA_NVCC_FLAGS="-ccbin gcc-4.9" \
+    -DCUDA_NVCC_FLAGS="-ccbin gcc-5" \
     -DCMAKE_CXX_FLAGS="-fPIC"
    ```
 


### PR DESCRIPTION
depsolving and cmake incantation for Ubuntu 17.04 "Zesty" addressing the problems of requiring an older version of gcc and error "relocation R_X86_64_32S against.bss' can not be used when making a shared object" mentioned in https://github.com/ethereum-mining/ethminer/issues/38 