### PR TITLE
Fix scrambed console out put

### DIFF
--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -25,7 +25,7 @@
 #ifdef __APPLE__
 #include <pthread.h>
 #endif
-#include "Guards.h"
+#include <mutex>
 using namespace std;
 using namespace dev;
 
@@ -33,7 +33,7 @@ using namespace dev;
 
 // Logging
 int dev::g_logVerbosity = 5;
-mutex x_logOverride;
+static mutex x_logOverride;
 
 /// Map of Log Channel types to bool, false forces the channel to be disabled, true forces it to be enabled.
 /// If a channel has no entry, then it will output as long as its verbosity (LogChannel::verbosity) is less than
@@ -60,7 +60,7 @@ LogOutputStreamBase::LogOutputStreamBase(char const* _id, std::type_info const* 
 	m_autospacing(_autospacing),
 	m_verbosity(_v)
 {
-	Guard l(x_logOverride);
+	x_logOverride.lock();
 	auto it = s_logOverride.find(_info);
 	if ((it != s_logOverride.end() && it->second) || (it == s_logOverride.end() && (int)_v <= g_logVerbosity))
 	{
@@ -74,6 +74,11 @@ LogOutputStreamBase::LogOutputStreamBase(char const* _id, std::type_info const* 
 		static char const* c_end = EthReset "  ";
 		m_sstr << _id << c_begin << buf << c_sep1 << std::left << std::setw(8) << getThreadName() << ThreadContext::join(c_sep2) << c_end;
 	}
+}
+
+LogOutputStreamBase::~LogOutputStreamBase()
+{
+	x_logOverride.unlock();
 }
 
 /// Associate a name with each thread for nice logging.

--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -33,7 +33,7 @@ using namespace dev;
 
 // Logging
 int dev::g_logVerbosity = 5;
-static mutex x_logOverride;
+static mutex x_logGuard;
 
 /// Map of Log Channel types to bool, false forces the channel to be disabled, true forces it to be enabled.
 /// If a channel has no entry, then it will output as long as its verbosity (LogChannel::verbosity) is less than
@@ -60,7 +60,7 @@ LogOutputStreamBase::LogOutputStreamBase(char const* _id, std::type_info const* 
 	m_autospacing(_autospacing),
 	m_verbosity(_v)
 {
-	x_logOverride.lock();
+	x_logGuard.lock();
 	auto it = s_logOverride.find(_info);
 	if ((it != s_logOverride.end() && it->second) || (it == s_logOverride.end() && (int)_v <= g_logVerbosity))
 	{
@@ -78,7 +78,7 @@ LogOutputStreamBase::LogOutputStreamBase(char const* _id, std::type_info const* 
 
 LogOutputStreamBase::~LogOutputStreamBase()
 {
-	x_logOverride.unlock();
+	x_logGuard.unlock();
 }
 
 /// Associate a name with each thread for nice logging.

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -87,6 +87,7 @@ class LogOutputStreamBase
 {
 public:
 	LogOutputStreamBase(char const* _id, std::type_info const* _info, unsigned _v, bool _autospacing);
+	virtual ~LogOutputStreamBase();
 
 	void comment(std::string const& _t)
 	{


### PR DESCRIPTION
Console out put formatting is protected from reentrant though I'm
not sure it needs to be? C++ 11 states that iostreams are thread
safe but they do not guarantee that the stream data won't be
intertwined.

Include the call to iostream cerr within the guard. This should
clear up the occasionally mangled console output that often
manifests as 2 lines concatenated to a single folled by a blank
line.