### PR TITLE
CUDA: Display PCI information in --list-devices.

### DIFF
--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -201,14 +201,23 @@ void CUDAMiner::listDevices()
 	{
 		string outString = "\nListing CUDA devices.\nFORMAT: [deviceID] deviceName\n";
 		int numDevices = getNumDevices();
+		char pciIdBuff[8 + 1 + 8 + 1 + 8 + 1]; /* int can need max 8 characters in hexnotation */
+
 		for (int i = 0; i < numDevices; ++i)
 		{
+			string bpciIdBuff_s;
 			cudaDeviceProp props;
+			
 			CUDA_SAFE_CALL(cudaGetDeviceProperties(&props, i));
+
+			sprintf(pciIdBuff, "%04x:%02x:%02x",
+			        props.pciDomainID, props.pciBusID, props.pciDeviceID);
+			bpciIdBuff_s = pciIdBuff;
 
 			outString += "[" + to_string(i) + "] " + string(props.name) + "\n";
 			outString += "\tCompute version: " + to_string(props.major) + "." + to_string(props.minor) + "\n";
 			outString += "\tcudaDeviceProp::totalGlobalMem: " + to_string(props.totalGlobalMem) + "\n";
+			outString += "\tPCI: " + bpciIdBuff_s + "\n";
 		}
 		std::cout << outString;
 	}


### PR DESCRIPTION
etheminer and nvidia-smi uses different ids for GPU indexing.
It seems nvidia-smi enumerates the devices based on the PCI address.

When using "--cuda-devices-enum pci" the displayed gpu id in
ethminer matches those used in nvidia-smi.
So its easier to adjust settings (overclock/power) using nvidia-smi
with the same id reported in ethminer.

I already created a pull request (#492) but due my mistake while reworking I deleted the branch and the pull request was closed. (Sorry for that)
  