### PR TITLE
libethash-cl: restore Mesa/Clover support in unstable kernel

### DIFF
--- a/libethash-cl/CLMiner_kernel_unstable.cl
+++ b/libethash-cl/CLMiner_kernel_unstable.cl
@@ -36,6 +36,10 @@
 #endif
 #define HASHES_PER_LOOP (GROUP_SIZE / THREADS_PER_HASH)
 
+#ifdef cl_clang_storage_class_specifiers
+    #pragma OPENCL EXTENSION cl_clang_storage_class_specifiers : enable
+#endif
+
 // Check for valid THREADS_PER_HASH param
 #if THREADS_PER_HASH == 1
     #define LN_THREAD_PER_HASH  0


### PR DESCRIPTION
The Mesa/Clover support has been broken in commit b1a152b2045139a052e5c3e643a72c9f05e91bae / #294

This commit reverts the removed Clover lines before the above commit.

Fixes #444, #443