### PR TITLE
No need to call the randomizer with each new job.

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -278,15 +278,6 @@ void CLMiner::report(uint64_t _nonce, WorkPackage const& _w)
 	}
 }
 
-namespace
-{
-uint64_t randomNonce()
-{
-	static std::mt19937_64 s_gen(std::random_device{}());
-	return std::uniform_int_distribution<uint64_t>{}(s_gen);
-}
-}
-
 void CLMiner::workLoop()
 {
 	// Memory for zero-ing buffers. Cannot be static because crashes on macOS.
@@ -346,7 +337,7 @@ void CLMiner::workLoop()
 				if (w.exSizeBits >= 0)
 					startNonce = w.startNonce | ((uint64_t)index << (64 - 4 - w.exSizeBits)); // This can support up to 16 devices.
 				else
-					startNonce = randomNonce();
+					startNonce = get_start_nonce();
 
 				auto switchEnd = std::chrono::high_resolution_clock::now();
 				auto globalSwitchTime = std::chrono::duration_cast<std::chrono::milliseconds>(switchEnd - workSwitchStart).count();

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -465,8 +465,7 @@ void CUDAMiner::search(
 	{
 		if (initialize)
 		{
-			random_device engine;
-			m_current_nonce = uniform_int_distribution<uint64_t>()(engine);
+			m_current_nonce = get_start_nonce();
 			m_current_index = 0;
 			CUDA_SAFE_CALL(cudaDeviceSynchronize());
 			for (unsigned int i = 0; i < s_numStreams; i++)

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -51,6 +51,16 @@ public:
 		std::function<Miner*(FarmFace&, unsigned)> create;
 	};
 
+	Farm()
+	{
+		// Given that all nonces are equally likely to solve the problem
+		// we could reasonably always start the nonce search ranges
+		// at a fixed place, but that would be boring. Provide a once
+		// per run randomized start place, without creating much overhead.
+		random_device engine;
+		m_nonce_scrambler = uniform_int_distribution<uint64_t>()(engine);
+	}
+
 	~Farm()
 	{
 		stop();
@@ -306,15 +316,20 @@ public:
 		return stream.str();
 	}
 
-    void set_pool_addresses(string primaryUrl, string primaryPort, string failoverUrl, string failoverPort) {
-        m_pool_addresses = primaryUrl + ":" + primaryPort;
-        if (failoverUrl != "")
-            m_pool_addresses += ";" + failoverUrl + ":" + failoverPort;
-    }
+	void set_pool_addresses(string primaryUrl, string primaryPort, string failoverUrl, string failoverPort) {
+		m_pool_addresses = primaryUrl + ":" + primaryPort;
+		if (failoverUrl != "")
+			m_pool_addresses += ";" + failoverUrl + ":" + failoverPort;
+	}
 
-    string get_pool_addresses() {
-        return m_pool_addresses;
-    }
+	string get_pool_addresses() {
+		return m_pool_addresses;
+	}
+
+	uint64_t get_nonce_scrambler()
+	{
+		return m_nonce_scrambler;
+	}
 
 private:
 	/**
@@ -357,7 +372,8 @@ private:
 	mutable SolutionStats m_solutionStats;
 	std::chrono::steady_clock::time_point m_farm_launched = std::chrono::steady_clock::now();
 
-    string m_pool_addresses;
+    	string m_pool_addresses;
+	uint64_t m_nonce_scrambler;
 }; 
 
 }

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -156,6 +156,7 @@ public:
 	 */
 	virtual bool submitProof(Solution const& _p) = 0;
 	virtual void failedSolution() = 0;
+	virtual uint64_t get_nonce_scrambler() = 0;
 };
 
 /**
@@ -190,6 +191,12 @@ public:
 	virtual HwMonitor hwmon() = 0;
 
 	unsigned Index() { return index; };
+
+	uint64_t get_start_nonce()
+	{
+		// Each GPU is given a non-overlapping 2^40 range to search
+		return farm.get_nonce_scrambler() + ((uint64_t) index << 40);
+	}
 
 protected:
 


### PR DESCRIPTION
We don't want to delay a job switch with an expensive
random number generation. Besides this approach does
not guarantee that two GPU will not be given overlapping
search ranges (highly unlikely but possible).

Instead we give each GPU its own unique 2^40 nonce
range to search and we do it very efficiently.