### PR TITLE
10 digit target always 0 in log messages!!!

### DIFF
--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -124,7 +124,7 @@ void CUDAMiner::workLoop()
 		if (!w)
 			return;
 
-		cnote << "set work; seed: " << "#" + w.seed.hex().substr(0, 8) + ", target: " << "#" + w.boundary.hex().substr(0, 12);
+		cnote << "set work; seed: " << "#" + w.seed.hex().substr(0, 8) + ", target: " << "#" + w.boundary.hex().substr(0, 22);
 		if (!m_miner || m_minerSeed != w.seed)
 		{
 			unsigned device = s_devices[index] > -1 ? s_devices[index] : index;


### PR DESCRIPTION
With difficulty increasing, 12 digits don't give us any idea of the actual target!!! Makes for confusing log since 0 is the hardest possible target! Add 10 digits.