### PR TITLE
CUDAMiner: Pass work package to report()

### DIFF
--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -64,10 +64,10 @@ namespace eth
 
 
 	protected:
-		void found(uint64_t const* _nonces, uint32_t count) override
+		void found(uint64_t const* _nonces, uint32_t count, const WorkPackage& w) override
 		{
 			for (uint32_t i = 0; i < count; i++)
-				m_owner.report(_nonces[i]);
+				m_owner.report(_nonces[i], w);
 		}
 
 		void searched(uint32_t _count) override
@@ -106,10 +106,9 @@ CUDAMiner::~CUDAMiner()
 	delete m_hook;
 }
 
-void CUDAMiner::report(uint64_t _nonce)
+void CUDAMiner::report(uint64_t _nonce, const WorkPackage& w)
 {
 	// FIXME: This code is exactly the same as in EthashGPUMiner.
-	WorkPackage w = work();  // Copy work package to avoid repeated mutex lock.
 	Result r = EthashAux::eval(w.seed, w.header, _nonce);
 	if (r.value < w.boundary)
 		farm.submitProof(Solution{_nonce, r.mixHash, w.header, w.seed, w.boundary, w.job, m_hook->isStale()});
@@ -117,7 +116,6 @@ void CUDAMiner::report(uint64_t _nonce)
 	{
 		farm.failedSolution();
 		cwarn << "FAILURE: GPU gave incorrect result!";
-
 	}
 }
 
@@ -193,7 +191,7 @@ void CUDAMiner::workLoop()
 			uint64_t startN = current.startNonce;
 			if (current.exSizeBits >= 0) 
 				startN = current.startNonce | ((uint64_t)index << (64 - 4 - current.exSizeBits)); // this can support up to 16 devices
-			m_miner.search(current.header.data(), upper64OfBoundary, *m_hook, (current.exSizeBits >= 0), startN);
+			m_miner.search(current.header.data(), upper64OfBoundary, *m_hook, (current.exSizeBits >= 0), startN, w);
 
 			// Check if we should stop.
 			if (shouldStop())

--- a/libethash-cuda/CUDAMiner.h
+++ b/libethash-cuda/CUDAMiner.h
@@ -75,7 +75,7 @@ class EthashCUDAHook;
 		void waitPaused() override;
 	private:
 		void workLoop() override;
-		void report(uint64_t _nonce);
+		void report(uint64_t _nonce, const WorkPackage& work);
 
 		bool init(const h256& seed);
 

--- a/libethash-cuda/ethash_cuda_miner.cpp
+++ b/libethash-cuda/ethash_cuda_miner.cpp
@@ -241,7 +241,7 @@ cpyDag:
 	}
 }
 
-void ethash_cuda_miner::search(uint8_t const* header, uint64_t target, search_hook& hook, bool _ethStratum, uint64_t _startN)
+void ethash_cuda_miner::search(uint8_t const* header, uint64_t target, search_hook& hook, bool _ethStratum, uint64_t _startN, const dev::eth::WorkPackage& w)
 {
 	bool initialize = false;
 	bool exit = false;
@@ -311,7 +311,7 @@ void ethash_cuda_miner::search(uint8_t const* header, uint64_t target, search_ho
 		if (m_current_index >= s_numStreams)
 		{
 			if (found_count)
-				hook.found(nonces, found_count);
+				hook.found(nonces, found_count, w);
 			hook.searched(batch_size);
 			exit = hook.shouldStop();
 		}

--- a/libethash-cuda/ethash_cuda_miner.h
+++ b/libethash-cuda/ethash_cuda_miner.h
@@ -9,6 +9,14 @@
 #include <libhwmon/wrapnvml.h>
 #include "ethash_cuda_miner_kernel.h"
 
+namespace dev
+{
+namespace eth
+{
+class WorkPackage;
+}
+}
+
 class ethash_cuda_miner
 {
 public:
@@ -17,7 +25,7 @@ public:
 		virtual ~search_hook(); // always a virtual destructor for a class with virtuals.
 
 		// reports progress, return true to abort
-		virtual void found(uint64_t const* nonces, uint32_t count) = 0;
+		virtual void found(uint64_t const* nonces, uint32_t count, const dev::eth::WorkPackage& w) = 0;
 		virtual void searched(uint32_t count) = 0;
 		virtual bool shouldStop() = 0;
 	};
@@ -38,7 +46,7 @@ public:
 
 	bool init(size_t numDevices, ethash_light_t _light, uint8_t const* _lightData, uint64_t _lightSize, unsigned _deviceId, bool _cpyToHost, uint8_t * &hostDAG, unsigned dagCreateDevice);
 
-	void search(uint8_t const* header, uint64_t target, search_hook& hook, bool _ethStratum, uint64_t _startN);
+	void search(uint8_t const* header, uint64_t target, search_hook& hook, bool _ethStratum, uint64_t _startN, const dev::eth::WorkPackage& w);
 	dev::eth::HwMonitor hwmon();
 
 	/* -- default values -- */


### PR DESCRIPTION
Fix fixes the race condition when the pool thread has a new work package already. The work package is passed along with the nonce now to make sure that the solution reported is valid.

This requires to change the signatures of multiple function, but it should be simplified a lot after ethash_cuda_miner is merges with CUDAMiner.