### PR TITLE
CUDA: -L sequential parameter is broken

### DIFF
--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -55,9 +55,12 @@ bool CUDAMiner::init(const h256& seed)
 {
 	// take local copy of work since it may end up being overwritten by kickOff/pause.
 	try {
+		if (s_dagLoadMode == DAG_LOAD_MODE_SEQUENTIAL)
+			while (s_dagLoadIndex < index)
+				this_thread::sleep_for(chrono::milliseconds(100));
 		unsigned device = s_devices[index] > -1 ? s_devices[index] : index;
 
-		cnote << "Initialising miner...";
+		cnote << "Initialising miner " << index;
 
 		EthashAux::LightType light;
 		light = EthashAux::light(seed);

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -53,7 +53,6 @@ CUDAMiner::~CUDAMiner()
 
 bool CUDAMiner::init(const h256& seed)
 {
-	// take local copy of work since it may end up being overwritten by kickOff/pause.
 	try {
 		if (s_dagLoadMode == DAG_LOAD_MODE_SEQUENTIAL)
 			while (s_dagLoadIndex < index)
@@ -98,6 +97,7 @@ void CUDAMiner::workLoop()
 	{
 		while(true)
 		{
+	                // take local copy of work since it may end up being overwritten.
 			const WorkPackage w = work();
 			
 			if (current.header != w.header || current.seed != w.seed)


### PR DESCRIPTION
R13 ignores this parameter for cuda and
does parallel load instead. This corrects
the issue.