### PR TITLE
Fix segfault and deadlock in CUDAMiner.

### DIFF
--- a/libdevcore/CMakeLists.txt
+++ b/libdevcore/CMakeLists.txt
@@ -4,5 +4,5 @@ file(GLOB SOURCES "*.cpp")
 find_package(Threads)
 
 add_library(devcore ${SOURCES} ${HEADERS})
-target_link_libraries(devcore PUBLIC Boost::boost)
+target_link_libraries(devcore PUBLIC Boost::boost Boost::system)
 target_link_libraries(devcore PRIVATE Threads::Threads)

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -96,6 +96,7 @@ CUDAMiner::CUDAMiner(FarmFace& _farm, unsigned _index) :
 
 CUDAMiner::~CUDAMiner()
 {
+	stopWorking();
 	pause();
 	delete m_miner;
 	delete m_hook;
@@ -189,7 +190,7 @@ void CUDAMiner::workLoop()
 			if (current.exSizeBits >= 0) 
 				startN = current.startNonce | ((uint64_t)index << (64 - 4 - current.exSizeBits)); // this can support up to 16 devices
 			m_miner->search(current.header.data(), upper64OfBoundary, *m_hook, (current.exSizeBits >= 0), startN);
-			
+
 			// Check if we should stop.
 			if (shouldStop())
 			{

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -135,17 +135,19 @@ public:
 	 */
 	void stop()
 	{
-		Guard l(x_minerWork);
-		m_miners.clear();
-		m_isMining = false;
-
-		if (p_hashrateTimer) {
-			p_hashrateTimer->cancel();
+		{
+			Guard l(x_minerWork);
+			m_miners.clear();
+			m_isMining = false;
 		}
 
 		m_io_service.stop();
 		m_serviceThread.join();
-		p_hashrateTimer = nullptr;
+
+		if (p_hashrateTimer) {
+			p_hashrateTimer->cancel();
+			p_hashrateTimer = nullptr;
+		}
 	}
 
 	void collectHashRate()


### PR DESCRIPTION
* Add stopWorking() to destructor before pause() to prevent workLoop from continuing on deleted members.
* Scope minerWork lock to just the m_miners member, preventing deadlock with collectHashRate.
* Fix race with hashrateTimer by canceling and removing after serviceThread is joined to prevent retriggering the timer in serviceThread.
* Add boost::system to target_link_libraries for devcore for those that don't compile with stratum.