### PR TITLE
No duplicate evals, no invalid shares, minimal diff

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -862,7 +862,7 @@ private:
 					cnote << "  Nonce:" << solution.nonce;
 					cnote << "  headerHash:" << solution.headerHash.hex();
 					cnote << "  mixHash:" << solution.mixHash.hex();
-					cnote << EthLime << "Accepted." << EthReset;
+					cnote << EthLime << " Accepted." << EthReset;
 					f.acceptedSolution(solution.stale);
 				}
 				else {
@@ -870,7 +870,7 @@ private:
 					cwarn << "  Nonce:" << solution.nonce;
 					cwarn << "  headerHash:" << solution.headerHash.hex();
 					cwarn << "  mixHash:" << solution.mixHash.hex();
-					cwarn << "Not accepted.";
+					cwarn << EthYellow << " Rejected." << EthReset;
 					f.rejectedSolution(solution.stale);
 				}
 			}

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -858,22 +858,21 @@ private:
 				}
 				bool ok = prpc->eth_submitWork("0x" + toHex(solution.nonce), "0x" + toString(solution.headerHash), "0x" + toString(solution.mixHash));
 				if (ok) {
-					cnote << "Solution found; Submitted to" << _remote << "...";
+					cnote << "Solution found; Submitted to" << _remote;
 					cnote << "  Nonce:" << solution.nonce;
 					cnote << "  headerHash:" << solution.headerHash.hex();
 					cnote << "  mixHash:" << solution.mixHash.hex();
 					cnote << EthLime << "Accepted." << EthReset;
-					f.acceptedSolution(false);
+					f.acceptedSolution(solution.stale);
 				}
 				else {
-					cwarn << "Solution found; Submitted to" << _remote << "...";
+					cwarn << "Solution found; Submitted to" << _remote;
 					cwarn << "  Nonce:" << solution.nonce;
 					cwarn << "  headerHash:" << solution.headerHash.hex();
 					cwarn << "  mixHash:" << solution.mixHash.hex();
 					cwarn << "Not accepted.";
-					f.rejectedSolution(false);
+					f.rejectedSolution(solution.stale);
 				}
-					//exit(0);
 			}
 			catch (jsonrpc::JsonRpcException&)
 			{

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -856,31 +856,24 @@ private:
 					}
 					this_thread::sleep_for(chrono::milliseconds(_recheckPeriod));
 				}
-				if (EthashAux::eval(solution.seedHash, solution.headerHash, solution.nonce).value < solution.boundary)
-				{
-					bool ok = prpc->eth_submitWork("0x" + toHex(solution.nonce), "0x" + toString(solution.headerHash), "0x" + toString(solution.mixHash));
-					if (ok) {
-						cnote << "Solution found; Submitted to" << _remote << "...";
-						cnote << "  Nonce:" << solution.nonce;
-						cnote << "  headerHash:" << solution.headerHash.hex();
-						cnote << "  mixHash:" << solution.mixHash.hex();
-						cnote << EthLime << "Accepted." << EthReset;
-						f.acceptedSolution(false);
-					}
-					else {
-						cwarn << "Solution found; Submitted to" << _remote << "...";
-						cwarn << "  Nonce:" << solution.nonce;
-						cwarn << "  headerHash:" << solution.headerHash.hex();
-						cwarn << "  mixHash:" << solution.mixHash.hex();
-						cwarn << "Not accepted.";
-						f.rejectedSolution(false);
-					}
-					//exit(0);
+				bool ok = prpc->eth_submitWork("0x" + toHex(solution.nonce), "0x" + toString(solution.headerHash), "0x" + toString(solution.mixHash));
+				if (ok) {
+					cnote << "Solution found; Submitted to" << _remote << "...";
+					cnote << "  Nonce:" << solution.nonce;
+					cnote << "  headerHash:" << solution.headerHash.hex();
+					cnote << "  mixHash:" << solution.mixHash.hex();
+					cnote << EthLime << "Accepted." << EthReset;
+					f.acceptedSolution(false);
 				}
 				else {
-					f.failedSolution();
-					cwarn << "FAILURE: GPU gave incorrect result!";
+					cwarn << "Solution found; Submitted to" << _remote << "...";
+					cwarn << "  Nonce:" << solution.nonce;
+					cwarn << "  headerHash:" << solution.headerHash.hex();
+					cwarn << "  mixHash:" << solution.mixHash.hex();
+					cwarn << "Not accepted.";
+					f.rejectedSolution(false);
 				}
+					//exit(0);
 			}
 			catch (jsonrpc::JsonRpcException&)
 			{

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -104,8 +104,10 @@ void CLMiner::report(uint64_t _nonce, WorkPackage const& _w)
 	Result r = EthashAux::eval(_w.seed, _w.header, _nonce);
 	if (r.value < _w.boundary)
 		farm.submitProof(Solution{_nonce, r.mixHash, _w.header, _w.seed, _w.boundary, false});
-	else
-		cwarn << "Invalid solution";
+	else {
+		farm.failedSolution();
+		cwarn << "FAILURE: GPU gave incorrect result!";
+	}
 }
 
 void CLMiner::kickOff()

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -103,7 +103,7 @@ void CLMiner::report(uint64_t _nonce, WorkPackage const& _w)
 	// TODO: Why re-evaluating?
 	Result r = EthashAux::eval(_w.seed, _w.header, _nonce);
 	if (r.value < _w.boundary)
-		farm.submitProof(Solution{_nonce, r.mixHash, _w.header, _w.seed, _w.boundary, false});
+		farm.submitProof(Solution{_nonce, r.mixHash, _w.header, _w.seed, _w.boundary, _w.job, false});
 	else {
 		farm.failedSolution();
 		cwarn << "FAILURE: GPU gave incorrect result!";

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -103,7 +103,7 @@ void CLMiner::report(uint64_t _nonce, WorkPackage const& _w)
 	// TODO: Why re-evaluating?
 	Result r = EthashAux::eval(_w.seed, _w.header, _nonce);
 	if (r.value < _w.boundary)
-		farm.submitProof(Solution{_nonce, r.mixHash, _w.header, _w.seed, _w.boundary});
+		farm.submitProof(Solution{_nonce, r.mixHash, _w.header, _w.seed, _w.boundary, false});
 	else
 		cwarn << "Invalid solution";
 }

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -114,6 +114,12 @@ void CUDAMiner::report(uint64_t _nonce)
 	Result r = EthashAux::eval(w.seed, w.header, _nonce);
 	if (r.value < w.boundary)
 		farm.submitProof(Solution{_nonce, r.mixHash, w.header, w.seed, w.boundary, m_hook->isStale()});
+	else
+	{
+		farm.failedSolution();
+		cwarn << "FAILURE: GPU gave incorrect result!";
+
+	}
 }
 
 void CUDAMiner::kickOff()

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -113,7 +113,7 @@ void CUDAMiner::report(uint64_t _nonce)
 	WorkPackage w = work();  // Copy work package to avoid repeated mutex lock.
 	Result r = EthashAux::eval(w.seed, w.header, _nonce);
 	if (r.value < w.boundary)
-		farm.submitProof(Solution{_nonce, r.mixHash, w.header, w.seed, w.boundary, m_hook->isStale()});
+		farm.submitProof(Solution{_nonce, r.mixHash, w.header, w.seed, w.boundary, w.job, m_hook->isStale()});
 	else
 	{
 		farm.failedSolution();
@@ -154,7 +154,7 @@ bool CUDAMiner::init(const h256& seed)
 				// all devices have loaded DAG, we can free now
 				delete[] s_dagInHostMemory;
 				s_dagInHostMemory = NULL;
-				cout << "Freeing DAG from host" << endl;
+				cnote << "Freeing DAG from host";
 			}
 		}
 		return true;

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -59,16 +59,22 @@ namespace eth
 			m_aborted = m_abort = false;
 		}
 
-	protected:
-		virtual bool found(uint64_t const* _nonces) override
+		bool isStale()
 		{
-			m_owner.report(_nonces[0]);
+			return m_abort;
+		}
+
+
+	protected:
+		virtual bool found(uint64_t const* _nonces, uint32_t count) override
+		{
+			for (uint32_t i = 0; i < count; i++)
+				m_owner.report(_nonces[i]);
 			return m_owner.shouldStop();
 		}
 
-		virtual bool searched(uint64_t _startNonce, uint32_t _count) override
+		virtual bool searched(uint32_t _count) override
 		{
-			(void) _startNonce;  // FIXME: unusued arg.
 			UniqueGuard l(x_all);
 			m_owner.addHashCount(_count);
 			if (m_abort || m_owner.shouldStop())
@@ -107,7 +113,7 @@ void CUDAMiner::report(uint64_t _nonce)
 	WorkPackage w = work();  // Copy work package to avoid repeated mutex lock.
 	Result r = EthashAux::eval(w.seed, w.header, _nonce);
 	if (r.value < w.boundary)
-		farm.submitProof(Solution{_nonce, r.mixHash, w.header, w.seed, w.boundary});
+		farm.submitProof(Solution{_nonce, r.mixHash, w.header, w.seed, w.boundary, m_hook->isStale()});
 }
 
 void CUDAMiner::kickOff()

--- a/libethash-cuda/ethash_cuda_miner.cpp
+++ b/libethash-cuda/ethash_cuda_miner.cpp
@@ -374,17 +374,17 @@ void ethash_cuda_miner::search(uint8_t const* header, uint64_t target, search_ho
 		{
 			CUDA_SAFE_CALL(cudaStreamSynchronize(stream));
 			found_count = buffer[0];
-			if (found_count)
+			if (found_count) {
 				buffer[0] = 0;
-			for (unsigned int j = 0; j < found_count; j++)
-				nonces[j] = nonce_base + buffer[j + 1];
+				if (found_count > (SEARCH_RESULT_BUFFER_SIZE - 1))
+					found_count = SEARCH_RESULT_BUFFER_SIZE - 1;
+				for (unsigned int j = 0; j < found_count; j++)
+					nonces[j] = nonce_base + buffer[j + 1];
+			}
 		}
 		run_ethash_search(s_gridSize, s_blockSize, m_sharedBytes, stream, buffer, m_current_nonce, m_parallelHash);
 		if (m_current_index >= s_numStreams)
-		{
-			exit = found_count && hook.found(nonces);
-			exit |= hook.searched(nonce_base, batch_size);
-		}
+			exit = (found_count && hook.found(nonces, found_count)) || hook.searched(batch_size);
 	}
 }
 

--- a/libethash-cuda/ethash_cuda_miner.h
+++ b/libethash-cuda/ethash_cuda_miner.h
@@ -17,8 +17,8 @@ public:
 		virtual ~search_hook(); // always a virtual destructor for a class with virtuals.
 
 		// reports progress, return true to abort
-		virtual bool found(uint64_t const* nonces) = 0;
-		virtual bool searched(uint64_t start_nonce, uint32_t count) = 0;
+		virtual bool found(uint64_t const* nonces, uint32_t count) = 0;
+		virtual bool searched(uint32_t count) = 0;
 	};
 
 public:

--- a/libethash-cuda/ethash_cuda_miner_kernel.cu
+++ b/libethash-cuda/ethash_cuda_miner_kernel.cu
@@ -31,7 +31,8 @@ ethash_search(
 	uint32_t const gid = blockIdx.x * blockDim.x + threadIdx.x;	
         uint64_t hash = compute_hash<_PARALLEL_HASH>(start_nonce + gid);
 	if (cuda_swab64(hash) > d_target) return;
-	uint32_t index = atomicInc(const_cast<uint32_t*>(g_output), SEARCH_RESULT_BUFFER_SIZE - 1) + 1;
+	uint32_t index = atomicInc(const_cast<uint32_t*>(g_output), 0xffffffff) + 1;
+	if (index > SEARCH_RESULT_BUFFER_SIZE -1) return;
 	g_output[index] = gid;
 }
 
@@ -149,9 +150,7 @@ void ethash_generate_dag(
 	{
 		ethash_calculate_dag_item <<<blocks, threads, 0, stream >>>(i * blocks * threads);
 		CUDA_SAFE_CALL(cudaDeviceSynchronize());
-		printf("CUDA#%d: %.0f%%\n",device, 100.0f * (float)i / (float)fullRuns);
 	}
-	//printf("GPU#%d 100%%\n");
 	CUDA_SAFE_CALL(cudaGetLastError());
 }
 

--- a/libethcore/EthashAux.h
+++ b/libethcore/EthashAux.h
@@ -39,6 +39,7 @@ struct Solution
 	h256 headerHash;
 	h256 seedHash;
 	h256 boundary;
+	h256 job;
 	bool stale;
 };
 
@@ -96,6 +97,7 @@ struct WorkPackage
 	h256 boundary;
 	h256 header;	///< When h256() means "pause until notified a new work package is available".
 	h256 seed;
+	h256 job;
 
 	uint64_t startNonce = 0;
 	int exSizeBits = -1;

--- a/libethcore/EthashAux.h
+++ b/libethcore/EthashAux.h
@@ -39,6 +39,7 @@ struct Solution
 	h256 headerHash;
 	h256 seedHash;
 	h256 boundary;
+	bool stale;
 };
 
 struct Result

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -155,6 +155,7 @@ public:
 	 * @return true iff the solution was good (implying that mining should be .
 	 */
 	virtual bool submitProof(Solution const& _p) = 0;
+	virtual void failedSolution() = 0;
 };
 
 /**

--- a/libstratum/EthStratumClient.cpp
+++ b/libstratum/EthStratumClient.cpp
@@ -511,9 +511,12 @@ bool EthStratumClient::submitHashrate(string const & rate) {
 }
 
 bool EthStratumClient::submit(Solution solution) {
+	string temp_job;
 	x_current.lock();
-	string temp_job = m_job;
-	string temp_previous_job = m_previousJob;
+	if (solution.stale)
+		temp_job = m_previousJob;
+	else
+		temp_job = m_job;
 	x_current.unlock();
 
 	string minernonce;
@@ -522,60 +525,37 @@ bool EthStratumClient::submit(Solution solution) {
 		minernonce = nonceHex.substr(m_extraNonceHexSize, 16 - m_extraNonceHexSize);
 	}
 
-	if (!solution.stale)
-	{
-		string json;
+	string json;
 
-		switch (m_protocol) {
-			case STRATUM_PROTOCOL_STRATUM:
-				json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_job + "\",\"0x" + nonceHex + "\",\"0x" + solution.headerHash.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
-				break;
-			case STRATUM_PROTOCOL_ETHPROXY:
-				json = "{\"id\": 4, \"worker\":\"" + m_worker + "\", \"method\": \"eth_submitWork\", \"params\": [\"0x" + nonceHex + "\",\"0x" + solution.headerHash.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
-				break;
-			case STRATUM_PROTOCOL_ETHEREUMSTRATUM:
-				json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_job + "\",\"" + minernonce + "\"]}\n";
-				break;
-		}
-
-		std::ostream os(&m_requestBuffer);
-		os << json;
-		m_stale = false;
-		async_write(m_socket, m_requestBuffer,
-			boost::bind(&EthStratumClient::handleResponse, this,
-			boost::asio::placeholders::error));
-		cnote << "Solution found; Submitted to" << p_active->host;
-		if (m_protocol != STRATUM_PROTOCOL_ETHEREUMSTRATUM) {
-			cnote << "Nonce:" << "0x" + nonceHex;
-		}
-		return true;
-	}
-	else
-	{
-		string json;
-
-		switch (m_protocol) {
+	switch (m_protocol) {
 		case STRATUM_PROTOCOL_STRATUM:
-			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_previous_job + "\",\"0x" + nonceHex + "\",\"0x" + solution.headerHash.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
+			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_job + "\",\"0x" + nonceHex + "\",\"0x" + solution.headerHash.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
 			break;
 		case STRATUM_PROTOCOL_ETHPROXY:
 			json = "{\"id\": 4, \"worker\":\"" + m_worker + "\", \"method\": \"eth_submitWork\", \"params\": [\"0x" + nonceHex + "\",\"0x" + solution.headerHash.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
 			break;
 		case STRATUM_PROTOCOL_ETHEREUMSTRATUM:
-			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_previous_job + "\",\"" + minernonce + "\"]}\n";
+			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_job + "\",\"" + minernonce + "\"]}\n";
 			break;
-		}
-
-		std::ostream os(&m_requestBuffer);
-		os << json;
-		m_stale = true;
-		async_write(m_socket, m_requestBuffer,
-			boost::bind(&EthStratumClient::handleResponse, this,
-			boost::asio::placeholders::error));
-		cwarn << "Submitted stale solution.";
-		return true;
 	}
 
-	return false;
+	std::ostream os(&m_requestBuffer);
+	os << json;
+	m_stale = solution.stale;
+	async_write(m_socket, m_requestBuffer,
+		boost::bind(&EthStratumClient::handleResponse, this,
+		boost::asio::placeholders::error));
+	if (m_stale)
+	{
+		cwarn << "Stale solution found. Submitted to" << p_active->host;
+	}
+	else
+	{
+		cnote << "Solution found; Submitted to" << p_active->host;
+	}
+	if (m_protocol != STRATUM_PROTOCOL_ETHEREUMSTRATUM) {
+		cnote << "Nonce:" << "0x" + nonceHex;
+	}
+	return true;
 }
 

--- a/libstratum/EthStratumClient.cpp
+++ b/libstratum/EthStratumClient.cpp
@@ -399,18 +399,13 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
 
 					if (sHeaderHash != "" && sSeedHash != "")
 					{
-
-						h256 seedHash = h256(sSeedHash);
-
-						m_previousJob = m_job;
-
 						m_current.header = h256(sHeaderHash);
-						m_current.seed = seedHash;
+						m_current.seed = h256(sSeedHash);
 						m_current.boundary = h256();
 						diffToTarget((uint32_t*)m_current.boundary.data(), m_nextWorkDifficulty);
 						m_current.startNonce = ethash_swap_u64(*((uint64_t*)m_extraNonce.data()));
 						m_current.exSizeBits = m_extraNonceHexSize * 4;
-						m_job = job;
+						m_current.job = h256(job);
 
 						p_farm->setWork(m_current);
 						cnote << "Received new job #" + job.substr(0, 8)
@@ -433,28 +428,23 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
 					if (sHeaderHash != "" && sSeedHash != "" && sShareTarget != "")
 					{
 
-						h256 seedHash = h256(sSeedHash);
 						h256 headerHash = h256(sHeaderHash);
 
 						if (headerHash != m_current.header)
 						{
-							//x_current.lock();
 							if (p_worktimer)
 								p_worktimer->cancel();
 
-							m_previousJob = m_job;
-
 							m_current.header = h256(sHeaderHash);
-							m_current.seed = seedHash;
+							m_current.seed = h256(sSeedHash);
 							m_current.boundary = h256(sShareTarget);
-							m_job = job;
+							m_current.job = h256(job);
 
 							p_farm->setWork(m_current);
 							cnote << "Received new job #" + job.substr(0, 8)
 								<< " seed: " << "#" + m_current.seed.hex().substr(0, 32)
 								<< " target: " << "#" + m_current.boundary.hex().substr(0, 24);
 
-							//x_current.unlock();
 							p_worktimer = new boost::asio::deadline_timer(m_io_service, boost::posix_time::seconds(m_worktimeout));
 							p_worktimer->async_wait(boost::bind(&EthStratumClient::work_timeout_handler, this, boost::asio::placeholders::error));
 
@@ -511,13 +501,6 @@ bool EthStratumClient::submitHashrate(string const & rate) {
 }
 
 bool EthStratumClient::submit(Solution solution) {
-	string temp_job;
-	x_current.lock();
-	if (solution.stale)
-		temp_job = m_previousJob;
-	else
-		temp_job = m_job;
-	x_current.unlock();
 
 	string minernonce;
 	string nonceHex = toHex(solution.nonce);
@@ -529,13 +512,13 @@ bool EthStratumClient::submit(Solution solution) {
 
 	switch (m_protocol) {
 		case STRATUM_PROTOCOL_STRATUM:
-			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_job + "\",\"0x" + nonceHex + "\",\"0x" + solution.headerHash.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
+			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + solution.job.hex() + "\",\"0x" + nonceHex + "\",\"0x" + solution.headerHash.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
 			break;
 		case STRATUM_PROTOCOL_ETHPROXY:
 			json = "{\"id\": 4, \"worker\":\"" + m_worker + "\", \"method\": \"eth_submitWork\", \"params\": [\"0x" + nonceHex + "\",\"0x" + solution.headerHash.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
 			break;
 		case STRATUM_PROTOCOL_ETHEREUMSTRATUM:
-			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_job + "\",\"" + minernonce + "\"]}\n";
+			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + solution.job.hex() + "\",\"" + minernonce + "\"]}\n";
 			break;
 	}
 

--- a/libstratum/EthStratumClient.cpp
+++ b/libstratum/EthStratumClient.cpp
@@ -520,8 +520,6 @@ bool EthStratumClient::submitHashrate(string const & rate) {
 
 bool EthStratumClient::submit(Solution solution) {
 	x_current.lock();
-	h256 temp_header = m_current.header;
-	h256 temp_previous_header = m_previous.header;
 	string temp_job = m_job;
 	string temp_previous_job = m_previousJob;
 	x_current.unlock();
@@ -538,10 +536,10 @@ bool EthStratumClient::submit(Solution solution) {
 
 		switch (m_protocol) {
 			case STRATUM_PROTOCOL_STRATUM:
-				json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_job + "\",\"0x" + nonceHex + "\",\"0x" + temp_header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
+				json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_job + "\",\"0x" + nonceHex + "\",\"0x" + solution.headerHash.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
 				break;
 			case STRATUM_PROTOCOL_ETHPROXY:
-				json = "{\"id\": 4, \"worker\":\"" + m_worker + "\", \"method\": \"eth_submitWork\", \"params\": [\"0x" + nonceHex + "\",\"0x" + temp_header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
+				json = "{\"id\": 4, \"worker\":\"" + m_worker + "\", \"method\": \"eth_submitWork\", \"params\": [\"0x" + nonceHex + "\",\"0x" + solution.headerHash.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
 				break;
 			case STRATUM_PROTOCOL_ETHEREUMSTRATUM:
 				json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_job + "\",\"" + minernonce + "\"]}\n";
@@ -566,10 +564,10 @@ bool EthStratumClient::submit(Solution solution) {
 
 		switch (m_protocol) {
 		case STRATUM_PROTOCOL_STRATUM:
-			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_previous_job + "\",\"0x" + nonceHex + "\",\"0x" + temp_previous_header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
+			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_previous_job + "\",\"0x" + nonceHex + "\",\"0x" + solution.headerHash.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
 			break;
 		case STRATUM_PROTOCOL_ETHPROXY:
-			json = "{\"id\": 4, \"worker\":\"" + m_worker + "\", \"method\": \"eth_submitWork\", \"params\": [\"0x" + nonceHex + "\",\"0x" + temp_previous_header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
+			json = "{\"id\": 4, \"worker\":\"" + m_worker + "\", \"method\": \"eth_submitWork\", \"params\": [\"0x" + nonceHex + "\",\"0x" + solution.headerHash.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
 			break;
 		case STRATUM_PROTOCOL_ETHEREUMSTRATUM:
 			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_previous_job + "\",\"" + minernonce + "\"]}\n";

--- a/libstratum/EthStratumClient.cpp
+++ b/libstratum/EthStratumClient.cpp
@@ -402,11 +402,6 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
 
 						h256 seedHash = h256(sSeedHash);
 
-						m_previous.header = m_current.header;
-						m_previous.seed = m_current.seed;
-						m_previous.boundary = m_current.boundary;
-						m_previous.startNonce = m_current.startNonce;
-						m_previous.exSizeBits = m_previous.exSizeBits;
 						m_previousJob = m_job;
 
 						m_current.header = h256(sHeaderHash);
@@ -447,9 +442,6 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
 							if (p_worktimer)
 								p_worktimer->cancel();
 
-							m_previous.header = m_current.header;
-							m_previous.seed = m_current.seed;
-							m_previous.boundary = m_current.boundary;
 							m_previousJob = m_job;
 
 							m_current.header = h256(sHeaderHash);

--- a/libstratum/EthStratumClient.h
+++ b/libstratum/EthStratumClient.h
@@ -67,7 +67,6 @@ private:
 	Farm* p_farm;
 	std::mutex x_current;
 	WorkPackage m_current;
-	WorkPackage m_previous;
 
 	bool m_stale = false;
 

--- a/libstratum/EthStratumClient.h
+++ b/libstratum/EthStratumClient.h
@@ -65,13 +65,9 @@ private:
 	int m_pending;
 
 	Farm* p_farm;
-	std::mutex x_current;
 	WorkPackage m_current;
 
 	bool m_stale = false;
-
-	string m_job;
-	string m_previousJob;
 
 	std::thread m_serviceThread;  ///< The IO service thread.
 	boost::asio::io_service m_io_service;

--- a/libstratum/EthStratumClientV2.cpp
+++ b/libstratum/EthStratumClientV2.cpp
@@ -472,7 +472,7 @@ bool EthStratumClientV2::submit(Solution solution) {
 		minernonce = nonceHex.substr(m_extraNonceHexSize, 16 - m_extraNonceHexSize);
 	}
 
-	if (~solution.stale)
+	if (!solution.stale)
 	{
 		string json;
 		switch (m_protocol) {

--- a/libstratum/EthStratumClientV2.cpp
+++ b/libstratum/EthStratumClientV2.cpp
@@ -346,11 +346,6 @@ void EthStratumClientV2::processReponse(Json::Value& responseObject)
 					{
 						h256 seedHash = h256(sSeedHash);
 
-						m_previous.header = m_current.header;
-						m_previous.seed = m_current.seed;
-						m_previous.boundary = m_current.boundary;
-						m_previous.startNonce = m_current.startNonce;
-						m_previous.exSizeBits = m_previous.exSizeBits;
 						m_previousJob = m_job;
 
 						m_current.header = h256(sHeaderHash);
@@ -391,9 +386,6 @@ void EthStratumClientV2::processReponse(Json::Value& responseObject)
 							//if (p_worktimer)
 							//	p_worktimer->cancel();
 
-							m_previous.header = m_current.header;
-							m_previous.seed = m_current.seed;
-							m_previous.boundary = m_current.boundary;
 							m_previousJob = m_job;
 
 							m_current.header = h256(sHeaderHash);
@@ -460,8 +452,6 @@ bool EthStratumClientV2::submitHashrate(string const & rate) {
 
 bool EthStratumClientV2::submit(Solution solution) {
 	x_current.lock();
-	h256 temp_header = m_current.header;
-	h256 temp_previous_header = m_previous.header;
 	string temp_job = m_job;
 	string temp_previous_job = m_previousJob;
 	x_current.unlock();
@@ -477,10 +467,10 @@ bool EthStratumClientV2::submit(Solution solution) {
 		string json;
 		switch (m_protocol) {
 		case STRATUM_PROTOCOL_STRATUM:
-			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_job + "\",\"0x" + nonceHex + "\",\"0x" + temp_header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
+			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_job + "\",\"0x" + nonceHex + "\",\"0x" + solution.headerHash.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
 			break;
 		case STRATUM_PROTOCOL_ETHPROXY:
-			json = "{\"id\": 4, \"worker\":\"" + m_worker + "\", \"method\": \"eth_submitWork\", \"params\": [\"0x" + nonceHex + "\",\"0x" + temp_header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
+			json = "{\"id\": 4, \"worker\":\"" + m_worker + "\", \"method\": \"eth_submitWork\", \"params\": [\"0x" + nonceHex + "\",\"0x" + solution.headerHash.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
 			break;
 		case STRATUM_PROTOCOL_ETHEREUMSTRATUM:
 			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_job + "\",\"" + minernonce + "\"]}\n";
@@ -501,10 +491,10 @@ bool EthStratumClientV2::submit(Solution solution) {
 		string json;
 		switch (m_protocol) {
 		case STRATUM_PROTOCOL_STRATUM:
-			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_previous_job + "\",\"0x" + nonceHex + "\",\"0x" + temp_previous_header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
+			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_previous_job + "\",\"0x" + nonceHex + "\",\"0x" + solution.headerHash.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
 			break;
 		case STRATUM_PROTOCOL_ETHPROXY:
-			json = "{\"id\": 4, \"worker\":\"" + m_worker + "\", \"method\": \"eth_submitWork\", \"params\": [\"0x" + nonceHex + "\",\"0x" + temp_previous_header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
+			json = "{\"id\": 4, \"worker\":\"" + m_worker + "\", \"method\": \"eth_submitWork\", \"params\": [\"0x" + nonceHex + "\",\"0x" + solution.headerHash.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
 			break;
 		case STRATUM_PROTOCOL_ETHEREUMSTRATUM:
 			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_previous_job + "\",\"" + minernonce + "\"]}\n";

--- a/libstratum/EthStratumClientV2.cpp
+++ b/libstratum/EthStratumClientV2.cpp
@@ -460,9 +460,9 @@ bool EthStratumClientV2::submitHashrate(string const & rate) {
 
 bool EthStratumClientV2::submit(Solution solution) {
 	x_current.lock();
-	WorkPackage tempWork(m_current);
+	h256 temp_header = m_current.header;
+	h256 temp_previous_header = m_previous.header;
 	string temp_job = m_job;
-	WorkPackage tempPreviousWork(m_previous);
 	string temp_previous_job = m_previousJob;
 	x_current.unlock();
 
@@ -472,15 +472,15 @@ bool EthStratumClientV2::submit(Solution solution) {
 		minernonce = nonceHex.substr(m_extraNonceHexSize, 16 - m_extraNonceHexSize);
 	}
 
-	if (EthashAux::eval(tempWork.seed, tempWork.header, solution.nonce).value < tempWork.boundary)
+	if (~solution.stale)
 	{
 		string json;
 		switch (m_protocol) {
 		case STRATUM_PROTOCOL_STRATUM:
-			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_job + "\",\"0x" + nonceHex + "\",\"0x" + tempWork.header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
+			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_job + "\",\"0x" + nonceHex + "\",\"0x" + temp_header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
 			break;
 		case STRATUM_PROTOCOL_ETHPROXY:
-			json = "{\"id\": 4, \"worker\":\"" + m_worker + "\", \"method\": \"eth_submitWork\", \"params\": [\"0x" + nonceHex + "\",\"0x" + tempWork.header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
+			json = "{\"id\": 4, \"worker\":\"" + m_worker + "\", \"method\": \"eth_submitWork\", \"params\": [\"0x" + nonceHex + "\",\"0x" + temp_header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
 			break;
 		case STRATUM_PROTOCOL_ETHEREUMSTRATUM:
 			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_job + "\",\"" + minernonce + "\"]}\n";
@@ -496,15 +496,15 @@ bool EthStratumClientV2::submit(Solution solution) {
 		}
 		return true;
 	}
-	else if (EthashAux::eval(tempPreviousWork.seed, tempPreviousWork.header, solution.nonce).value < tempPreviousWork.boundary)
+	else
 	{
 		string json;
 		switch (m_protocol) {
 		case STRATUM_PROTOCOL_STRATUM:
-			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_previous_job + "\",\"0x" + nonceHex + "\",\"0x" + tempPreviousWork.header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
+			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_previous_job + "\",\"0x" + nonceHex + "\",\"0x" + temp_previous_header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
 			break;
 		case STRATUM_PROTOCOL_ETHPROXY:
-			json = "{\"id\": 4, \"worker\":\"" + m_worker + "\", \"method\": \"eth_submitWork\", \"params\": [\"0x" + nonceHex + "\",\"0x" + tempPreviousWork.header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
+			json = "{\"id\": 4, \"worker\":\"" + m_worker + "\", \"method\": \"eth_submitWork\", \"params\": [\"0x" + nonceHex + "\",\"0x" + temp_previous_header.hex() + "\",\"0x" + solution.mixHash.hex() + "\"]}\n";
 			break;
 		case STRATUM_PROTOCOL_ETHEREUMSTRATUM:
 			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" + p_active->user + "\",\"" + temp_previous_job + "\",\"" + minernonce + "\"]}\n";
@@ -515,11 +515,6 @@ bool EthStratumClientV2::submit(Solution solution) {
 		write(m_socket, m_requestBuffer);
 		cwarn << "Submitted stale solution.";
 		return true;
-	}
-	else {
-		m_stale = false;
-		cwarn << "FAILURE: GPU gave incorrect result!";
-		p_farm->failedSolution();
 	}
 
 	return false;

--- a/libstratum/EthStratumClientV2.h
+++ b/libstratum/EthStratumClientV2.h
@@ -66,7 +66,6 @@ private:
 	Farm* p_farm;
 	mutex x_current;
 	WorkPackage m_current;
-	WorkPackage m_previous;
 
 	bool m_stale = false;
 

--- a/libstratum/EthStratumClientV2.h
+++ b/libstratum/EthStratumClientV2.h
@@ -64,13 +64,9 @@ private:
 	string m_response;
 
 	Farm* p_farm;
-	mutex x_current;
 	WorkPackage m_current;
 
 	bool m_stale = false;
-
-	string m_job;
-	string m_previousJob;
 
 	boost::asio::io_service m_io_service;
 	boost::asio::ip::tcp::socket m_socket;


### PR DESCRIPTION
This accomplishes the initial goal of eliminating the double
evaluation of solutions as well as supports the virtually
impossible case of a single thread grid finding more than one
solution. The goal this time around was not to monkey with
the thread model. This doesn't alter or resequence any software
locks. I'd bet that if this one locks up, then the master
code probably does as well!

As it turns out the low level C++ GPU result handler knows
when it's sending invalid solutions up the stack. It just
had no way of telling stratum about it. It seems that is
the whole reason a copy of the previous job is held and the
rechecking of the solution was done in submit. Someone
figured where these rare apparent invalids were coming from
and added a re-evaluation in submit, if that passed the share
is submitted normally, otherwise a second re-evaluation is
done againd the previous job. If that passes it is submitted
knowingly as a stale share! Expedient but inefficient at the
worst time.

The calculation of a light hash in the re-evaluation is
compute intensive and delays the sending of the share to the
pool. Not sure why you'd knowingly submit a stale share, but
there it is.

In order to keep the model as intact as possible, we simply
add a bool to the solution tuple that will hold the stale
status. It can then be conveniently passed up to stratum.
The submit method will no longer need to recheck the solution
to determine whether its for the current or last job. To keep
tings as close to the way they were, submit still sends stale
shares.

As it turns out this results in a cleaner design.
  