### PR TITLE
Fix ethereumstratum when job number is >8 chars

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -271,7 +271,7 @@ void CLMiner::report(uint64_t _nonce, WorkPackage const& _w)
 	// TODO: Why re-evaluating?
 	Result r = EthashAux::eval(_w.seed, _w.header, _nonce);
 	if (r.value < _w.boundary)
-		farm.submitProof(Solution{_nonce, r.mixHash, _w.header, _w.seed, _w.boundary, _w.job, false});
+		farm.submitProof(Solution{_nonce, r.mixHash, _w.header, _w.seed, _w.boundary, _w.job, _w.job_len, false});
 	else {
 		farm.failedSolution();
 		cwarn << "FAILURE: GPU gave incorrect result!";

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -52,7 +52,7 @@ void CUDAMiner::report(uint64_t _nonce, const WorkPackage& w)
 	// FIXME: This code is exactly the same as in EthashGPUMiner.
 	Result r = EthashAux::eval(w.seed, w.header, _nonce);
 	if (r.value < w.boundary)
-		farm.submitProof(Solution{_nonce, r.mixHash, w.header, w.seed, w.boundary, w.job, m_abort});
+		farm.submitProof(Solution{_nonce, r.mixHash, w.header, w.seed, w.boundary, w.job, w.job_len, m_abort});
 	else
 	{
 		farm.failedSolution();

--- a/libethcore/EthashAux.h
+++ b/libethcore/EthashAux.h
@@ -40,6 +40,7 @@ struct Solution
 	h256 seedHash;
 	h256 boundary;
 	h256 job;
+	int job_len;
 	bool stale;
 };
 
@@ -101,6 +102,7 @@ struct WorkPackage
 
 	uint64_t startNonce = 0;
 	int exSizeBits = -1;
+	int job_len = 8;
 };
 
 }

--- a/libstratum/EthStratumClient.cpp
+++ b/libstratum/EthStratumClient.cpp
@@ -406,12 +406,13 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
 						diffToTarget((uint32_t*)m_current.boundary.data(), m_nextWorkDifficulty);
 						m_current.startNonce = ethash_swap_u64(*((uint64_t*)m_extraNonce.data()));
 						m_current.exSizeBits = m_extraNonceHexSize * 4;
+						m_current.job_len = job.size();
 						if (m_protocol == STRATUM_PROTOCOL_ETHEREUMSTRATUM)
-							job = job + string(64 - 8, '0');
+							job.resize(64, '0');
 						m_current.job = h256(job);
 
 						p_farm->setWork(m_current);
-						cnote << "Received new job #" + job.substr(0, 8)
+						cnote << "Received new job #" + job.substr(0, m_current.job_len)
 							<< " seed: " << "#" + m_current.seed.hex().substr(0, 32)
 							<< " target: " << "#" + m_current.boundary.hex().substr(0, 24);
 					}
@@ -441,12 +442,10 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
 							m_current.header = h256(sHeaderHash);
 							m_current.seed = h256(sSeedHash);
 							m_current.boundary = h256(sShareTarget);
-							if (m_protocol == STRATUM_PROTOCOL_ETHEREUMSTRATUM)
-								job = job + string(64 - 8, '0');
 							m_current.job = h256(job);
 
 							p_farm->setWork(m_current);
-							cnote << "Received new job #" + job.substr(0, 8)
+							cnote << "Received new job #" + job.substr(0, m_current.job_len)
 								<< " seed: " << "#" + m_current.seed.hex().substr(0, 32)
 								<< " target: " << "#" + m_current.boundary.hex().substr(0, 24);
 						}
@@ -521,7 +520,7 @@ bool EthStratumClient::submit(Solution solution) {
 			break;
 		case STRATUM_PROTOCOL_ETHEREUMSTRATUM:
 			json = "{\"id\": 4, \"method\": \"mining.submit\", \"params\": [\"" +
-				p_active->user + "\",\"" + solution.job.hex().substr(0, 8) + "\",\"" +
+				p_active->user + "\",\"" + solution.job.hex().substr(0, solution.job_len) + "\",\"" +
 				nonceHex.substr(m_extraNonceHexSize, 16 - m_extraNonceHexSize) + "\"]}\n";
 			break;
 	}


### PR DESCRIPTION
The current code assumes the incoming job number will always be 8 hex
characters long; this currently breaks with nicehash, which is sending
16 hex character job numbers like '000000047fa89505'.

This commit fixes the issue by storing the incoming job number length in
WorkPackage and Solution, then using it to truncate the stored job
number back to whatever the original length was.

It also fixes a closely issue where the padding, which added 56 `0`s,
was padding out to 72 characters; the fix here resizes directly to 64
characters, whatever the input size.

Fixes #563 (#588 didn't entirely fix it, as per the above).