### PR TITLE
Check whether the device has enough RAM whenever we create the DAG

### DIFF
--- a/libethash-cuda/ethash_cuda_miner.cpp
+++ b/libethash-cuda/ethash_cuda_miner.cpp
@@ -232,6 +232,12 @@ bool ethash_cuda_miner::init(ethash_light_t _light, uint8_t const* _lightData, u
 		cudalog << "Set Device to current";
 		if(dagSize128 != m_dag_size || !m_dag)
 		{
+			//Check whether the current device has sufficient memory everytime we recreate the dag
+			if (device_props.totalGlobalMem < dagSize)
+			{
+				cudalog <<  "CUDA device " << string(device_props.name) << " has insufficient GPU memory." << device_props.totalGlobalMem << " bytes of memory found < " << dagSize << " bytes of memory required";
+				return false;
+			}
 			//We need to reset the device and recreate the dag  
 			cudalog << "Resetting device";
 			CUDA_SAFE_CALL(cudaDeviceReset());


### PR DESCRIPTION
Many of the current open issues are from people, that don't understand that you can't mine ethereum with a GPU with less than 3GB RAM
https://github.com/ethereum-mining/ethminer/issues/449