### PR TITLE
Added smoothing of displayed hashrate, should no longer jump that much.

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -649,7 +649,6 @@ private:
 			this_thread::sleep_for(chrono::seconds(i ? _trialDuration : _warmupDuration));
 
 			auto mp = f.miningProgress();
-			f.resetMiningProgress();
 			if (!i)
 				continue;
 			auto rate = mp.rate();
@@ -715,7 +714,6 @@ private:
 			for (unsigned i = 0; !completed; ++i)
 			{
 				auto mp = f.miningProgress();
-				f.resetMiningProgress();
 
 				cnote << "Mining on difficulty " << difficulty << " " << mp;
 				this_thread::sleep_for(chrono::milliseconds(1000));
@@ -795,7 +793,6 @@ private:
 				for (unsigned i = 0; !completed; ++i)
 				{
 					auto mp = f.miningProgress();
-					f.resetMiningProgress();
 					if (current)
 					{
 						minelog << mp << f.getSolutionStats();
@@ -945,7 +942,6 @@ private:
 			while (client.isRunning())
 			{
 				auto mp = f.miningProgress();
-				f.resetMiningProgress();
 				if (client.isConnected())
 				{
 					if (client.current())
@@ -995,7 +991,6 @@ private:
 			while (client.isRunning())
 			{
 				auto mp = f.miningProgress();
-				f.resetMiningProgress();
 				if (client.isConnected())
 				{
 					if (client.current())

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -321,7 +321,6 @@ private:
 	std::thread m_serviceThread;  ///< The IO service thread.
 	boost::asio::io_service m_io_service;
 	boost::asio::deadline_timer * p_hashrateTimer = nullptr;
-	//void processHashRate(const boost::system::error_code& ec);
 	std::vector<WorkingProgress> m_lastProgresses;
 
 	mutable SolutionStats m_solutionStats;

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -150,7 +150,7 @@ public:
 		p_hashrateTimer = nullptr;
 	}
 
-	void Farm::collectHashRate()
+	void collectHashRate()
 	{
 		WorkingProgress p;
 		Guard l2(x_minerWork);
@@ -184,7 +184,7 @@ public:
 		}
 	}
 
-	void Farm::processHashRate(const boost::system::error_code& ec) {
+	void processHashRate(const boost::system::error_code& ec) {
 
 		if (!ec) {
 			collectHashRate();
@@ -231,7 +231,7 @@ public:
 		for (auto const& cp : m_lastProgresses) {
 			p.ms += cp.ms;
 			p.hashes += cp.hashes;
-			for (int i = 0; i < cp.minersHashes.size(); i++)
+			for (unsigned int i = 0; i < cp.minersHashes.size(); i++)
 			{
 				p.minersHashes.at(i) += cp.minersHashes.at(i);
 			}

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -224,8 +224,10 @@ public:
 		p.hashes = 0;
 		{
 			Guard l2(x_minerWork);
-			for (auto const& i : m_miners)
+			for (auto const& i : m_miners) {
+				(void) i; // unused
 				p.minersHashes.push_back(0);
+			}
 		}
 
 		for (auto const& cp : m_lastProgresses) {

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <boost/asio.hpp>
+#include <boost/bind.hpp>
 #include <thread>
 #include <list>
 #include <atomic>
@@ -28,6 +30,8 @@
 #include <libdevcore/Worker.h>
 #include <libethcore/Miner.h>
 #include <libethcore/BlockHeader.h>
+
+using namespace boost::asio;
 
 namespace dev
 {
@@ -60,13 +64,16 @@ public:
 	 */
 	void setWork(WorkPackage const& _wp)
 	{
+		//Collect hashrate before miner reset their work
+		collectHashRate();
+
+		// Set work to each miner
 		Guard l(x_minerWork);
 		if (_wp.header == m_work.header && _wp.startNonce == m_work.startNonce)
 			return;
 		m_work = _wp;
 		for (auto const& m: m_miners)
 			m->setWork(m_work);
-		resetTimer();
 	}
 
 	void setSealers(std::map<std::string, SealerDescriptor> const& _sealers) { m_sealers = _sealers; }
@@ -110,9 +117,21 @@ public:
 		m_isMining = true;
 		m_lastSealer = _sealer;
 		b_lastMixed = mixed;
-		resetTimer();
+
+		if (!p_hashrateTimer) {
+			p_hashrateTimer = new boost::asio::deadline_timer(m_io_service, boost::posix_time::milliseconds(1000));
+			p_hashrateTimer->async_wait(boost::bind(&Farm::processHashRate, this, boost::asio::placeholders::error));
+			if (m_serviceThread.joinable()) {
+				m_io_service.reset();
+			}
+			else {
+				m_serviceThread = std::thread{ boost::bind(&boost::asio::io_service::run, &m_io_service) };
+			}
+		}
+
 		return true;
 	}
+
 	/**
 	 * @brief Stop all mining activities.
 	 */
@@ -121,6 +140,59 @@ public:
 		Guard l(x_minerWork);
 		m_miners.clear();
 		m_isMining = false;
+
+		if (p_hashrateTimer) {
+			p_hashrateTimer->cancel();
+		}
+
+		m_io_service.stop();
+		m_serviceThread.join();
+		p_hashrateTimer = nullptr;
+	}
+
+	void Farm::collectHashRate()
+	{
+		WorkingProgress p;
+		Guard l2(x_minerWork);
+		p.ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_lastStart).count();
+		//Collect
+		for (auto const& i : m_miners)
+		{
+			uint64_t minerHashCount = i->hashCount();
+			p.hashes += minerHashCount;
+			p.minersHashes.push_back(minerHashCount);
+		}
+
+		//Reset
+		for (auto const& i : m_miners)
+		{
+			i->resetHashCount();
+		}
+		m_lastStart = std::chrono::steady_clock::now();
+
+		if (p.hashes > 0) {
+			m_lastProgresses.push_back(p);
+		}
+
+		// We smooth the hashrate over the last x seconds
+		int allMs = 0;
+		for (auto const& cp : m_lastProgresses) {
+			allMs += cp.ms;
+		}
+		if (allMs > m_hashrateSmoothInterval) {
+			m_lastProgresses.erase(m_lastProgresses.begin());
+		}
+	}
+
+	void Farm::processHashRate(const boost::system::error_code& ec) {
+
+		if (!ec) {
+			collectHashRate();
+		}
+
+		// Restart timer 	
+		p_hashrateTimer->expires_at(p_hashrateTimer->expires_at() + boost::posix_time::milliseconds(1000));
+		p_hashrateTimer->async_wait(boost::bind(&Farm::processHashRate, this, boost::asio::placeholders::error));
 	}
 	
 	/**
@@ -148,30 +220,26 @@ public:
 	WorkingProgress const& miningProgress() const
 	{
 		WorkingProgress p;
-		p.ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_lastStart).count();
+		p.ms = 0;
+		p.hashes = 0;
 		{
 			Guard l2(x_minerWork);
-			for (auto const& i: m_miners)
+			for (auto const& i : m_miners)
+				p.minersHashes.push_back(0);
+		}
+
+		for (auto const& cp : m_lastProgresses) {
+			p.ms += cp.ms;
+			p.hashes += cp.hashes;
+			for (int i = 0; i < cp.minersHashes.size(); i++)
 			{
-				uint64_t minerHashCount = i->hashCount();
-				p.hashes += minerHashCount;
-				p.minersHashes.push_back(minerHashCount);
+				p.minersHashes.at(i) += cp.minersHashes.at(i);
 			}
 		}
+
 		Guard l(x_progress);
 		m_progress = p;
 		return m_progress;
-	}
-
-	/**
-	 * @brief Reset the mining progess counter.
-	 */
-	void resetMiningProgress()
-	{
-		DEV_GUARDED(x_minerWork)
-			for (auto const& i: m_miners)
-				i->resetHashCount();
-		resetTimer();
 	}
 
 	SolutionStats getSolutionStats() {
@@ -230,11 +298,6 @@ private:
 		return m_onSolutionFound(_s);
 	}
 
-	void resetTimer()
-	{
-		m_lastStart = std::chrono::steady_clock::now();
-	}
-
 	mutable Mutex x_minerWork;
 	std::vector<std::shared_ptr<Miner>> m_miners;
 	WorkPackage m_work;
@@ -243,7 +306,6 @@ private:
 
 	mutable Mutex x_progress;
 	mutable WorkingProgress m_progress;
-	std::chrono::steady_clock::time_point m_lastStart;
 
 	SolutionFound m_onSolutionFound;
 	MinerRestart m_onMinerRestart;
@@ -251,6 +313,14 @@ private:
 	std::map<std::string, SealerDescriptor> m_sealers;
 	std::string m_lastSealer;
 	bool b_lastMixed = false;
+
+	std::chrono::steady_clock::time_point m_lastStart;
+	int m_hashrateSmoothInterval = 10000;
+	std::thread m_serviceThread;  ///< The IO service thread.
+	boost::asio::io_service m_io_service;
+	boost::asio::deadline_timer * p_hashrateTimer = nullptr;
+	//void processHashRate(const boost::system::error_code& ec);
+	std::vector<WorkingProgress> m_lastProgresses;
 
 	mutable SolutionStats m_solutionStats;
 


### PR DESCRIPTION
Hashrate will now be smoothed/averaged before display, also the shown hashrate is no longer affected by when the rate is read. It also is not affected by set work.

Currently it averages the last 10 seconds. so if you playing around with clocks you need to wait a bit longer now.