### PR TITLE
Add support for compute_62 / sm_62

### DIFF
--- a/libethash-cuda/CMakeLists.txt
+++ b/libethash-cuda/CMakeLists.txt
@@ -17,6 +17,7 @@ else()
 		"-gencode arch=compute_52,code=sm_52"
 		"-gencode arch=compute_60,code=sm_60"
 		"-gencode arch=compute_61,code=sm_61"
+		"-gencode=arch=compute_62,code=sm_62"
 	)
 endif()
 


### PR DESCRIPTION
Since @chfast suggested in #208 to just create a PR with this, i now did.

Not really sure if supporting compute_62 / sm_62  is really needed tho.
It seems this is for a new generation of chips? Most likely for cars? Or a SOC like targa.

Well here is the PR anyways, this should fix the #208 issue :D