### PR TITLE
CUDA: Use atomic rather than relying on special case

### DIFF
--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -512,7 +512,7 @@ void CUDAMiner::search(
 			}
 			addHashCount(batch_size);
 			bool t = true;
-			if (m_abort.compare_exchange_weak(t, false))
+			if (m_abort.compare_exchange_strong(t, false))
 				break;
 			if (shouldStop())
 			{

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -134,9 +134,7 @@ void CUDAMiner::workLoop()
 
 void CUDAMiner::kick_miner()
 {
-	bool f = false;
-	// weak if ok here. If it fails it's because it was already true!
-	m_abort.compare_exchange_weak(f, true);
+	m_abort.store(true, std::memory_order_relaxed);
 }
 
 void CUDAMiner::setNumInstances(unsigned _instances)
@@ -518,9 +516,7 @@ void CUDAMiner::search(
 				break;
 			if (shouldStop())
 			{
-				// shutting down. don't want to get stuck here
-				// use weak exchange.
-				m_abort.compare_exchange_weak(t, false);
+				m_abort.store(false, std::memory_order_relaxed);
 				break;
 			}
 		}

--- a/libethash-cuda/CUDAMiner.h
+++ b/libethash-cuda/CUDAMiner.h
@@ -106,7 +106,7 @@ protected:
 	void kick_miner() override;
 
 private:
-	bool m_abort = false;
+	atomic<bool> m_abort = {false};
 
 	void workLoop() override;
 


### PR DESCRIPTION
Though not strictly required since we know the specifics
of the case, play by the rules of engagement
in a multithreaded/multiprocessor environment.