### PR TITLE
Added: reporting current hashrate to pool

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -926,6 +926,9 @@ private:
 					{
 						minelog << "Waiting for work package...";
 					}
+					
+					auto rate = mp.rate();
+					client.submitHashrate(toJS(rate));
 				}
 				this_thread::sleep_for(chrono::milliseconds(m_farmRecheckPeriod));
 			}
@@ -966,6 +969,9 @@ private:
 					{
 						minelog << "Waiting for work package...";
 					}
+					
+					auto rate = mp.rate();
+					client.submitHashrate(toJS(rate));
 				}
 				this_thread::sleep_for(chrono::milliseconds(m_farmRecheckPeriod));
 			}

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -235,6 +235,10 @@ public:
 		{
 			m_worktimeout = atoi(argv[++i]);
 		}
+		else if ((arg == "-RH" || arg == "--report-hashrate") && i + 1 < argc)
+		{
+			m_report_stratum_hashrate = true;
+		}
 
 #endif
 #if ETH_ETHASHCL
@@ -542,9 +546,8 @@ public:
 			<< "        0: official stratum spec: ethpool, ethermine, coinotron, mph, nanopool (default)" << endl
 			<< "        1: eth-proxy compatible: dwarfpool, f2pool, nanopool" << endl
 			<< "        2: EthereumStratum/1.0.0: nicehash" << endl
+			<< "    -RH, --report-hashrate Report current hashrate to pool (please only enable on pools supporting this)" << endl
 			<< "    -SE, --stratum-email <s> Email address used in eth-proxy (optional)" << endl
-#endif
-#if ETH_STRATUM
 			<< "    --farm-recheck <n>  Leave n ms between checks for changed work (default: 500). When using stratum, use a high value (i.e. 2000) to get more stable hashrate output" << endl
 #endif
 			<< endl
@@ -927,8 +930,10 @@ private:
 						minelog << "Waiting for work package...";
 					}
 					
-					auto rate = mp.rate();
-					client.submitHashrate(toJS(rate));
+					if (this->m_report_stratum_hashrate) {
+						auto rate = mp.rate();
+						client.submitHashrate(toJS(rate));
+					}
 				}
 				this_thread::sleep_for(chrono::milliseconds(m_farmRecheckPeriod));
 			}
@@ -970,8 +975,10 @@ private:
 						minelog << "Waiting for work package...";
 					}
 					
-					auto rate = mp.rate();
-					client.submitHashrate(toJS(rate));
+					if (this->m_report_stratum_hashrate) {
+						auto rate = mp.rate();
+						client.submitHashrate(toJS(rate));
+					}
 				}
 				this_thread::sleep_for(chrono::milliseconds(m_farmRecheckPeriod));
 			}
@@ -1027,6 +1034,7 @@ private:
 	int m_worktimeout = 180;
 
 #if ETH_STRATUM
+	bool m_report_stratum_hashrate = false;
 	int m_stratumClientVersion = 1;
 	int m_stratumProtocol = STRATUM_PROTOCOL_STRATUM;
 	string m_user;

--- a/libstratum/EthStratumClient.cpp
+++ b/libstratum/EthStratumClient.cpp
@@ -502,6 +502,16 @@ void EthStratumClient::work_timeout_handler(const boost::system::error_code& ec)
 	}
 }
 
+bool EthStratumClient::submitHashrate(string const & rate) {
+	h256 id = h256::random();
+	// There is no stratum method to submit the hashrate so we use the rpc variant.
+	string json = "{\"id\": 6, \"jsonrpc\":\"2.0\", \"method\": \"eth_submitHashrate\", \"params\": [\"" + rate + "\",\"0x" + id.hex() + "\"]}\n";
+	std::ostream os(&m_requestBuffer);
+	os << json;
+	write(m_socket, m_requestBuffer);
+	return true;
+}
+
 bool EthStratumClient::submit(Solution solution) {
 	x_current.lock();
 	WorkPackage tempWork(m_current);

--- a/libstratum/EthStratumClient.cpp
+++ b/libstratum/EthStratumClient.cpp
@@ -47,6 +47,8 @@ EthStratumClient::EthStratumClient(Farm* f, MinerType m, string const & host, st
 	m_protocol = protocol;
 	m_email = email;
 
+	m_submit_hashrate_id = h256::random().hex();
+	
 	p_farm = f;
 	p_worktimer = nullptr;
 	connect();
@@ -503,9 +505,8 @@ void EthStratumClient::work_timeout_handler(const boost::system::error_code& ec)
 }
 
 bool EthStratumClient::submitHashrate(string const & rate) {
-	h256 id = h256::random();
 	// There is no stratum method to submit the hashrate so we use the rpc variant.
-	string json = "{\"id\": 6, \"jsonrpc\":\"2.0\", \"method\": \"eth_submitHashrate\", \"params\": [\"" + rate + "\",\"0x" + id.hex() + "\"]}\n";
+	string json = "{\"id\": 6, \"jsonrpc\":\"2.0\", \"method\": \"eth_submitHashrate\", \"params\": [\"" + rate + "\",\"0x" + this->m_submit_hashrate_id + "\"]}\n";
 	std::ostream os(&m_requestBuffer);
 	os << json;
 	write(m_socket, m_requestBuffer);

--- a/libstratum/EthStratumClient.h
+++ b/libstratum/EthStratumClient.h
@@ -31,6 +31,7 @@ public:
 	bool isConnected() { return m_connected && m_authorized; }
 	h256 currentHeaderHash() { return m_current.header; }
 	bool current() { return static_cast<bool>(m_current); }
+	bool submitHashrate(string const & rate);
 	bool submit(Solution solution);
 	void reconnect();
 private:

--- a/libstratum/EthStratumClient.h
+++ b/libstratum/EthStratumClient.h
@@ -92,6 +92,8 @@ private:
 
 	h64 m_extraNonce;
 	int m_extraNonceHexSize;
+	
+	string m_submit_hashrate_id;
 
 	void processExtranonce(std::string& enonce);
 };

--- a/libstratum/EthStratumClientV2.cpp
+++ b/libstratum/EthStratumClientV2.cpp
@@ -47,6 +47,8 @@ EthStratumClientV2::EthStratumClientV2(Farm* f, MinerType m, string const & host
 	m_protocol = protocol;
 	m_email = email;
 
+	m_submit_hashrate_id = h256::random().hex();
+	
 	p_farm = f;
 	p_worktimer = nullptr;
 	startWorking();
@@ -445,9 +447,8 @@ void EthStratumClientV2::work_timeout_handler(const boost::system::error_code& e
 }
 
 bool EthStratumClientV2::submitHashrate(string const & rate) {
-	h256 id = h256::random();
 	// There is no stratum method to submit the hashrate so we use the rpc variant.
-	string json = "{\"id\": 6, \"jsonrpc\":\"2.0\", \"method\": \"eth_submitHashrate\", \"params\": [\"" + rate + "\",\"0x" + id.hex() + "\"]}\n";
+	string json = "{\"id\": 6, \"jsonrpc\":\"2.0\", \"method\": \"eth_submitHashrate\", \"params\": [\"" + rate + "\",\"0x" + this->m_submit_hashrate_id + "\"]}\n";
 	std::ostream os(&m_requestBuffer);
 	os << json;
 	write(m_socket, m_requestBuffer);

--- a/libstratum/EthStratumClientV2.cpp
+++ b/libstratum/EthStratumClientV2.cpp
@@ -444,6 +444,16 @@ void EthStratumClientV2::work_timeout_handler(const boost::system::error_code& e
 	}
 }
 
+bool EthStratumClientV2::submitHashrate(string const & rate) {
+	h256 id = h256::random();
+	// There is no stratum method to submit the hashrate so we use the rpc variant.
+	string json = "{\"id\": 6, \"jsonrpc\":\"2.0\", \"method\": \"eth_submitHashrate\", \"params\": [\"" + rate + "\",\"0x" + id.hex() + "\"]}\n";
+	std::ostream os(&m_requestBuffer);
+	os << json;
+	write(m_socket, m_requestBuffer);
+	return true;
+}
+
 bool EthStratumClientV2::submit(Solution solution) {
 	x_current.lock();
 	WorkPackage tempWork(m_current);

--- a/libstratum/EthStratumClientV2.h
+++ b/libstratum/EthStratumClientV2.h
@@ -33,6 +33,7 @@ public:
 	h256 currentHeaderHash() { return m_current.header; }
 	bool current() { return static_cast<bool>(m_current); }
 	unsigned waitState() { return m_waitState; }
+	bool submitHashrate(string const & rate);
 	bool submit(Solution solution);
 	void reconnect();
 private:

--- a/libstratum/EthStratumClientV2.h
+++ b/libstratum/EthStratumClientV2.h
@@ -90,6 +90,8 @@ private:
 
 	h64 m_extraNonce;
 	int m_extraNonceHexSize;
+	
+	string m_submit_hashrate_id;
 
 	void processExtranonce(std::string& enonce);
 };


### PR DESCRIPTION
This PR adds reporting the current hashrate to the pool, also known as Reported Hashrate.
This should fix #49 

Since Stratum does not support reporting the hashrate i looked at what claymore miner is using. 
As it turns out, most (if not all) communication of claymore is jsonrpc.
This also is the case for hashrate reporting. So i implemented it that way too.

Also since there are two stratum client versions i added the method to both.

Tested on ethermine.org