### PR TITLE
CUDA: Allow enum devices ordered by PCI information

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -1068,7 +1068,7 @@ private:
 	unsigned m_globalWorkSizeMultiplier = ethash_cuda_miner::c_defaultGridSize;
 	unsigned m_localWorkSize = ethash_cuda_miner::c_defaultBlockSize;
 	unsigned m_cudaDeviceCount = 0;
-	unsigned m_cudaDevices[16];
+	unsigned m_cudaDevices[ETHHASH_MAX_CUDA_DEVICES];
 	unsigned m_numStreams = ethash_cuda_miner::c_defaultNumStreams;
 	unsigned m_cudaSchedule = 4; // sync
 #endif

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -332,6 +332,17 @@ public:
 				}
 			}
 		}
+		else if (arg == "--cuda-devices-enum")
+		{
+			string mode = argv[++i];
+			if (mode == "default") m_cudaDevicesEnumMode = 0;
+			else if (mode == "pci") m_cudaDevicesEnumMode = 1;
+			else
+			{
+				cerr << "Bad " << arg << " option: " << argv[i] << endl;
+				BOOST_THROW_EXCEPTION(BadArgument());
+			}
+		}
 		else if (arg == "--cuda-parallel-hash" && i + 1 < argc)
 		{
 				try {
@@ -487,7 +498,10 @@ public:
 #endif
 #if ETH_ETHASHCUDA
 			if (m_minerType == MinerType::CUDA || m_minerType == MinerType::Mixed)
+			{
+				CUDAMiner::setDevicesEnumMode(m_cudaDevicesEnumMode);
 				CUDAMiner::listDevices();
+			}
 #endif
 			exit(0);
 		}
@@ -520,6 +534,7 @@ public:
 		else if (m_minerType == MinerType::CUDA || m_minerType == MinerType::Mixed)
 		{
 #if ETH_ETHASHCUDA
+			CUDAMiner::setDevicesEnumMode(m_cudaDevicesEnumMode);
 			if (m_cudaDeviceCount > 0)
 			{
 				CUDAMiner::setDevices(m_cudaDevices, m_cudaDeviceCount);
@@ -615,6 +630,9 @@ public:
 			<< "        yield - Instruct CUDA to yield its thread when waiting for results from the device." << endl
 			<< "        sync  - Instruct CUDA to block the CPU thread on a synchronization primitive when waiting for the results from the device." << endl
 			<< "    --cuda-devices <0 1 ..n> Select which CUDA GPUs to mine on. Default is to use all" << endl
+			<< "    --cuda-devices-enum Enumerate devices ordered:" << endl
+			<< "        default - as Nvidea driver returns" << endl
+			<< "        pci     - by pciDomainID/pciBusID/pciDeviceID (like nvidia-smi)" << endl
 			<< "    --cuda-parallel-hash <1 2 ..8> Define how many hashes to calculate in a kernel, can be scaled to achieve better performance. Default=4" << endl
 #endif
 #if API_CORE
@@ -1068,6 +1086,7 @@ private:
 	unsigned m_globalWorkSizeMultiplier = ethash_cuda_miner::c_defaultGridSize;
 	unsigned m_localWorkSize = ethash_cuda_miner::c_defaultBlockSize;
 	unsigned m_cudaDeviceCount = 0;
+	unsigned m_cudaDevicesEnumMode = 0; // 0=enumeratation from Nvidea driver, 1=PciId
 	unsigned m_cudaDevices[ETHHASH_MAX_CUDA_DEVICES];
 	unsigned m_numStreams = ethash_cuda_miner::c_defaultNumStreams;
 	unsigned m_cudaSchedule = 4; // sync

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -285,7 +285,7 @@ public:
 				if(m_openclThreadsPerHash != 1 && m_openclThreadsPerHash != 2 &&
 				   m_openclThreadsPerHash != 4 && m_openclThreadsPerHash != 8) {
 					BOOST_THROW_EXCEPTION(BadArgument());
-				} 
+				}
 			}
 			catch(...) {
 				cerr << "Bad " << arg << " option: " << argv[i] << endl;
@@ -500,7 +500,7 @@ public:
 				CLMiner::setDevices(m_openclDevices, m_openclDeviceCount);
 				m_miningThreads = m_openclDeviceCount;
 			}
-			
+
 			CLMiner::setThreadsPerHash(m_openclThreadsPerHash);
 			if (!CLMiner::configureGPU(
 					m_localWorkSize,
@@ -787,11 +787,11 @@ private:
 
 		h256 id = h256::random();
 		Farm f;
-		
+
 #if API_CORE
 		Api api(this->m_api_port, f);
 #endif
-		
+
 		f.setSealers(sealers);
 
 		if (_m == MinerType::CL)
@@ -933,11 +933,11 @@ private:
 			m_farmRecheckPeriod = m_defaultStratumFarmRecheckPeriod;
 
 		Farm f;
-		
+
 #if API_CORE
 		Api api(this->m_api_port, f);
 #endif
-	
+
 		// this is very ugly, but if Stratum Client V2 tunrs out to be a success, V1 will be completely removed anyway
 		if (m_stratumClientVersion == 1) {
 			EthStratumClient client(&f, m_minerType, m_farmURL, m_port, m_user, m_pass, m_maxFarmRetries, m_worktimeout, m_stratumProtocol, m_email);
@@ -964,7 +964,7 @@ private:
 				}
 				return false;
 			});
-			f.onMinerRestart([&](){ 
+			f.onMinerRestart([&](){
 				client.reconnect();
 			});
 
@@ -984,7 +984,7 @@ private:
 					{
 						minelog << "Waiting for work package...";
 					}
-					
+
 					if (this->m_report_stratum_hashrate) {
 						auto rate = mp.rate();
 						client.submitHashrate(toJS(rate));
@@ -1013,7 +1013,7 @@ private:
 				client.submit(sol);
 				return false;
 			});
-			f.onMinerRestart([&](){ 
+			f.onMinerRestart([&](){
 				client.reconnect();
 			});
 
@@ -1033,7 +1033,7 @@ private:
 					{
 						minelog << "Waiting for work package...";
 					}
-					
+
 					if (this->m_report_stratum_hashrate) {
 						auto rate = mp.rate();
 						client.submitHashrate(toJS(rate));
@@ -1095,7 +1095,7 @@ private:
 	bool m_show_hwmonitors = false;
 #if API_CORE
 	int m_api_port = 0;
-#endif	
+#endif
 
 #if ETH_STRATUM
 	bool m_report_stratum_hashrate = false;

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -332,21 +332,21 @@ public:
 				}
 			}
 		}
-                else if (arg == "--cuda-parallel-hash" && i + 1 < argc)
-                {
-                        try {
-                                m_parallelHash = stol(argv[++i]);
-                                if (m_parallelHash == 0 || m_parallelHash > 8)
-                                {
-                                    throw BadArgument();
-                                }
-                        }
-                        catch (...)
-                        {
-                                cerr << "Bad " << arg << " option: " << argv[i] << endl;
-                                BOOST_THROW_EXCEPTION(BadArgument());
-                        }
-                }
+		else if (arg == "--cuda-parallel-hash" && i + 1 < argc)
+		{
+				try {
+						m_parallelHash = stol(argv[++i]);
+						if (m_parallelHash == 0 || m_parallelHash > 8)
+						{
+							throw BadArgument();
+						}
+				}
+				catch (...)
+				{
+						cerr << "Bad " << arg << " option: " << argv[i] << endl;
+						BOOST_THROW_EXCEPTION(BadArgument());
+				}
+		}
 		else if (arg == "--cuda-schedule" && i + 1 < argc)
 		{
 			string mode = argv[++i];

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -87,7 +87,7 @@ namespace eth
 unsigned CUDAMiner::s_platformId = 0;
 unsigned CUDAMiner::s_deviceId = 0;
 unsigned CUDAMiner::s_numInstances = 0;
-int CUDAMiner::s_devices[16] = { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
+int CUDAMiner::s_devices[ETHHASH_MAX_CUDA_DEVICES] = { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
 
 CUDAMiner::CUDAMiner(FarmFace& _farm, unsigned _index) :
 	Miner("CUDA", _farm, _index),

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -131,10 +131,10 @@ bool CUDAMiner::init(const h256& seed)
 		light = EthashAux::light(seed);
 		bytesConstRef lightData = light->data();
 
-		m_miner->init(light->light, lightData.data(), lightData.size(), 
+		m_miner->init(light->light, lightData.data(), lightData.size(),
 			device, (s_dagLoadMode == DAG_LOAD_MODE_SINGLE), s_dagInHostMemory);
 		s_dagLoadIndex++;
-    
+
 		if (s_dagLoadMode == DAG_LOAD_MODE_SINGLE)
 		{
 			if (s_dagLoadIndex >= s_numInstances && s_dagInHostMemory)
@@ -166,7 +166,7 @@ void CUDAMiner::workLoop()
 		while(true)
 		{
 			const WorkPackage w = work();
-			
+
 			if(!m_miner || current.header != w.header || current.seed != w.seed)
 			{
 				if(!w || w.header == h256())
@@ -175,7 +175,7 @@ void CUDAMiner::workLoop()
 					std::this_thread::sleep_for(std::chrono::seconds(3));
 					continue;
 				}
-				
+
 				//cnote << "set work; seed: " << "#" + w.seed.hex().substr(0, 8) + ", target: " << "#" + w.boundary.hex().substr(0, 12);
 				if (!m_miner || current.seed != w.seed)
 				{
@@ -186,10 +186,10 @@ void CUDAMiner::workLoop()
 			}
 			uint64_t upper64OfBoundary = (uint64_t)(u64)((u256)current.boundary >> 192);
 			uint64_t startN = current.startNonce;
-			if (current.exSizeBits >= 0) 
+			if (current.exSizeBits >= 0)
 				startN = current.startNonce | ((uint64_t)index << (64 - 4 - current.exSizeBits)); // this can support up to 16 devices
 			m_miner->search(current.header.data(), upper64OfBoundary, *m_hook, (current.exSizeBits >= 0), startN);
-			
+
 			// Check if we should stop.
 			if (shouldStop())
 			{

--- a/libethash-cuda/CUDAMiner.h
+++ b/libethash-cuda/CUDAMiner.h
@@ -49,6 +49,8 @@ class EthashCUDAHook;
 		static unsigned getNumDevices();
 		static void listDevices();
 		static void setParallelHash(unsigned _parallelHash);
+		static void setDevicesEnumMode(unsigned _devicesEnumMode);
+		static unsigned getDeviceUsingEnumMode(unsigned _device);
 		static bool configureGPU(
 			unsigned _blockSize,
 			unsigned _gridSize,
@@ -87,8 +89,9 @@ class EthashCUDAHook;
 		static unsigned s_platformId;
 		static unsigned s_deviceId;
 		static unsigned s_numInstances;
+		static unsigned s_devicesEnumMode;
+		static unsigned *s_devicesEnumByPci;
 		static int s_devices[ETHHASH_MAX_CUDA_DEVICES];
-
 	};
 }
 }

--- a/libethash-cuda/CUDAMiner.h
+++ b/libethash-cuda/CUDAMiner.h
@@ -41,9 +41,9 @@ class EthashCUDAHook;
 		CUDAMiner(FarmFace& _farm, unsigned _index);
 		~CUDAMiner();
 
-		static unsigned instances() 
-		{ 
-			return s_numInstances > 0 ? s_numInstances : 1; 
+		static unsigned instances()
+		{
+			return s_numInstances > 0 ? s_numInstances : 1;
 		}
 		static std::string platformInfo();
 		static unsigned getNumDevices();
@@ -58,13 +58,13 @@ class EthashCUDAHook;
 			unsigned _dagLoadMode,
 			unsigned _dagCreateDevice
 			);
-		static void setNumInstances(unsigned _instances) 
-		{ 
+		static void setNumInstances(unsigned _instances)
+		{
 			s_numInstances = std::min<unsigned>(_instances, getNumDevices());
 		}
-		static void setDevices(unsigned * _devices, unsigned _selectedDeviceCount) 
+		static void setDevices(unsigned * _devices, unsigned _selectedDeviceCount)
 		{
-			for (unsigned i = 0; i < _selectedDeviceCount; i++) 
+			for (unsigned i = 0; i < _selectedDeviceCount; i++)
 			{
 				s_devices[i] = _devices[i];
 			}
@@ -87,7 +87,7 @@ class EthashCUDAHook;
 		static unsigned s_platformId;
 		static unsigned s_deviceId;
 		static unsigned s_numInstances;
-		static int s_devices[16];
+		static int s_devices[ETHHASH_MAX_CUDA_DEVICES];
 
 	};
 }

--- a/libethash-cuda/cuda_helper.h
+++ b/libethash-cuda/cuda_helper.h
@@ -107,7 +107,7 @@ __device__ __forceinline__ uint64_t MAKE_ULONGLONG(uint32_t LO, uint32_t HI)
 	return result;
 }
 
-__device__ __forceinline__ uint64_t REPLACE_HIWORD(const uint64_t x, const uint32_t y) 
+__device__ __forceinline__ uint64_t REPLACE_HIWORD(const uint64_t x, const uint32_t y)
 {
 	uint64_t result;
 	asm(
@@ -120,7 +120,7 @@ __device__ __forceinline__ uint64_t REPLACE_HIWORD(const uint64_t x, const uint3
 	return result;
 
 }
-__device__ __forceinline__ uint64_t REPLACE_LOWORD(const uint64_t x, const uint32_t y) 
+__device__ __forceinline__ uint64_t REPLACE_LOWORD(const uint64_t x, const uint32_t y)
 {
 	uint64_t result;
 	asm(
@@ -258,7 +258,7 @@ uint64_t xor3(const uint64_t a, const uint64_t b, const uint64_t c)
 	uint64_t result;
 	asm("xor.b64 %0, %2, %3;\n\t"
 	    "xor.b64 %0, %0, %1;\n\t"
-		//output : input registers 
+		//output : input registers
 		: "=l"(result) : "l"(a), "l"(b), "l"(c));
 	return result;
 }
@@ -614,7 +614,7 @@ static __device__ __forceinline__ uint2 operator* (uint2 a, uint2 b)
 
 // uint2 method
 #if  __CUDA_ARCH__ >= 350
-__device__ __inline__ uint2 ROR2(const uint2 a, const int offset) 
+__device__ __inline__ uint2 ROR2(const uint2 a, const int offset)
 {
 	uint2 result;
 	if (offset < 32) {
@@ -628,15 +628,15 @@ __device__ __inline__ uint2 ROR2(const uint2 a, const int offset)
 	return result;
 }
 #else
-__device__ __inline__ uint2 ROR2(const uint2 v, const int n) 
+__device__ __inline__ uint2 ROR2(const uint2 v, const int n)
 {
 	uint2 result;
-	if (n <= 32) 
+	if (n <= 32)
 	{
 		result.y = ((v.y >> (n)) | (v.x << (32 - n)));
 		result.x = ((v.x >> (n)) | (v.y << (32 - n)));
 	}
-	else 
+	else
 	{
 		result.y = ((v.x >> (n - 32)) | (v.y << (64 - n)));
 		result.x = ((v.y >> (n - 32)) | (v.x << (64 - n)));
@@ -733,12 +733,12 @@ __inline__ __device__ uint2 ROL2(const uint2 a, const int offset) {
 __inline__ __device__ uint2 ROL2(const uint2 v, const int n)
 {
 		uint2 result;
-		if (n <= 32) 
+		if (n <= 32)
 		{
 			result.y = ((v.y << (n)) | (v.x >> (32 - n)));
 			result.x = ((v.x << (n)) | (v.y >> (32 - n)));
 		}
-		else 
+		else
 		{
 			result.y = ((v.x << (n - 32)) | (v.y >> (64 - n)));
 			result.x = ((v.y << (n - 32)) | (v.x >> (64 - n)));
@@ -828,7 +828,7 @@ static __forceinline__ __device__ uint2 SHL2(uint2 a, int offset)
 {
 #if __CUDA_ARCH__ > 300
 	uint2 result;
-	if (offset<32) 
+	if (offset<32)
 	{
 		asm("{\n\t"
 			"shf.l.clamp.b32 %1,%2,%3,%4; \n\t"
@@ -845,7 +845,7 @@ static __forceinline__ __device__ uint2 SHL2(uint2 a, int offset)
 	}
 	return result;
 #else
-	if (offset<=32) 
+	if (offset<=32)
 	{
 		a.y = (a.y << offset) | (a.x >> (32 - offset));
 		a.x = (a.x << offset);
@@ -878,7 +878,7 @@ static __forceinline__ __device__ uint2 SHR2(uint2 a, int offset)
 	}
 	return result;
 	#else
-	if (offset<=32) 
+	if (offset<=32)
 	{
 		a.x = (a.x >> offset) | (a.y << (32 - offset));
 		a.y = (a.y >> offset);
@@ -981,7 +981,7 @@ static __device__ __forceinline__ ulonglong2 madd4long(ulonglong2 a, ulonglong2 
 	}
 static __device__ __forceinline__ void madd4long2(ulonglong2 &a, ulonglong2 b)
  {
-	
+
 		asm("{\n\t"
 		 ".reg .u32 a0,a1,a2,a3,b0,b1,b2,b3;\n\t"
 		 "mov.b64 {a0,a1}, %0;\n\t"
@@ -996,7 +996,7 @@ static __device__ __forceinline__ void madd4long2(ulonglong2 &a, ulonglong2 b)
 		 "mov.b64 %1, {b2,b3};\n\t"
 		 "}\n\t"
 		 : "+l"(a.x), "+l"(a.y) : "l"(b.x), "l"(b.y));
-	
+
 }
 
 __device__ __forceinline__

--- a/libethash-cuda/dagger_shared.cuh
+++ b/libethash-cuda/dagger_shared.cuh
@@ -17,13 +17,13 @@ __device__ uint64_t compute_hash(
 	uint64_t state[25];
 	state[4] = nonce;
 	keccak_f1600_init(state);
-	
+
 	// Threads work together in this phase in groups of 8.
 	const int thread_id  = threadIdx.x &  (THREADS_PER_HASH - 1);
 	const int hash_id = threadIdx.x  >> 3;
 
 	extern __shared__  compute_hash_share share[];
-	
+
 	for (int i = 0; i < THREADS_PER_HASH; i++)
 	{
 		// share init with other threads

--- a/libethash-cuda/dagger_shuffled.cuh
+++ b/libethash-cuda/dagger_shuffled.cuh
@@ -9,11 +9,11 @@ __device__ __forceinline__ uint64_t compute_hash(
 {
 	// sha3_512(header .. nonce)
 	uint2 state[12];
-	
+
 	state[4] = vectorize(nonce);
 
 	keccak_f1600_init(state);
-	
+
 	// Threads work together in this phase in groups of 8.
 	const int thread_id  = threadIdx.x &  (THREADS_PER_HASH - 1);
 	const int mix_idx    = thread_id & 3;
@@ -23,12 +23,12 @@ __device__ __forceinline__ uint64_t compute_hash(
 		uint4 mix[_PARALLEL_HASH];
 		uint32_t offset[_PARALLEL_HASH];
 		uint32_t init0[_PARALLEL_HASH];
-	
+
 		// share init among threads
 		for (int p = 0; p < _PARALLEL_HASH; p++)
 		{
 			uint2 shuffle[8];
-			for (int j = 0; j < 8; j++) 
+			for (int j = 0; j < 8; j++)
 			{
 #if CUDA_VERSION < SHUFFLE_DEPRECATED
 				shuffle[j].x = __shfl(state[j].x, i+p, THREADS_PER_HASH);
@@ -75,7 +75,7 @@ __device__ __forceinline__ uint64_t compute_hash(
 					mix[p] = fnv4(mix[p], d_dag[offset[p]].uint4s[thread_id]);
 				}
 
-                                
+
 			}
 		}
 
@@ -113,7 +113,7 @@ __device__ __forceinline__ uint64_t compute_hash(
 			}
 		}
 	}
-	
+
 	// keccak_256(keccak_512(header..nonce) .. mix);
 	return keccak_f1600_final(state);
 }

--- a/libethash-cuda/ethash_cuda_miner.cpp
+++ b/libethash-cuda/ethash_cuda_miner.cpp
@@ -183,14 +183,22 @@ void ethash_cuda_miner::listDevices()
 	{
 		string outString = "\nListing CUDA devices.\nFORMAT: [deviceID] deviceName\n";
 		int numDevices = getNumDevices();
+		char pciIdBuff[8 + 1 + 8 + 1 + 8 + 1]; /* int can need max 8 characters in hexnotation */
+
 		for (int i = 0; i < numDevices; ++i)
 		{
+			string bpciIdBuff_s;
 			cudaDeviceProp props;
 			CUDA_SAFE_CALL(cudaGetDeviceProperties(&props, i));
+
+			sprintf(pciIdBuff, "%04x:%02x:%02x",
+			        props.pciDomainID, props.pciBusID, props.pciDeviceID);
+			bpciIdBuff_s = pciIdBuff;
 
 			outString += "[" + to_string(i) + "] " + string(props.name) + "\n";
 			outString += "\tCompute version: " + to_string(props.major) + "." + to_string(props.minor) + "\n";
 			outString += "\tcudaDeviceProp::totalGlobalMem: " + to_string(props.totalGlobalMem) + "\n";
+			outString += "\tPciID: " + bpciIdBuff_s + "\n";
 		}
 		std::cout << outString;
 	}

--- a/libethash-cuda/ethash_cuda_miner.cpp
+++ b/libethash-cuda/ethash_cuda_miner.cpp
@@ -22,6 +22,7 @@
 
 #define _CRT_SECURE_NO_WARNINGS
 
+#include <assert.h>
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>
@@ -100,7 +101,10 @@ int ethash_cuda_miner::getNumDevices()
 	int deviceCount = -1;
 	cudaError_t err = cudaGetDeviceCount(&deviceCount);
 	if (err == cudaSuccess)
+	{
+		assert(deviceCount <= ETHHASH_MAX_CUDA_DEVICES);
 		return deviceCount;
+	}
 
 	if (err == cudaErrorInsufficientDriver)
 	{

--- a/libethash-cuda/ethash_cuda_miner.h
+++ b/libethash-cuda/ethash_cuda_miner.h
@@ -30,7 +30,8 @@ public:
 
 	static std::string platform_info(unsigned _deviceId = 0);
 	static int getNumDevices();
-	static void listDevices();
+	static void listDevices(unsigned *_devices);
+	static unsigned *getDevicesOrderedByPciInfo();
 	static bool configureGPU(
 		int *	 _devices,
 		unsigned _blockSize,

--- a/libethash-cuda/ethash_cuda_miner.h
+++ b/libethash-cuda/ethash_cuda_miner.h
@@ -9,6 +9,10 @@
 #include <libhwmon/wrapnvml.h>
 #include "ethash_cuda_miner_kernel.h"
 
+#ifndef ETHHASH_MAX_CUDA_DEVICES
+#define ETHHASH_MAX_CUDA_DEVICES 16
+#endif
+
 class ethash_cuda_miner
 {
 public:
@@ -35,7 +39,7 @@ public:
 		unsigned _scheduleFlag,
 		uint64_t _currentBlock
 		);
-        static void setParallelHash(unsigned _parallelHash);
+	static void setParallelHash(unsigned _parallelHash);
 
 	bool init(ethash_light_t _light, uint8_t const* _lightData, uint64_t _lightSize, unsigned _deviceId, bool _cpyToHost, uint8_t * &hostDAG);
 

--- a/libethash-cuda/ethash_cuda_miner.h
+++ b/libethash-cuda/ethash_cuda_miner.h
@@ -58,14 +58,14 @@ private:
 	uint64_t m_starting_nonce;
 	uint64_t m_current_index;
 	uint32_t m_sharedBytes;
-	
+
 	///Constants on GPU
 	hash128_t* m_dag = nullptr;
 	std::vector<hash64_t*> m_light;
 	uint32_t m_dag_size = -1;
 	uint32_t m_device_num;
-	
-	
+
+
 
 	volatile uint32_t ** m_search_buf;
 	cudaStream_t  * m_streams;

--- a/libethash-cuda/ethash_cuda_miner_kernel.cu
+++ b/libethash-cuda/ethash_cuda_miner_kernel.cu
@@ -22,13 +22,13 @@
 #endif
 
 template <uint32_t _PARALLEL_HASH>
-__global__ void 
+__global__ void
 ethash_search(
 	volatile uint32_t* g_output,
 	uint64_t start_nonce
 	)
 {
-	uint32_t const gid = blockIdx.x * blockDim.x + threadIdx.x;	
+	uint32_t const gid = blockIdx.x * blockDim.x + threadIdx.x;
         uint64_t hash = compute_hash<_PARALLEL_HASH>(start_nonce + gid);
 	if (cuda_swab64(hash) > d_target) return;
 	uint32_t index = atomicInc(const_cast<uint32_t*>(g_output), SEARCH_RESULT_BUFFER_SIZE - 1) + 1;
@@ -103,7 +103,7 @@ ethash_calculate_dag_item(uint32_t start)
 		}
 
 
-#endif		
+#endif
 	}
 	SHA3_512(dag_node.uint2s);
 	hash64_t * dag_nodes = (hash64_t *)d_dag;
@@ -129,7 +129,7 @@ ethash_calculate_dag_item(uint32_t start)
 		}
 		dag_nodes[shuffle_index].uint4s[thread_id] = s[thread_id];
 	}
-#endif		 
+#endif
 }
 
 void ethash_generate_dag(

--- a/libethash-cuda/keccak.cuh
+++ b/libethash-cuda/keccak.cuh
@@ -234,7 +234,7 @@ __device__ __forceinline__ void keccak_f1600_init(uint2* state)
 		s[10] = ROL2(u, 1);
 
 		/* chi: a[i,j] ^= ~b[i,j+1] & b[i,j+2] */
-			
+
 		u = s[0]; v = s[1];
 		s[0] = chi(s[0], s[1], s[2]);
 		s[1] = chi(s[1], s[2], s[3]);
@@ -242,14 +242,14 @@ __device__ __forceinline__ void keccak_f1600_init(uint2* state)
 		s[3] = chi(s[3], s[4], u);
 		s[4] = chi(s[4], u, v);
 
-		u = s[5]; v = s[6]; 
+		u = s[5]; v = s[6];
 		s[5] = chi(s[5], s[6], s[7]);
 		s[6] = chi(s[6], s[7], s[8]);
 		s[7] = chi(s[7], s[8], s[9]);
 		s[8] = chi(s[8], s[9], u);
 		s[9] = chi(s[9], u, v);
 
-		u = s[10]; v = s[11]; 
+		u = s[10]; v = s[11];
 		s[10] = chi(s[10], s[11], s[12]);
 		s[11] = chi(s[11], s[12], s[13]);
 		s[12] = chi(s[12], s[13], s[14]);
@@ -350,7 +350,7 @@ __device__ __forceinline__ uint64_t keccak_f1600_final(uint2* state)
 	}
 	s[12].x = 1;
 	s[16].y = 0x80000000;
-	
+
 	/* theta: c = a[0,i] ^ a[1,i] ^ .. a[4,i] */
 	t[0] = xor3(s[0], s[5], s[10]);
 	t[1] = xor3(s[1], s[6], s[11]) ^ s[16];
@@ -542,7 +542,7 @@ __device__ __forceinline__ uint64_t keccak_f1600_final(uint2* state)
 
 		/* chi: a[i,j] ^= ~b[i,j+1] & b[i,j+2] */
 		u = s[0]; v = s[1];
-		s[0] = chi(s[0], s[1], s[2]);	
+		s[0] = chi(s[0], s[1], s[2]);
 		s[1] = chi(s[1], s[2], s[3]);
 		s[2] = chi(s[2], s[3], s[4]);
 		s[3] = chi(s[3], s[4], u);
@@ -601,7 +601,7 @@ __device__ __forceinline__ uint64_t keccak_f1600_final(uint2* state)
 }
 
 __device__ __forceinline__ void SHA3_512(uint2* s) {
-	
+
 	uint2 t[5], u, v;
 
 	for (uint32_t i = 8; i < 25; i++)

--- a/libethash-cuda/keccak_u64.cuh
+++ b/libethash-cuda/keccak_u64.cuh
@@ -229,7 +229,7 @@ __device__ __forceinline__ void keccak_f1600_init(uint64_t * s)
 		s[10] = ROTL64(u, 1);
 
 		/* chi: a[i,j] ^= ~b[i,j+1] & b[i,j+2] */
-			
+
 		u = s[0]; v = s[1];
 		s[0] = chi(s[0], s[1], s[2]);
 		s[1] = chi(s[1], s[2], s[3]);
@@ -237,14 +237,14 @@ __device__ __forceinline__ void keccak_f1600_init(uint64_t * s)
 		s[3] = chi(s[3], s[4], u);
 		s[4] = chi(s[4], u, v);
 
-		u = s[5]; v = s[6]; 
+		u = s[5]; v = s[6];
 		s[5] = chi(s[5], s[6], s[7]);
 		s[6] = chi(s[6], s[7], s[8]);
 		s[7] = chi(s[7], s[8], s[9]);
 		s[8] = chi(s[8], s[9], u);
 		s[9] = chi(s[9], u, v);
 
-		u = s[10]; v = s[11]; 
+		u = s[10]; v = s[11];
 		s[10] = chi(s[10], s[11], s[12]);
 		s[11] = chi(s[11], s[12], s[13]);
 		s[12] = chi(s[12], s[13], s[14]);
@@ -338,7 +338,7 @@ __device__ __forceinline__ uint64_t keccak_f1600_final(uint64_t* s)
 	}
 	s[12] = 0x0000000000000001;
 	s[16] = 0x8000000000000000;
-	
+
 	/* theta: c = a[0,i] ^ a[1,i] ^ .. a[4,i] */
 	t[0] = xor3(s[0], s[5], s[10]);
 	t[1] = xor3(s[1], s[6], s[11]) ^ s[16];
@@ -530,7 +530,7 @@ __device__ __forceinline__ uint64_t keccak_f1600_final(uint64_t* s)
 
 		/* chi: a[i,j] ^= ~b[i,j+1] & b[i,j+2] */
 		u = s[0]; v = s[1];
-		s[0] = chi(s[0], s[1], s[2]);	
+		s[0] = chi(s[0], s[1], s[2]);
 		s[1] = chi(s[1], s[2], s[3]);
 		s[2] = chi(s[2], s[3], s[4]);
 		s[3] = chi(s[3], s[4], u);


### PR DESCRIPTION
etheminer and nvidia-smi uses different ids for GPU indexing.
It seems nvidia-smi enumerates the devices based on the PCI address.

When using "--cuda-devices-enum pci" the displayed gpu id in
ethminer matches those used in nvidia-smi.
So its easier to adjust settings (overclock/power) using nvidia-smi
with the same id reported in ethminer.