### PR TITLE
Halve the nvidia farm switch time.

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -403,8 +403,9 @@ void CLMiner::workLoop()
 	}
 }
 
-void CLMiner::pause()
-{}
+void CLMiner::pause() {}
+
+void CLMiner::waitPaused() {}
 
 unsigned CLMiner::getNumDevices()
 {

--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -86,6 +86,7 @@ public:
 protected:
 	void kickOff() override;
 	void pause() override;
+	void waitPaused() override;
 
 private:
 	void workLoop() override;

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -41,6 +41,10 @@ namespace eth
 
 				m_abort = true;
 			}
+                }
+
+                void wait()
+                {
 			// m_abort is true so now searched()/found() will return true to abort the search.
 			// we hang around on this thread waiting for them to point out that they have aborted since
 			// otherwise we may end up deleting this object prior to searched()/found() being called.
@@ -207,6 +211,11 @@ void CUDAMiner::workLoop()
 void CUDAMiner::pause()
 {
 	m_hook->abort();
+}
+
+void CUDAMiner::waitPaused()
+{
+	m_hook->wait();
 }
 
 unsigned CUDAMiner::getNumDevices()

--- a/libethash-cuda/CUDAMiner.h
+++ b/libethash-cuda/CUDAMiner.h
@@ -72,6 +72,7 @@ class EthashCUDAHook;
 	protected:
 		void kickOff() override;
 		void pause() override;
+		void waitPaused() override;
 	private:
 		void workLoop() override;
 		void report(uint64_t _nonce);

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -72,6 +72,8 @@ public:
 		m_work = _wp;
 		for (auto const& m: m_miners)
 			m->setWork(m_work);
+		for (auto const& m: m_miners)
+			m->startWork();
 	}
 
 	void setSealers(std::map<std::string, SealerDescriptor> const& _sealers) { m_sealers = _sealers; }

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -181,6 +181,11 @@ public:
 			workSwitchStart = std::chrono::high_resolution_clock::now();
 		}
 		pause();
+	}
+
+	void startWork()
+	{
+		waitPaused();
 		kickOff();
 		m_hashCount = 0;
 	}
@@ -203,6 +208,7 @@ protected:
 	 * @brief No work left to be done. Pause until told to kickOff().
 	 */
 	virtual void pause() = 0;
+	virtual void waitPaused() = 0;
 
 	WorkPackage work() const { Guard l(x_work); return m_work; }
 


### PR DESCRIPTION
When it gets new work the farm calls setWork for each
GPU’s miners.

For an nvidia GPU miner, setWork:

- Sets a flag for the miner to stop. The miner will not
  acknowledge this flag till it completes its current
  calculation pass, on average half of one hash
  calculation’s time.

- Wait for the miner to stop (blocks).

- Reset the miner with new work.

This has performance and cost consequences. Since the
farm calls setWork sequentially over all miners, a miner
will not be stopped and informed of new work, till the
previous has completed the reset. It also means that
because of this, the laer a miner restarts the more
likely to provide a stale share working on old work
instead of getting started new work.

To mittigate this we break up the setWork process in
two parts: setWork and waitReady.

setWork

- Sets a flag for the miner to stop.

waitReady

- Wait for the miner to stop (blocks).

- Reset the miner with new work.

With this partitioning we can now restart the GPUs in
parallel by first iterating over miners with setWork
(which can’t block), then doing a second pass calling
waitReady.

Actual measuments - Ubuntu - 4X1060 - time from start
of farm setWork to completion of last GPU reset):

- Sequential GPU resets – avg. farm setWork time 180-200ms.
  (yes, it’s that slow!!!)

- Parallel GPU resets – avg. farm setWork time 70-90ms.

These are averages since, at least for nvidia, switch
time is highly dependent on when new work arrives during
a hash calculation, so it fluctuates a lot per job.