### PR TITLE
CUDA: Update default numStreams for better performance

### DIFF
--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -241,7 +241,7 @@ void CUDAMiner::setParallelHash(unsigned _parallelHash)
 
 unsigned const CUDAMiner::c_defaultBlockSize = 128;
 unsigned const CUDAMiner::c_defaultGridSize = 8192; // * CL_DEFAULT_LOCAL_WORK_SIZE
-unsigned const CUDAMiner::c_defaultNumStreams = 2;
+unsigned const CUDAMiner::c_defaultNumStreams = 1;
 
 bool CUDAMiner::cuda_configureGPU(
 	size_t numDevices,


### PR DESCRIPTION
In the current implementation numStreams=1 will always
give better results.