### PR TITLE
Get rid of failed shares... again!

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -306,7 +306,7 @@ void CLMiner::workLoop()
 	try {
 		while (true)
 		{
-			const WorkPackage w = work();
+			const WorkPackage w = getWork();
 
 			if (current.header != w.header)
 			{

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -269,6 +269,7 @@ void CLMiner::report(uint64_t _nonce, WorkPackage const& _w)
 {
 	assert(_nonce != 0);
 	// TODO: Why re-evaluating?
+        // Answer: To calculate the mix hash
 	Result r = EthashAux::eval(_w.seed, _w.header, _nonce);
 	if (r.value < _w.boundary)
 		farm.submitProof(Solution{_nonce, r.mixHash, _w.header, _w.seed, _w.boundary, _w.job, false});
@@ -305,7 +306,7 @@ void CLMiner::workLoop()
 	try {
 		while (true)
 		{
-			const WorkPackage w = work();
+			const WorkPackage w = getWork();
 
 			if (current.header != w.header)
 			{

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -306,7 +306,7 @@ void CLMiner::workLoop()
 	try {
 		while (true)
 		{
-			const WorkPackage w = getWork();
+			const WorkPackage w = work();
 
 			if (current.header != w.header)
 			{

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -170,7 +170,7 @@ void CUDAMiner::workLoop()
 	{
 		while(true)
 		{
-			const WorkPackage w = work();
+			const WorkPackage w = getWork();
 			
 			if (current.header != w.header || current.seed != w.seed)
 			{

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -109,7 +109,7 @@ CUDAMiner::~CUDAMiner()
 void CUDAMiner::report(uint64_t _nonce)
 {
 	// FIXME: This code is exactly the same as in EthashGPUMiner.
-	WorkPackage &w = work();  // No need to copy, use reference.
+	WorkPackage w = work();  // Copy work package to avoid repeated mutex lock.
 	Result r = EthashAux::eval(w.seed, w.header, _nonce);
 	if (r.value < w.boundary)
 		farm.submitProof(Solution{_nonce, r.mixHash, w.header, w.seed, w.boundary, w.job, m_hook->isStale()});
@@ -170,7 +170,7 @@ void CUDAMiner::workLoop()
 	{
 		while(true)
 		{
-			const WorkPackage w = work();
+			const WorkPackage w = getWork();
 			
 			if (current.header != w.header || current.seed != w.seed)
 			{

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -109,7 +109,7 @@ CUDAMiner::~CUDAMiner()
 void CUDAMiner::report(uint64_t _nonce)
 {
 	// FIXME: This code is exactly the same as in EthashGPUMiner.
-	WorkPackage w = work();  // Copy work package to avoid repeated mutex lock.
+	WorkPackage &w = work();  // No need to copy, use reference.
 	Result r = EthashAux::eval(w.seed, w.header, _nonce);
 	if (r.value < w.boundary)
 		farm.submitProof(Solution{_nonce, r.mixHash, w.header, w.seed, w.boundary, w.job, m_hook->isStale()});
@@ -170,7 +170,7 @@ void CUDAMiner::workLoop()
 	{
 		while(true)
 		{
-			const WorkPackage w = getWork();
+			const WorkPackage w = work();
 			
 			if (current.header != w.header || current.seed != w.seed)
 			{

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -288,8 +288,6 @@ public:
 	void onSolutionFound(SolutionFound const& _handler) { m_onSolutionFound = _handler; }
 	void onMinerRestart(MinerRestart const& _handler) { m_onMinerRestart = _handler; }
 
-	WorkPackage work() const { Guard l(x_minerWork); return m_work; }
-
 	std::chrono::steady_clock::time_point farmLaunched() {
 		return m_farm_launched;
 	}

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -175,8 +175,12 @@ public:
 
 	void setWork(WorkPackage const& _work)
 	{
-		m_work = _work;
-		workSwitchStart = std::chrono::high_resolution_clock::now();
+		{
+			Guard l(x_work);
+			m_nextwork = _work;
+                        m_newwork = true;
+			workSwitchStart = std::chrono::high_resolution_clock::now();
+		}
 		pause();
 	}
 
@@ -207,8 +211,17 @@ protected:
 	virtual void pause() = 0;
 	virtual void waitPaused() = 0;
 
-	WorkPackage work() const { return m_work; }
-	WorkPackage &work() { return m_work; }
+	WorkPackage work() const { Guard l(x_work); return m_work; }
+	WorkPackage getWork()
+        {
+                Guard l(x_work);
+                if (m_newwork)
+                {
+                        m_newwork = false;
+                        m_work = m_nextwork;
+                }
+                return m_work;
+        }
 
 	void addHashCount(uint64_t _n) { m_hashCount += _n; }
 
@@ -225,6 +238,10 @@ private:
 	uint64_t m_hashCount = 0;
 
 	WorkPackage m_work;
+	WorkPackage m_nextwork;
+        bool m_newwork = false;
+
+	mutable Mutex x_work;
 };
 
 }

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -177,7 +177,8 @@ public:
 	{
 		{
 			Guard l(x_work);
-			m_work = _work;
+			m_nextwork = _work;
+                        m_newwork = true;
 			workSwitchStart = std::chrono::high_resolution_clock::now();
 		}
 		pause();
@@ -211,6 +212,16 @@ protected:
 	virtual void waitPaused() = 0;
 
 	WorkPackage work() const { Guard l(x_work); return m_work; }
+	WorkPackage getWork()
+        {
+                Guard l(x_work);
+                if (m_newwork)
+                {
+                        m_newwork = false;
+                        m_work = m_nextwork;
+                }
+                return m_work;
+        }
 
 	void addHashCount(uint64_t _n) { m_hashCount += _n; }
 
@@ -227,6 +238,9 @@ private:
 	uint64_t m_hashCount = 0;
 
 	WorkPackage m_work;
+	WorkPackage m_nextwork;
+        bool m_newwork = false;
+
 	mutable Mutex x_work;
 };
 

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -175,12 +175,8 @@ public:
 
 	void setWork(WorkPackage const& _work)
 	{
-		{
-			Guard l(x_work);
-			m_nextwork = _work;
-                        m_newwork = true;
-			workSwitchStart = std::chrono::high_resolution_clock::now();
-		}
+		m_work = _work;
+		workSwitchStart = std::chrono::high_resolution_clock::now();
 		pause();
 	}
 
@@ -211,17 +207,8 @@ protected:
 	virtual void pause() = 0;
 	virtual void waitPaused() = 0;
 
-	WorkPackage work() const { Guard l(x_work); return m_work; }
-	WorkPackage getWork()
-        {
-                Guard l(x_work);
-                if (m_newwork)
-                {
-                        m_newwork = false;
-                        m_work = m_nextwork;
-                }
-                return m_work;
-        }
+	WorkPackage work() const { return m_work; }
+	WorkPackage &work() { return m_work; }
 
 	void addHashCount(uint64_t _n) { m_hashCount += _n; }
 
@@ -238,10 +225,6 @@ private:
 	uint64_t m_hashCount = 0;
 
 	WorkPackage m_work;
-	WorkPackage m_nextwork;
-        bool m_newwork = false;
-
-	mutable Mutex x_work;
 };
 
 }


### PR DESCRIPTION
What causes failed shares in the cuda miner? They
occur when the miner's work package changes between
the time it is 1st obtained at the top of its workloop,
and the time when it is used again to verify the a solution.

Make sure that doesn't happen by only getting new
work at the top of the work loop as is the case in
CLMiner.