### PR TITLE
Add D-Bus support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ cmake_policy(SET CMP0054 NEW)
 option(ETHASHCL "Build with OpenCL mining" ON)
 option(ETHASHCUDA "Build with CUDA mining" OFF)
 option(ETHSTRATUM "Build with Stratum protocol support" ON)
+option(ETHDBUS "Build with D-Bus support" OFF)
 
 
 # propagates CMake configuration options to the compiler
@@ -70,6 +71,9 @@ function(configureProject)
 	endif()
 	if (ETHSTRATUM)
 		add_definitions(-DETH_STRATUM)
+	endif()
+	if (ETHDBUS)
+		add_definitions(-DETH_DBUS)
 	endif()
 endfunction()
 
@@ -127,6 +131,7 @@ message("------------------------------------------------------------- component
 message("-- ETHASHCL         Build OpenCL components                  ${ETHASHCL}")
 message("-- ETHASHCUDA       Build CUDA components                    ${ETHASHCUDA}")
 message("-- ETHSTRATUM       Build Stratum components                 ${ETHSTRATUM}")
+message("-- ETHDBUS          Build D-Bus components                   ${ETHDBUS}")
 message("------------------------------------------------------------------------")
 message("")
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+ethminer/DBusInt.h	@MRZA-MRZA

--- a/ethminer/CMakeLists.txt
+++ b/ethminer/CMakeLists.txt
@@ -16,6 +16,16 @@ target_link_libraries(${EXECUTABLE} ethcore)
 target_link_libraries(${EXECUTABLE} ethash)
 target_link_libraries(${EXECUTABLE} devcore libjson-rpc-cpp::client)
 
+if(ETHDBUS)
+	find_package(PkgConfig)
+	set( ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:/usr/lib/x86_64-linux-gnu/pkgconfig" )
+	pkg_check_modules(DBUS dbus-1)
+	include_directories(${DBUS_INCLUDE_DIRS})
+	link_directories(${DBUS_LIBRARY_DIRS})
+	target_link_libraries(${EXECUTABLE} ${DBUS_LIBRARIES})
+endif()
+
+
 if(ETHSTRATUM)
     target_link_libraries(${EXECUTABLE} ethstratum)
 endif()

--- a/ethminer/DBusInt.h
+++ b/ethminer/DBusInt.h
@@ -26,7 +26,7 @@ public:
 		{
 			DBusMessage *msg;
 			msg = dbus_message_new_signal("/eth/miner/hash", "eth.miner.monitor", "Hash");
-			if (msg == NULL)
+			if (msg == nullptr)
 			{
 				cerr << "Message is null!" << endl;
 			}

--- a/ethminer/DBusInt.h
+++ b/ethminer/DBusInt.h
@@ -1,0 +1,38 @@
+#include <dbus/dbus.h>
+
+using namespace std;
+
+class DBusInt{
+	public:
+		DBusInt(){
+			dbus_error_init(&err);
+			conn = dbus_bus_get(DBUS_BUS_SESSION, &err);
+			if(!conn){
+				cerr << "DBus error " << err.name << ": " << err.message << endl;
+				exit(-1);
+			}
+			dbus_bus_request_name(conn, "eth.miner", DBUS_NAME_FLAG_REPLACE_EXISTING, &err);
+			if(dbus_error_is_set(&err)){
+				cerr << "DBus error " << err.name << ": " << err.message << endl;
+				dbus_connection_close(conn);
+				exit(-1);
+			}
+			cout << "DBus initialized!" << endl;
+		}
+
+		void send(const char *hash){
+			DBusMessage *msg;
+			msg = dbus_message_new_signal("/eth/miner/hash", "eth.miner.monitor", "Hash");
+			if(msg == NULL){
+				cerr << "Message is null!" << endl;
+				exit(1);
+			}
+			dbus_message_append_args(msg, DBUS_TYPE_STRING, &hash, DBUS_TYPE_INVALID);
+			if(!dbus_connection_send(conn, msg, NULL)) cerr << "Error sending message!" << endl;
+			dbus_message_unref(msg);
+		}
+
+	private:
+		DBusError err;
+		DBusConnection *conn;
+};

--- a/ethminer/DBusInt.h
+++ b/ethminer/DBusInt.h
@@ -2,17 +2,21 @@
 
 using namespace std;
 
-class DBusInt{
-	public:
-		DBusInt(){
+class DBusInt
+{
+public:
+		DBusInt()
+		{
 			dbus_error_init(&err);
 			conn = dbus_bus_get(DBUS_BUS_SESSION, &err);
-			if(!conn){
+			if (!conn)
+			{
 				cerr << "DBus error " << err.name << ": " << err.message << endl;
 				exit(-1);
 			}
 			dbus_bus_request_name(conn, "eth.miner", DBUS_NAME_FLAG_REPLACE_EXISTING, &err);
-			if(dbus_error_is_set(&err)){
+			if (dbus_error_is_set(&err))
+			{
 				cerr << "DBus error " << err.name << ": " << err.message << endl;
 				dbus_connection_close(conn);
 				exit(-1);
@@ -20,19 +24,21 @@ class DBusInt{
 			cout << "DBus initialized!" << endl;
 		}
 
-		void send(const char *hash){
+		void send(const char *hash)
+		{
 			DBusMessage *msg;
 			msg = dbus_message_new_signal("/eth/miner/hash", "eth.miner.monitor", "Hash");
-			if(msg == NULL){
+			if (msg == NULL)
+			{
 				cerr << "Message is null!" << endl;
 				exit(1);
 			}
 			dbus_message_append_args(msg, DBUS_TYPE_STRING, &hash, DBUS_TYPE_INVALID);
-			if(!dbus_connection_send(conn, msg, NULL)) cerr << "Error sending message!" << endl;
+			if (!dbus_connection_send(conn, msg, NULL)) cerr << "Error sending message!" << endl;
 			dbus_message_unref(msg);
 		}
 
-	private:
+private:
 		DBusError err;
 		DBusConnection *conn;
 };

--- a/ethminer/DBusInt.h
+++ b/ethminer/DBusInt.h
@@ -12,14 +12,12 @@ public:
 			if (!conn)
 			{
 				cerr << "DBus error " << err.name << ": " << err.message << endl;
-				exit(-1);
 			}
 			dbus_bus_request_name(conn, "eth.miner", DBUS_NAME_FLAG_REPLACE_EXISTING, &err);
 			if (dbus_error_is_set(&err))
 			{
 				cerr << "DBus error " << err.name << ": " << err.message << endl;
 				dbus_connection_close(conn);
-				exit(-1);
 			}
 			cout << "DBus initialized!" << endl;
 		}
@@ -31,7 +29,6 @@ public:
 			if (msg == NULL)
 			{
 				cerr << "Message is null!" << endl;
-				exit(1);
 			}
 			dbus_message_append_args(msg, DBUS_TYPE_STRING, &hash, DBUS_TYPE_INVALID);
 			if (!dbus_connection_send(conn, msg, NULL)) cerr << "Error sending message!" << endl;

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -784,7 +784,7 @@ private:
 					{
 						minelog << mp << f.getSolutionStats();
 #if ETH_DBUS
-						dbusint.send(toString(mp).c_str());
+						dbusint.send(toString(mp).data());
 #endif
 					}
 					else
@@ -929,7 +929,7 @@ private:
 					{
 						minelog << mp << f.getSolutionStats();
 #if ETH_DBUS
-						dbusint.send(toString(mp).c_str());
+						dbusint.send(toString(mp).data());
 #endif
 					}
 					else
@@ -976,7 +976,7 @@ private:
 					{
 						minelog << mp << f.getSolutionStats();
 #if ETH_DBUS
-						dbusint.send(toString(mp).c_str());
+						dbusint.send(toString(mp).data());
 #endif
 					}
 					else if (client.waitState() == MINER_WAIT_STATE_WORK)

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -50,6 +50,9 @@
 #include <libstratum/EthStratumClient.h>
 #include <libstratum/EthStratumClientV2.h>
 #endif
+#if ETH_DBUS
+#include "DBusInt.h"
+#endif
 
 using namespace std;
 using namespace dev;
@@ -774,8 +777,12 @@ private:
 				{
 					auto mp = f.miningProgress();
 					f.resetMiningProgress();
-					if (current)
+					if (current){
 						minelog << "Mining on" << current.header << ": " << mp << f.getSolutionStats();
+#if ETH_DBUS
+						dbusint.send(toString(mp).c_str());
+#endif
+					}
 					else
 						minelog << "Getting work package...";
 
@@ -917,6 +924,9 @@ private:
 					if (client.current())
 					{
 						minelog << "Mining on" << client.currentHeaderHash() << ": " << mp << f.getSolutionStats();
+#if ETH_DBUS
+						dbusint.send(toString(mp).c_str());
+#endif
 					}
 					else
 					{
@@ -956,6 +966,9 @@ private:
 					if (client.current())
 					{
 						minelog << "Mining on" << client.currentHeaderHash() << ": " << mp << f.getSolutionStats();
+#if ETH_DBUS
+						dbusint.send(toString(mp).c_str());
+#endif
 					}
 					else if (client.waitState() == MINER_WAIT_STATE_WORK)
 					{
@@ -1026,4 +1039,8 @@ private:
 	string m_email = "";
 #endif
 	string m_fport = "";
+
+#if ETH_DBUS
+	DBusInt dbusint;
+#endif
 };


### PR DESCRIPTION
Some initial D-Bus support. It constantly reports current hash rate using D-Bus so it can be caught by external application (for monitoring purposes). To compile with D-Bus support add "-DETHDBUS=ON" to cmake command. D-Bus interface is "eth.miner.monitor". Signal name is "Hash".