### PR TITLE
Remove redundant re-evaluation in EthStratumClient::submit

### DIFF
--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -33,7 +33,7 @@ using namespace dev;
 
 // Logging
 int dev::g_logVerbosity = 5;
-mutex x_logOverride;
+static mutex x_guard;
 
 /// Map of Log Channel types to bool, false forces the channel to be disabled, true forces it to be enabled.
 /// If a channel has no entry, then it will output as long as its verbosity (LogChannel::verbosity) is less than
@@ -60,7 +60,7 @@ LogOutputStreamBase::LogOutputStreamBase(char const* _id, std::type_info const* 
 	m_autospacing(_autospacing),
 	m_verbosity(_v)
 {
-	Guard l(x_logOverride);
+	x_guard.lock();
 	auto it = s_logOverride.find(_info);
 	if ((it != s_logOverride.end() && it->second) || (it == s_logOverride.end() && (int)_v <= g_logVerbosity))
 	{
@@ -74,6 +74,7 @@ LogOutputStreamBase::LogOutputStreamBase(char const* _id, std::type_info const* 
 		static char const* c_end = EthReset "  ";
 		m_sstr << _id << c_begin << buf << c_sep1 << std::left << std::setw(8) << getThreadName() << ThreadContext::join(c_sep2) << c_end;
 	}
+	x_guard.unlock();
 }
 
 /// Associate a name with each thread for nice logging.

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -233,8 +233,7 @@ void CLMiner::workLoop()
 	}
 }
 
-void CLMiner::pause()
-{}
+void CLMiner::pause() {}
 
 unsigned CLMiner::getNumDevices()
 {

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -62,8 +62,6 @@ namespace eth
 	protected:
 		virtual bool found(uint64_t const* _nonces, uint32_t count) override
 		{
-			if (count >= SEARCH_RESULT_BUFFER_SIZE)
-				count = SEARCH_RESULT_BUFFER_SIZE - 1;
 			for (uint32_t i = 0; i < count; i++)
 				m_owner.report(_nonces[i]);
 			return m_owner.shouldStop();

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -60,9 +60,10 @@ namespace eth
 		}
 
 	protected:
-		virtual bool found(uint64_t const* _nonces) override
+		virtual bool found(uint64_t const* _nonces, uint32_t count) override
 		{
-			m_owner.report(_nonces[0]);
+			for (uint32_t i = 0; i < count; i++)
+				m_owner.report(_nonces[i]);
 			return m_owner.shouldStop();
 		}
 

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -62,6 +62,8 @@ namespace eth
 	protected:
 		virtual bool found(uint64_t const* _nonces, uint32_t count) override
 		{
+			if (count >= SEARCH_RESULT_BUFFER_SIZE)
+				count = SEARCH_RESULT_BUFFER_SIZE - 1;
 			for (uint32_t i = 0; i < count; i++)
 				m_owner.report(_nonces[i]);
 			return m_owner.shouldStop();

--- a/libethash-cuda/ethash_cuda_miner.cpp
+++ b/libethash-cuda/ethash_cuda_miner.cpp
@@ -374,10 +374,16 @@ void ethash_cuda_miner::search(uint8_t const* header, uint64_t target, search_ho
 		{
 			CUDA_SAFE_CALL(cudaStreamSynchronize(stream));
 			found_count = buffer[0];
-			if (found_count)
+			if (found_count) {
 				buffer[0] = 0;
-			for (unsigned int j = 0; j < found_count; j++)
-				nonces[j] = nonce_base + buffer[j + 1];
+				// guard against overflow. Eventhough CUDA will
+				// stop storing shares past the end of the buffer,
+				// it continues to count all valid shares.
+				if (found_count >= SEARCH_RESULT_BUFFER_SIZE)
+					found_count = SEARCH_RESULT_BUFFER_SIZE - 1;
+				for (unsigned int j = 0; j < found_count; j++)
+					nonces[j] = nonce_base + buffer[j + 1];
+			}
 		}
 		run_ethash_search(s_gridSize, s_blockSize, m_sharedBytes, stream, buffer, m_current_nonce, m_parallelHash);
 		if (m_current_index >= s_numStreams)

--- a/libethash-cuda/ethash_cuda_miner.cpp
+++ b/libethash-cuda/ethash_cuda_miner.cpp
@@ -389,7 +389,7 @@ void ethash_cuda_miner::search(uint8_t const* header, uint64_t target, search_ho
 		if (m_current_index >= s_numStreams)
 		{
 			exit = found_count && hook.found(nonces, found_count);
-			exit |= hook.searched(nonce_base, batch_size);
+			exit |= hook.searched(batch_size);
 		}
 	}
 }

--- a/libethash-cuda/ethash_cuda_miner.cpp
+++ b/libethash-cuda/ethash_cuda_miner.cpp
@@ -382,7 +382,7 @@ void ethash_cuda_miner::search(uint8_t const* header, uint64_t target, search_ho
 		run_ethash_search(s_gridSize, s_blockSize, m_sharedBytes, stream, buffer, m_current_nonce, m_parallelHash);
 		if (m_current_index >= s_numStreams)
 		{
-			exit = found_count && hook.found(nonces);
+			exit = found_count && hook.found(nonces, found_count);
 			exit |= hook.searched(nonce_base, batch_size);
 		}
 	}

--- a/libethash-cuda/ethash_cuda_miner.h
+++ b/libethash-cuda/ethash_cuda_miner.h
@@ -18,7 +18,7 @@ public:
 
 		// reports progress, return true to abort
 		virtual bool found(uint64_t const* nonces, uint32_t count) = 0;
-		virtual bool searched(uint64_t start_nonce, uint32_t count) = 0;
+		virtual bool searched(uint32_t count) = 0;
 	};
 
 public:

--- a/libethash-cuda/ethash_cuda_miner.h
+++ b/libethash-cuda/ethash_cuda_miner.h
@@ -17,7 +17,7 @@ public:
 		virtual ~search_hook(); // always a virtual destructor for a class with virtuals.
 
 		// reports progress, return true to abort
-		virtual bool found(uint64_t const* nonces) = 0;
+		virtual bool found(uint64_t const* nonces, uint32_t count) = 0;
 		virtual bool searched(uint64_t start_nonce, uint32_t count) = 0;
 	};
 

--- a/libethash-cuda/ethash_cuda_miner_kernel.cu
+++ b/libethash-cuda/ethash_cuda_miner_kernel.cu
@@ -156,7 +156,10 @@ void ethash_generate_dag(
 	{
 		ethash_calculate_dag_item <<<blocks, threads, 0, stream >>>(i * blocks * threads);
 		CUDA_SAFE_CALL(cudaDeviceSynchronize());
+#if defined(__CUDACC_DEBUG__)
+		//This might be useful for debug, but just slows startup 
 		printf("CUDA#%d: %.0f%%\n",device, 100.0f * (float)i / (float)fullRuns);
+#endif
 	}
 	//printf("GPU#%d 100%%\n");
 	CUDA_SAFE_CALL(cudaGetLastError());

--- a/libethash-cuda/ethash_cuda_miner_kernel.cu
+++ b/libethash-cuda/ethash_cuda_miner_kernel.cu
@@ -32,12 +32,9 @@ ethash_search(
         uint64_t hash = compute_hash<_PARALLEL_HASH>(start_nonce + gid);
 	if (cuda_swab64(hash) > d_target) return;
 	// found a valid result. Make sure there's enough room to store it
-	uint32_t index = atomicInc(const_cast<uint32_t*>(g_output), SEARCH_RESULT_BUFFER_SIZE + 1) + 1;
+	uint32_t index = atomicInc(const_cast<uint32_t*>(g_output), 0xffffffff) + 1;
 	if (index >= SEARCH_RESULT_BUFFER_SIZE)
-	{
-		atomicDec(const_cast<uint32_t*>(g_output), SEARCH_RESULT_BUFFER_SIZE + 1);
 		return;
-	}
 	g_output[index] = gid;
 }
 

--- a/libethash-cuda/ethash_cuda_miner_kernel.cu
+++ b/libethash-cuda/ethash_cuda_miner_kernel.cu
@@ -31,7 +31,19 @@ ethash_search(
 	uint32_t const gid = blockIdx.x * blockDim.x + threadIdx.x;	
         uint64_t hash = compute_hash<_PARALLEL_HASH>(start_nonce + gid);
 	if (cuda_swab64(hash) > d_target) return;
-	uint32_t index = atomicInc(const_cast<uint32_t*>(g_output), SEARCH_RESULT_BUFFER_SIZE - 1) + 1;
+	// found a valid result. Make sure there's enough room to store it
+	uint32_t last_index = g_output[0];
+	if (last_index >= SEARCH_RESULT_BUFFER_SIZE - 1) // Ran out of result space
+		return;
+	uint32_t index;
+	do
+	{
+		index = last_index + 1;
+		last_index = atomicCAS(const_cast<uint32_t*>(g_output), last_index, index);
+		if (last_index >= SEARCH_RESULT_BUFFER_SIZE - 1)
+			return;
+	} while (last_index != index - 1);
+	// Finally, store the valid result
 	g_output[index] = gid;
 }
 

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -72,6 +72,8 @@ public:
 		m_work = _wp;
 		for (auto const& m: m_miners)
 			m->setWork(m_work);
+		for (auto const& m: m_miners)
+			m->startWork();
 	}
 
 	void setSealers(std::map<std::string, SealerDescriptor> const& _sealers) { m_sealers = _sealers; }

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -175,9 +175,10 @@ public:
 	void setWork(WorkPackage const& _work)
 	{
 		{
-			Guard l(x_work);
+			x_work.lock();
 			m_work = _work;
 			workSwitchStart = std::chrono::high_resolution_clock::now();
+			x_work.unlock();
 		}
 		pause();
 	}
@@ -207,7 +208,14 @@ protected:
 	 */
 	virtual void pause() = 0;
 
-	WorkPackage work() const { Guard l(x_work); return m_work; }
+	WorkPackage work() const
+	{
+		WorkPackage work;
+		x_work.lock();
+		work = m_work;
+		x_work.unlock();
+		return work;
+	}
 
 	void addHashCount(uint64_t _n) { m_hashCount += _n; }
 

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -180,6 +180,10 @@ public:
 			workSwitchStart = std::chrono::high_resolution_clock::now();
 		}
 		pause();
+	}
+
+	void startWork()
+	{
 		kickOff();
 		m_hashCount = 0;
 	}

--- a/libstratum/EthStratumClient.cpp
+++ b/libstratum/EthStratumClient.cpp
@@ -532,8 +532,7 @@ bool EthStratumClient::submit(Solution solution) {
 		minernonce = nonceHex.substr(m_extraNonceHexSize, 16 - m_extraNonceHexSize);
 	}
 
-	if (EthashAux::eval(tempWork.seed, tempWork.header, solution.nonce).value < tempWork.boundary)
-	{
+		// Will re-indent this block later. For now, leave it such that the diff is readable
 		string json;
 
 		switch (m_protocol) {
@@ -559,38 +558,5 @@ bool EthStratumClient::submit(Solution solution) {
 			cnote << "Nonce:" << "0x" + nonceHex;
 		}
 		return true;
-	}
-	else if (EthashAux::eval(tempPreviousWork.seed, tempPreviousWork.header, solution.nonce).value < tempPreviousWork.boundary)
-	{
-		string json;
-
-		switch (m_protocol) {
-		case STRATUM_PROTOCOL_STRATUM:
-			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_previous_job + "\",\"0x" + nonceHex + "\",\"0x" + tempPreviousWork.header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
-			break;
-		case STRATUM_PROTOCOL_ETHPROXY:
-			json = "{\"id\": 4, \"worker\":\"" + m_worker + "\", \"method\": \"eth_submitWork\", \"params\": [\"0x" + nonceHex + "\",\"0x" + tempPreviousWork.header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
-			break;
-		case STRATUM_PROTOCOL_ETHEREUMSTRATUM:
-			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_previous_job + "\",\"" + minernonce + "\"]}\n";
-			break;
-		}
-
-		std::ostream os(&m_requestBuffer);
-		os << json;
-		m_stale = true;
-		async_write(m_socket, m_requestBuffer,
-			boost::bind(&EthStratumClient::handleResponse, this,
-			boost::asio::placeholders::error));
-		cwarn << "Submitted stale solution.";
-		return true;
-	}
-	else {
-		m_stale = false;
-		cwarn << "FAILURE: GPU gave incorrect result!";
-		p_farm->failedSolution();
-	}
-
-	return false;
 }
 

--- a/libstratum/EthStratumClient.cpp
+++ b/libstratum/EthStratumClient.cpp
@@ -439,7 +439,7 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
 								p_worktimer->cancel();
 
 							x_current.lock();
-							m_current.header = h256(sHeaderHash);
+							m_current.header = headerHash;
 							m_current.seed = h256(sSeedHash);
 							m_current.boundary = h256(sShareTarget);
 							m_job = job;

--- a/libstratum/EthStratumClient.cpp
+++ b/libstratum/EthStratumClient.cpp
@@ -400,15 +400,15 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
 					if (sHeaderHash != "" && sSeedHash != "")
 					{
 
-						h256 seedHash = h256(sSeedHash);
-
+						x_current.lock();
 						m_current.header = h256(sHeaderHash);
-						m_current.seed = seedHash;
+						m_current.seed = h256(sSeedHash);
 						m_current.boundary = h256();
 						diffToTarget((uint32_t*)m_current.boundary.data(), m_nextWorkDifficulty);
 						m_current.startNonce = ethash_swap_u64(*((uint64_t*)m_extraNonce.data()));
 						m_current.exSizeBits = m_extraNonceHexSize * 4;
 						m_job = job;
+						x_current.unlock();
 
 						p_farm->setWork(m_current);
 						cnote << "Received new job #" + job.substr(0, 8)
@@ -431,26 +431,25 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
 					if (sHeaderHash != "" && sSeedHash != "" && sShareTarget != "")
 					{
 
-						h256 seedHash = h256(sSeedHash);
 						h256 headerHash = h256(sHeaderHash);
 
 						if (headerHash != m_current.header)
 						{
-							//x_current.lock();
 							if (p_worktimer)
 								p_worktimer->cancel();
 
+							x_current.lock();
 							m_current.header = h256(sHeaderHash);
-							m_current.seed = seedHash;
+							m_current.seed = h256(sSeedHash);
 							m_current.boundary = h256(sShareTarget);
 							m_job = job;
+							x_current.unlock();
 
 							p_farm->setWork(m_current);
 							cnote << "Received new job #" + job.substr(0, 8)
 								<< " seed: " << "#" + m_current.seed.hex().substr(0, 32)
 								<< " target: " << "#" + m_current.boundary.hex().substr(0, 24);
 
-							//x_current.unlock();
 							p_worktimer = new boost::asio::deadline_timer(m_io_service, boost::posix_time::seconds(m_worktimeout));
 							p_worktimer->async_wait(boost::bind(&EthStratumClient::work_timeout_handler, this, boost::asio::placeholders::error));
 

--- a/libstratum/EthStratumClient.cpp
+++ b/libstratum/EthStratumClient.cpp
@@ -402,13 +402,6 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
 
 						h256 seedHash = h256(sSeedHash);
 
-						m_previous.header = m_current.header;
-						m_previous.seed = m_current.seed;
-						m_previous.boundary = m_current.boundary;
-						m_previous.startNonce = m_current.startNonce;
-						m_previous.exSizeBits = m_previous.exSizeBits;
-						m_previousJob = m_job;
-
 						m_current.header = h256(sHeaderHash);
 						m_current.seed = seedHash;
 						m_current.boundary = h256();
@@ -446,11 +439,6 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
 							//x_current.lock();
 							if (p_worktimer)
 								p_worktimer->cancel();
-
-							m_previous.header = m_current.header;
-							m_previous.seed = m_current.seed;
-							m_previous.boundary = m_current.boundary;
-							m_previousJob = m_job;
 
 							m_current.header = h256(sHeaderHash);
 							m_current.seed = seedHash;
@@ -522,8 +510,6 @@ bool EthStratumClient::submit(Solution solution) {
 	x_current.lock();
 	WorkPackage tempWork(m_current);
 	string temp_job = m_job;
-	WorkPackage tempPreviousWork(m_previous);
-	string temp_previous_job = m_previousJob;
 	x_current.unlock();
 
 	string minernonce;

--- a/libstratum/EthStratumClient.cpp
+++ b/libstratum/EthStratumClient.cpp
@@ -365,7 +365,7 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
 			p_farm->acceptedSolution(m_stale);
 		}
 		else {
-			cwarn << "Rejected.";
+			cwarn << EthYellow << "Rejected." << EthReset;
 			p_farm->rejectedSolution(m_stale);
 		}
 		break;

--- a/libstratum/EthStratumClient.h
+++ b/libstratum/EthStratumClient.h
@@ -67,12 +67,10 @@ private:
 	Farm* p_farm;
 	std::mutex x_current;
 	WorkPackage m_current;
-	WorkPackage m_previous;
 
 	bool m_stale = false;
 
 	string m_job;
-	string m_previousJob;
 
 	std::thread m_serviceThread;  ///< The IO service thread.
 	boost::asio::io_service m_io_service;
@@ -95,3 +93,4 @@ private:
 
 	void processExtranonce(std::string& enonce);
 };
+

--- a/libstratum/EthStratumClientV2.cpp
+++ b/libstratum/EthStratumClientV2.cpp
@@ -352,9 +352,9 @@ void EthStratumClientV2::processReponse(Json::Value& responseObject)
 						m_current.startNonce = ethash_swap_u64(*((uint64_t*)m_extraNonce.data()));
 						m_current.exSizeBits = m_extraNonceHexSize * 4;
 						m_job = job;
-						x_current.unlock();
 
 						p_farm->setWork(m_current);
+						x_current.unlock();
 						cnote << "Received new job #" + job.substr(0, 8)
 							<< " seed: " << "#" + m_current.seed.hex().substr(0, 32)
 							<< " target: " << "#" + m_current.boundary.hex().substr(0, 24);
@@ -384,9 +384,9 @@ void EthStratumClientV2::processReponse(Json::Value& responseObject)
 							m_current.seed = h256(sSeedHash);
 							m_current.boundary = h256(sShareTarget);
 							m_job = job;
-							x_current.unlock();
 
 							p_farm->setWork(m_current);
+							x_current.unlock();
 						}
 						cnote << "Received new job #" + job.substr(0, 8)
 							<< " seed: " << "#" + m_current.seed.hex().substr(0, 32)
@@ -441,30 +441,35 @@ bool EthStratumClientV2::submitHashrate(string const & rate) {
 }
 
 bool EthStratumClientV2::submit(Solution solution) {
+	string job;
+	h256 header;
+	int extraNonceHexSize;
 	x_current.lock();
-	WorkPackage tempWork(m_current);
-	string temp_job = m_job;
+	job = m_job;
+	header = m_current.header;
+	extraNonceHexSize = m_extraNonceHexSize;
 	x_current.unlock();
 
 	string minernonce;
 	string nonceHex = toHex(solution.nonce);
 	if (m_protocol == STRATUM_PROTOCOL_ETHEREUMSTRATUM) {
-		minernonce = nonceHex.substr(m_extraNonceHexSize, 16 - m_extraNonceHexSize);
+		minernonce = nonceHex.substr(extraNonceHexSize, 16 - extraNonceHexSize);
 	}
 
                 // Will re-indent this block later. For now, leave it such that the diff is readable
 		string json;
 		switch (m_protocol) {
 		case STRATUM_PROTOCOL_STRATUM:
-			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_job + "\",\"0x" + nonceHex + "\",\"0x" + tempWork.header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
+			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + job + "\",\"0x" + nonceHex + "\",\"0x" + header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
 			break;
 		case STRATUM_PROTOCOL_ETHPROXY:
-			json = "{\"id\": 4, \"worker\":\"" + m_worker + "\", \"method\": \"eth_submitWork\", \"params\": [\"0x" + nonceHex + "\",\"0x" + tempWork.header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
+			json = "{\"id\": 4, \"worker\":\"" + m_worker + "\", \"method\": \"eth_submitWork\", \"params\": [\"0x" + nonceHex + "\",\"0x" + header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
 			break;
 		case STRATUM_PROTOCOL_ETHEREUMSTRATUM:
-			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_job + "\",\"" + minernonce + "\"]}\n";
+			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + job + "\",\"" + minernonce + "\"]}\n";
 			break;
 		}
+
 		std::ostream os(&m_requestBuffer);
 		os << json;
 		m_stale = false;

--- a/libstratum/EthStratumClientV2.cpp
+++ b/libstratum/EthStratumClientV2.cpp
@@ -380,7 +380,7 @@ void EthStratumClientV2::processReponse(Json::Value& responseObject)
 						if (headerHash != m_current.header)
 						{
 							x_current.lock();
-							m_current.header = h256(sHeaderHash);
+							m_current.header = headerHash;
 							m_current.seed = h256(sSeedHash);
 							m_current.boundary = h256(sShareTarget);
 							m_job = job;

--- a/libstratum/EthStratumClientV2.cpp
+++ b/libstratum/EthStratumClientV2.cpp
@@ -472,8 +472,7 @@ bool EthStratumClientV2::submit(Solution solution) {
 		minernonce = nonceHex.substr(m_extraNonceHexSize, 16 - m_extraNonceHexSize);
 	}
 
-	if (EthashAux::eval(tempWork.seed, tempWork.header, solution.nonce).value < tempWork.boundary)
-	{
+                // Will re-indent this block later. For now, leave it such that the diff is readable
 		string json;
 		switch (m_protocol) {
 		case STRATUM_PROTOCOL_STRATUM:
@@ -495,33 +494,5 @@ bool EthStratumClientV2::submit(Solution solution) {
 			cnote << "Nonce:" << "0x" + nonceHex;
 		}
 		return true;
-	}
-	else if (EthashAux::eval(tempPreviousWork.seed, tempPreviousWork.header, solution.nonce).value < tempPreviousWork.boundary)
-	{
-		string json;
-		switch (m_protocol) {
-		case STRATUM_PROTOCOL_STRATUM:
-			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_previous_job + "\",\"0x" + nonceHex + "\",\"0x" + tempPreviousWork.header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
-			break;
-		case STRATUM_PROTOCOL_ETHPROXY:
-			json = "{\"id\": 4, \"worker\":\"" + m_worker + "\", \"method\": \"eth_submitWork\", \"params\": [\"0x" + nonceHex + "\",\"0x" + tempPreviousWork.header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
-			break;
-		case STRATUM_PROTOCOL_ETHEREUMSTRATUM:
-			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_previous_job + "\",\"" + minernonce + "\"]}\n";
-			break;
-		}		std::ostream os(&m_requestBuffer);
-		os << json;
-		m_stale = true;
-		write(m_socket, m_requestBuffer);
-		cwarn << "Submitted stale solution.";
-		return true;
-	}
-	else {
-		m_stale = false;
-		cwarn << "FAILURE: GPU gave incorrect result!";
-		p_farm->failedSolution();
-	}
-
-	return false;
 }
 

--- a/libstratum/EthStratumClientV2.cpp
+++ b/libstratum/EthStratumClientV2.cpp
@@ -346,13 +346,6 @@ void EthStratumClientV2::processReponse(Json::Value& responseObject)
 					{
 						h256 seedHash = h256(sSeedHash);
 
-						m_previous.header = m_current.header;
-						m_previous.seed = m_current.seed;
-						m_previous.boundary = m_current.boundary;
-						m_previous.startNonce = m_current.startNonce;
-						m_previous.exSizeBits = m_previous.exSizeBits;
-						m_previousJob = m_job;
-
 						m_current.header = h256(sHeaderHash);
 						m_current.seed = seedHash;
 						m_current.boundary = h256();
@@ -390,11 +383,6 @@ void EthStratumClientV2::processReponse(Json::Value& responseObject)
 							//x_current.lock();
 							//if (p_worktimer)
 							//	p_worktimer->cancel();
-
-							m_previous.header = m_current.header;
-							m_previous.seed = m_current.seed;
-							m_previous.boundary = m_current.boundary;
-							m_previousJob = m_job;
 
 							m_current.header = h256(sHeaderHash);
 							m_current.seed = seedHash;
@@ -462,8 +450,6 @@ bool EthStratumClientV2::submit(Solution solution) {
 	x_current.lock();
 	WorkPackage tempWork(m_current);
 	string temp_job = m_job;
-	WorkPackage tempPreviousWork(m_previous);
-	string temp_previous_job = m_previousJob;
 	x_current.unlock();
 
 	string minernonce;

--- a/libstratum/EthStratumClientV2.cpp
+++ b/libstratum/EthStratumClientV2.cpp
@@ -344,15 +344,15 @@ void EthStratumClientV2::processReponse(Json::Value& responseObject)
 
 					if (sHeaderHash != "" && sSeedHash != "")
 					{
-						h256 seedHash = h256(sSeedHash);
-
+						x_current.lock();
 						m_current.header = h256(sHeaderHash);
-						m_current.seed = seedHash;
+						m_current.seed = h256(sSeedHash);
 						m_current.boundary = h256();
 						diffToTarget((uint32_t*)m_current.boundary.data(), m_nextWorkDifficulty);
 						m_current.startNonce = ethash_swap_u64(*((uint64_t*)m_extraNonce.data()));
 						m_current.exSizeBits = m_extraNonceHexSize * 4;
 						m_job = job;
+						x_current.unlock();
 
 						p_farm->setWork(m_current);
 						cnote << "Received new job #" + job.substr(0, 8)
@@ -375,24 +375,18 @@ void EthStratumClientV2::processReponse(Json::Value& responseObject)
 					if (sHeaderHash != "" && sSeedHash != "" && sShareTarget != "")
 					{
 
-						h256 seedHash = h256(sSeedHash);
 						h256 headerHash = h256(sHeaderHash);
 
 						if (headerHash != m_current.header)
 						{
-							//x_current.lock();
-							//if (p_worktimer)
-							//	p_worktimer->cancel();
-
+							x_current.lock();
 							m_current.header = h256(sHeaderHash);
-							m_current.seed = seedHash;
+							m_current.seed = h256(sSeedHash);
 							m_current.boundary = h256(sShareTarget);
 							m_job = job;
+							x_current.unlock();
 
 							p_farm->setWork(m_current);
-							//x_current.unlock();
-							//p_worktimer = new boost::asio::deadline_timer(m_io_service, boost::posix_time::seconds(m_worktimeout));
-							//p_worktimer->async_wait(boost::bind(&EthStratumClientV2::work_timeout_handler, this, boost::asio::placeholders::error));
 						}
 						cnote << "Received new job #" + job.substr(0, 8)
 							<< " seed: " << "#" + m_current.seed.hex().substr(0, 32)

--- a/libstratum/EthStratumClientV2.h
+++ b/libstratum/EthStratumClientV2.h
@@ -66,12 +66,10 @@ private:
 	Farm* p_farm;
 	mutex x_current;
 	WorkPackage m_current;
-	WorkPackage m_previous;
 
 	bool m_stale = false;
 
 	string m_job;
-	string m_previousJob;
 
 	boost::asio::io_service m_io_service;
 	boost::asio::ip::tcp::socket m_socket;
@@ -93,3 +91,4 @@ private:
 
 	void processExtranonce(std::string& enonce);
 };
+


### PR DESCRIPTION
also fix rare but missed opportunity to submit a share.

When submit is called, the call stack will look like this:

EthStratumClient::submit()    <== eval() called in this method
MinerCLI::doStratum::__l7::()
dev::eth::CUDAMiner::report() <== eval() called in this method
dev::eth::EthashCUDAHook::found()
ethash_cuda_miner::search()
dev::eth::CUDAMiner::workLoop()
dev::Worker::startWorking::__l7::()

In this case, since the GPU solution is evaluated, and the mix
hash calculated in CUDAMiner::report, there is no need to do so
again in EthStratumClient::submit. There is the same evaluation
done in CLMiner::report, the only other caller of submit.

Since EthStratumClient::submit can only be called with a valid
share, remove the redundant call to EthashAux::eval along
with much dead code.

In the rare but possible case that a CUDA stream discovers
multiple good shares (up to 63 of them!!! what are the odds?),
process all found shares instead of just the 1st.