### PR TITLE
Strip unused (dead) code and data sections

### DIFF
--- a/cmake/EthCheckCXXFlags.cmake
+++ b/cmake/EthCheckCXXFlags.cmake
@@ -1,0 +1,45 @@
+include(CheckCXXCompilerFlag)
+
+# Adds CXX compiler flag if the flag is supported by the compiler.
+#
+# This is effectively a combination of CMake's check_cxx_compiler_flag()
+# and add_compile_options():
+#
+#    if(check_cxx_compiler_flag(flag))
+#        add_compile_options(flag)
+#
+function(eth_add_cxx_compiler_flag_if_supported FLAG)
+  # Remove leading - or / from the flag name.
+  string(REGEX REPLACE "^-|/" "" name ${FLAG})
+  check_cxx_compiler_flag(${FLAG} ${name})
+  if(${name})
+    add_compile_options(${FLAG})
+  endif()
+  # If the optional argument passed, store the result there.
+  if(ARGV1)
+    set(${ARGV1} ${name} PARENT_SCOPE)
+  endif()
+endfunction()
+
+# Adds CXX linker flag if the flag is supported by the linker.
+#
+# This is effectively a combination of CMake's check_cxx_compiler_flag()
+# which runs a test compile and link, with an update of the 
+# CMAKE_CXX_LINK_FLAGS which is passed to the CXX driver for
+# the link phase.
+#
+#    if(check_cxx_compiler_flag(flag))
+#        CMAKE_CXX_LINK_FLAGS += flag
+#
+function(eth_add_cxx_linker_flag_if_supported FLAG)
+  # Remove leading - or / from the flag name.
+  string(REGEX REPLACE "^-|/" "" name ${FLAG})
+  check_cxx_compiler_flag(${FLAG} ${name})
+  if(${name})
+    set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} ${FLAG}")
+  endif()
+  # If the optional argument passed, store the result there.
+  if(ARGV1)
+    set(${ARGV1} ${name} PARENT_SCOPE)
+  endif()
+endfunction()

--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -1,13 +1,23 @@
 # Set necessary compile and link flags
 
+include(EthCheckCXXFlags)
+
 # C++11 check and activation
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unknown-pragmas -Wextra -Wno-error=parentheses -pedantic")
 
+    eth_add_cxx_compiler_flag_if_supported(-ffunction-sections)
+    eth_add_cxx_compiler_flag_if_supported(-fdata-sections)
+    eth_add_cxx_linker_flag_if_supported(-Wl,--gc-sections)
+
 elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unknown-pragmas -Wextra")
+
+    eth_add_cxx_compiler_flag_if_supported(-ffunction-sections)
+    eth_add_cxx_compiler_flag_if_supported(-fdata-sections)
+    eth_add_cxx_linker_flag_if_supported(-Wl,--gc-sections)
 
 	if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++ -fcolor-diagnostics -Qunused-arguments")


### PR DESCRIPTION
Under gcc enable dead code and data stripping.
Removes about 20K from executable. Not much, but
its free.

I believe clang supports these flags as well.