### PR TITLE
Couple of small display related fixes

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -252,7 +252,7 @@ unsigned CLMiner::getNumDevices()
 
 void CLMiner::listDevices()
 {
-	string outString ="\nListing OpenCL devices.\nFORMAT: [deviceID] deviceName\n";
+	string outString ="\nListing OpenCL devices.\nFORMAT: [platformID] [deviceID] deviceName\n";
 	unsigned int i = 0;
 
 	vector<cl::Platform> platforms = getPlatforms();
@@ -260,10 +260,11 @@ void CLMiner::listDevices()
 		return;
 	for (unsigned j = 0; j < platforms.size(); ++j)
 	{
+		i = 0;
 		vector<cl::Device> devices = getDevices(platforms, j);
 		for (auto const& device: devices)
 		{
-			outString += "[" + to_string(i) + "] " + device.getInfo<CL_DEVICE_NAME>() + "\n";
+			outString += "[" + to_string(j) + "] [" + to_string(i) + "] " + device.getInfo<CL_DEVICE_NAME>() + "\n";
 			outString += "\tCL_DEVICE_TYPE: ";
 			switch (device.getInfo<CL_DEVICE_TYPE>())
 			{

--- a/libethash-cuda/ethash_cuda_miner.cpp
+++ b/libethash-cuda/ethash_cuda_miner.cpp
@@ -216,7 +216,7 @@ bool ethash_cuda_miner::init(ethash_light_t _light, uint8_t const* _lightData, u
 		cudaDeviceProp device_props;
 		CUDA_SAFE_CALL(cudaGetDeviceProperties(&device_props, device_num));
 
-		cudalog << "Using device: " << device_props.name << " (Compute " << device_props.major << "." << device_props.minor << ")";
+		cudalog << "Using device: " << device_props.name << " (Compute " + to_string(device_props.major) + "." + to_string(device_props.minor) + ")";
 
 		CUDA_SAFE_CALL(cudaSetDevice(device_num));
 		CUDA_SAFE_CALL(cudaDeviceReset());

--- a/libethash-cuda/ethash_cuda_miner.cpp
+++ b/libethash-cuda/ethash_cuda_miner.cpp
@@ -188,7 +188,7 @@ void ethash_cuda_miner::listDevices()
 			outString += "\tCompute version: " + to_string(props.major) + "." + to_string(props.minor) + "\n";
 			outString += "\tcudaDeviceProp::totalGlobalMem: " + to_string(props.totalGlobalMem) + "\n";
 		}
-		ETHCUDA_LOG(outString);
+		std::cout << outString;
 	}
 	catch(std::runtime_error const& err)
 	{


### PR DESCRIPTION
* Fixes CUDA Compute Version display
My CUDA Cleanup PR added huge spaces between the version number by displaying the compute version after card detection, this fixes it.
* Adds platformID and correct DeviceID for ``--list-devices``
It seems to be a big cause of confusion using ``--opencl-devices`` and ``--opencl-platform``. This is partly due to a bad listing of the openCL devices. This PR fixes this, by displaying the platformId AND the DeviceId. Also since (at least i think so) the devices are indexed per platform the deviceId resets per platform to 0

      Listing OpenCL devices.
      FORMAT: [platformID] [deviceID] deviceName
      [0] [0] Intel(R) HD Graphics 4000
              CL_DEVICE_TYPE: GPU
              CL_DEVICE_GLOBAL_MEM_SIZE: 662700032
              CL_DEVICE_MAX_MEM_ALLOC_SIZE: 165675008
              CL_DEVICE_MAX_WORK_GROUP_SIZE: 512
      [1] [0] GeForce GTX 1080
              CL_DEVICE_TYPE: GPU
              CL_DEVICE_GLOBAL_MEM_SIZE: 8589934592
              CL_DEVICE_MAX_MEM_ALLOC_SIZE: 2147483648
              CL_DEVICE_MAX_WORK_GROUP_SIZE: 1024
      [2] [0] Ellesmere
              CL_DEVICE_TYPE: GPU
              CL_DEVICE_GLOBAL_MEM_SIZE: 8589934592
              CL_DEVICE_MAX_MEM_ALLOC_SIZE: 4244635648
              CL_DEVICE_MAX_WORK_GROUP_SIZE: 256

* My CUDA Cleanup PR changed the way messages got output to the cli (mainly via own channel). I accidently also changed the way list-devices are printed out. This also fixes it.