### PR TITLE
Prevent concatenated console lines

### DIFF
--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -153,8 +153,7 @@ void dev::setThreadName(char const* _n)
 #endif
 }
 
-void dev::simpleDebugOut(std::string _s)
+void dev::simpleDebugOut(std::string const& _s)
 {
-        _s.push_back('\n');
-        std::cerr << _s;
+        std::cerr << _s + '\n';
 }

--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -155,5 +155,7 @@ void dev::setThreadName(char const* _n)
 
 void dev::simpleDebugOut(std::string const& _s)
 {
-	std::cerr << _s << '\n';
+        string s = _s;
+        s.push_back('\n');
+        std::cerr << s;
 }

--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -153,9 +153,8 @@ void dev::setThreadName(char const* _n)
 #endif
 }
 
-void dev::simpleDebugOut(std::string const& _s)
+void dev::simpleDebugOut(std::string _s)
 {
-        string s = _s;
-        s.push_back('\n');
-        std::cerr << s;
+        _s.push_back('\n');
+        std::cerr << _s;
 }

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -44,7 +44,7 @@ public:
 };
 
 /// A simple log-output function that prints log messages to stdout.
-void simpleDebugOut(std::string const&);
+void simpleDebugOut(std::string);
 
 /// The logging system's current verbosity.
 extern int g_logVerbosity;

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -44,7 +44,7 @@ public:
 };
 
 /// A simple log-output function that prints log messages to stdout.
-void simpleDebugOut(std::string);
+void simpleDebugOut(std::string const&);
 
 /// The logging system's current verbosity.
 extern int g_logVerbosity;


### PR DESCRIPTION
Create a copy of the constant parameter, append a new-line, send it with single << operator