### PR TITLE
Fix race condition in CLMiner::init through mutex

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -531,9 +531,10 @@ HwMonitor CLMiner::hwmon()
 	return hw;
 }
 
-
+std::mutex CLMiner::initMtx;
 bool CLMiner::init(const h256& seed)
 {
+	std::lock_guard<std::mutex> initLock(initMtx);
 	EthashAux::LightType light = EthashAux::light(seed);
 
 	// get all platforms

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -531,10 +531,11 @@ HwMonitor CLMiner::hwmon()
 	return hw;
 }
 
-std::mutex CLMiner::initMtx;
 bool CLMiner::init(const h256& seed)
 {
-	std::lock_guard<std::mutex> initLock(initMtx);
+	static std::mutex mtx;
+	std::lock_guard<std::mutex> initLock(mtx);
+
 	EthashAux::LightType light = EthashAux::light(seed);
 
 	// get all platforms

--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -83,7 +83,6 @@ private:
 	void report(uint64_t _nonce, WorkPackage const& _w);
 
 	bool init(const h256& seed);
-	static std::mutex initMtx;
 
 	cl::Context m_context;
 	cl::CommandQueue m_queue;

--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -83,6 +83,7 @@ private:
 	void report(uint64_t _nonce, WorkPackage const& _w);
 
 	bool init(const h256& seed);
+	static std::mutex initMtx;
 
 	cl::Context m_context;
 	cl::CommandQueue m_queue;


### PR DESCRIPTION
Instances of CLMiner are started concurrently. Apparently, CLMiner::init
has a race condition and should not run concurrently. A static mutex is
added to prevent this race condition.

This problem exists for me since a long time. With the latest stable release - 1.2 i think - i had the issue as well but it didnt occur always so i could work around it by trial and error, sometimes ethminer would not crash on startup. With recent code changes, it became worse and it almost always crashed.
These problems disappeared after this fix. I only tested it on Win10.
I am using 2x RX 480.

Side note: it could be cleaner to move things which should only be done once from init() to maybe the constructor, or some public method which should be called from outside once - the caller is then responsible to not do it concurrently. However, i guess this fix is fine as well. 

I think this relates to #477 and maybe #234
  