### PR TITLE
fixed #464; Position of -RH option

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -239,7 +239,7 @@ public:
 		{
 			m_worktimeout = atoi(argv[++i]);
 		}
-		else if ((arg == "-RH" || arg == "--report-hashrate") && i + 1 < argc)
+		else if ((arg == "-RH" || arg == "--report-hashrate"))
 		{
 			m_report_stratum_hashrate = true;
 		}


### PR DESCRIPTION
A minor fix to allow the -rh option to stand anywhere
see https://github.com/ethereum-mining/ethminer/issues/464