### PR TITLE
Clean up and minor optimizations

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -857,19 +857,23 @@ private:
 					}
 					this_thread::sleep_for(chrono::milliseconds(_recheckPeriod));
 				}
-				cnote << "Solution found; Submitting to" << _remote << "...";
-				cnote << "  Nonce:" << solution.nonce;
-				cnote << "  headerHash:" << solution.headerHash.hex();
-				cnote << "  mixHash:" << solution.mixHash.hex();
 				if (EthashAux::eval(solution.seedHash, solution.headerHash, solution.nonce).value < solution.boundary)
 				{
 					bool ok = prpc->eth_submitWork("0x" + toHex(solution.nonce), "0x" + toString(solution.headerHash), "0x" + toString(solution.mixHash));
 					if (ok) {
-						cnote << EthLime << "B-) Submitted and accepted." << EthReset;
+						cnote << "Solution found; Submitted to" << _remote << "...";
+						cnote << "  Nonce:" << solution.nonce;
+						cnote << "  headerHash:" << solution.headerHash.hex();
+						cnote << "  mixHash:" << solution.mixHash.hex();
+						cnote << EthLime << "Accepted." << EthReset;
 						f.acceptedSolution(false);
 					}
 					else {
-						cwarn << ":-( Not accepted.";
+						cwarn << "Solution found; Submitted to" << _remote << "...";
+						cwarn << "  Nonce:" << solution.nonce;
+						cwarn << "  headerHash:" << solution.headerHash.hex();
+						cwarn << "  mixHash:" << solution.mixHash.hex();
+						cwarn << "Not accepted.";
 						f.rejectedSolution(false);
 					}
 					//exit(0);

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -60,7 +60,7 @@ namespace eth
 		}
 
 	protected:
-		virtual bool found(uint64_t const* _nonces, uint32_t _count) override
+		virtual bool found(uint64_t const* _nonces) override
 		{
 			m_owner.report(_nonces[0]);
 			return m_owner.shouldStop();
@@ -124,7 +124,6 @@ void CUDAMiner::workLoop()
 		if (!w)
 			return;
 
-		cnote << "set work; seed: " << "#" + w.seed.hex().substr(0, 8) + ", target: " << "#" + w.boundary.hex().substr(0, 22);
 		if (!m_miner || m_minerSeed != w.seed)
 		{
 			unsigned device = s_devices[index] > -1 ? s_devices[index] : index;
@@ -162,7 +161,7 @@ void CUDAMiner::workLoop()
 			//bytesConstRef dagData = dag->data();
 			bytesConstRef lightData = light->data();
 
-			m_miner->init(light->light, lightData.data(), lightData.size(), device, (s_dagLoadMode == DAG_LOAD_MODE_SINGLE), &s_dagInHostMemory);
+			m_miner->init(light->light, lightData.data(), lightData.size(), device, (s_dagLoadMode == DAG_LOAD_MODE_SINGLE), s_dagInHostMemory);
 			s_dagLoadIndex++;
 
 			if (s_dagLoadMode == DAG_LOAD_MODE_SINGLE)

--- a/libethash-cuda/ethash_cuda_miner.h
+++ b/libethash-cuda/ethash_cuda_miner.h
@@ -17,7 +17,7 @@ public:
 		virtual ~search_hook(); // always a virtual destructor for a class with virtuals.
 
 		// reports progress, return true to abort
-		virtual bool found(uint64_t const* nonces, uint32_t count) = 0;
+		virtual bool found(uint64_t const* nonces) = 0;
 		virtual bool searched(uint64_t start_nonce, uint32_t count) = 0;
 	};
 
@@ -37,7 +37,7 @@ public:
 		);
         static void setParallelHash(unsigned _parallelHash);
 
-	bool init(ethash_light_t _light, uint8_t const* _lightData, uint64_t _lightSize, unsigned _deviceId, bool _cpyToHost, volatile void** hostDAG);
+	bool init(ethash_light_t _light, uint8_t const* _lightData, uint64_t _lightSize, unsigned _deviceId, bool _cpyToHost, uint8_t * &hostDAG);
 
 	void finish();
 	void search(uint8_t const* header, uint64_t target, search_hook& hook, bool _ethStratum, uint64_t _startN);

--- a/libethash-cuda/keccak_u64.cuh
+++ b/libethash-cuda/keccak_u64.cuh
@@ -32,6 +32,7 @@ __device__ __forceinline__ void keccak_f1600_init(uint64_t * s)
 	devectorize4(d_header.uint4s[0], s[0], s[1]);
 	devectorize4(d_header.uint4s[1], s[2], s[3]);
 
+	#pragma unroll
 	for (uint32_t i = 5; i < 25; i++)
 	{
 		s[i] = 0;
@@ -332,6 +333,7 @@ __device__ __forceinline__ uint64_t keccak_f1600_final(uint64_t* s)
 {
 	uint64_t t[5], u, v;
 
+	#pragma unroll
 	for (uint32_t i = 12; i < 25; i++)
 	{
 		s[i] = 0;
@@ -594,6 +596,7 @@ __device__ __forceinline__ void SHA3_512(uint2* s2) {
 
 	uint64_t t[5], u, v;
 
+	#pragma unroll
 	for (uint32_t i = 9; i < 25; i++)
 	{
 		s[i] = 0;

--- a/libethash-cuda/keccak_u64.cuh
+++ b/libethash-cuda/keccak_u64.cuh
@@ -32,7 +32,6 @@ __device__ __forceinline__ void keccak_f1600_init(uint64_t * s)
 	devectorize4(d_header.uint4s[0], s[0], s[1]);
 	devectorize4(d_header.uint4s[1], s[2], s[3]);
 
-	#pragma unroll
 	for (uint32_t i = 5; i < 25; i++)
 	{
 		s[i] = 0;
@@ -333,7 +332,6 @@ __device__ __forceinline__ uint64_t keccak_f1600_final(uint64_t* s)
 {
 	uint64_t t[5], u, v;
 
-	#pragma unroll
 	for (uint32_t i = 12; i < 25; i++)
 	{
 		s[i] = 0;
@@ -596,7 +594,6 @@ __device__ __forceinline__ void SHA3_512(uint2* s2) {
 
 	uint64_t t[5], u, v;
 
-	#pragma unroll
 	for (uint32_t i = 9; i < 25; i++)
 	{
 		s[i] = 0;

--- a/libethcore/Miner.cpp
+++ b/libethcore/Miner.cpp
@@ -6,10 +6,10 @@ using namespace eth;
 
 unsigned dev::eth::Miner::s_dagLoadMode = 0;
 
-volatile unsigned dev::eth::Miner::s_dagLoadIndex = 0;
+unsigned dev::eth::Miner::s_dagLoadIndex = 0;
 
 unsigned dev::eth::Miner::s_dagCreateDevice = 0;
 
-volatile void* dev::eth::Miner::s_dagInHostMemory = NULL;
+uint8_t* dev::eth::Miner::s_dagInHostMemory = NULL;
 
 

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -23,7 +23,6 @@
 
 #include <thread>
 #include <list>
-#include <atomic>
 #include <string>
 #include <boost/timer.hpp>
 #include <libdevcore/Common.h>
@@ -209,9 +208,9 @@ protected:
 	void addHashCount(uint64_t _n) { m_hashCount += _n; }
 
 	static unsigned s_dagLoadMode;
-	static volatile unsigned s_dagLoadIndex;
+	static unsigned s_dagLoadIndex;
 	static unsigned s_dagCreateDevice;
-	static volatile void* s_dagInHostMemory;
+	static uint8_t* s_dagInHostMemory;
 
 	const size_t index = 0;
 	FarmFace& farm;

--- a/libhwmon/wrapnvml.cpp
+++ b/libhwmon/wrapnvml.cpp
@@ -159,9 +159,9 @@ return NULL;
     if (cudaGetDeviceProperties(&props, i) == cudaSuccess) {
       int j;
       for (j=0; j<nvmlh->nvml_gpucount; j++) {
-        if ((nvmlh->nvml_pci_domain_id[j] == props.pciDomainID) &&
-            (nvmlh->nvml_pci_bus_id[j]    == props.pciBusID) &&
-            (nvmlh->nvml_pci_device_id[j] == props.pciDeviceID)) {
+        if ((nvmlh->nvml_pci_domain_id[j] == (unsigned int)props.pciDomainID) &&
+            (nvmlh->nvml_pci_bus_id[j]    == (unsigned int)props.pciBusID) &&
+            (nvmlh->nvml_pci_device_id[j] == (unsigned int)props.pciDeviceID)) {
 #if 0
           printf("CUDA GPU[%d] matches NVML GPU[%d]\n", i, j);
 #endif


### PR DESCRIPTION
- Don't waste time formatting output text before sending problem to GPU.
- Don't waste time formatting output text before sending solution to pool.
- Give more detail in stratum new job log such that we don't have to spit it out for each cards.
- Remove uneccessary use of volatile. There are no read/modify/write scenarios that need to be atomic.