### PR TITLE
make sure to initialize the correct number of CUDA devices in mixed mode -X param

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -531,7 +531,7 @@ public:
 			exit(1);
 #endif
 		}
-		else if (m_minerType == MinerType::CUDA || m_minerType == MinerType::Mixed)
+		if (m_minerType == MinerType::CUDA || m_minerType == MinerType::Mixed)
 		{
 #if ETH_ETHASHCUDA
 			if (m_cudaDeviceCount > 0)


### PR DESCRIPTION
This code should launch CUDA initialization process while in mixed mode and should not be coded as if/else statements but if/if .

This patch should fix the issue #553 