### PR TITLE
CUDA: Eliminate software evals completely! 

### DIFF
--- a/libethash-cuda/dagger_shuffled.cuh
+++ b/libethash-cuda/dagger_shuffled.cuh
@@ -4,7 +4,8 @@
 
 template <uint32_t _PARALLEL_HASH>
 __device__ __forceinline__ uint64_t compute_hash(
-	uint64_t nonce
+	uint64_t nonce,
+	uint2 *mix_hash
 	)
 {
 	// sha3_512(header .. nonce)
@@ -113,6 +114,10 @@ __device__ __forceinline__ uint64_t compute_hash(
 			}
 		}
 	}
+	mix_hash[0] = state[8];
+	mix_hash[1] = state[9];
+	mix_hash[2] = state[10];
+	mix_hash[3] = state[11];
 	
 	// keccak_256(keccak_512(header..nonce) .. mix);
 	return keccak_f1600_final(state);

--- a/libethash-cuda/ethash_cuda_miner_kernel.h
+++ b/libethash-cuda/ethash_cuda_miner_kernel.h
@@ -8,7 +8,9 @@
 // It is virtually impossible to get more than
 // one solution per stream hash calculation
 // Leave room for up to 3 results.
-#define SEARCH_RESULT_BUFFER_SIZE 4
+#define SEARCH_RESULT_ENTRIES 4
+// One word for gid and 8 for mix hash
+#define SEARCH_RESULT_BUFFER_SIZE (SEARCH_RESULT_ENTRIES * 9)
 
 #define ACCESSES 64
 #define THREADS_PER_HASH (128 / 16)
@@ -71,16 +73,16 @@ void ethash_generate_dag(
 	);
 
 
-#define CUDA_SAFE_CALL(call)								\
-do {														\
-	cudaError_t err = call;									\
-	if (cudaSuccess != err) {								\
+#define CUDA_SAFE_CALL(call)						\
+do {									\
+	cudaError_t err = call;						\
+	if (cudaSuccess != err) {					\
 		const char * errorString = cudaGetErrorString(err);	\
-		fprintf(stderr,										\
+		fprintf(stderr,						\
 			"CUDA error in func '%s' at line %i : %s.\n",	\
-			__FUNCTION__, __LINE__, errorString);			\
-		throw std::runtime_error(errorString);				\
-	}														\
+			__FUNCTION__, __LINE__, errorString);		\
+		throw std::runtime_error(errorString);			\
+	}								\
 } while (0)
 
 #endif


### PR DESCRIPTION
Given that we trust our GPUs there is no good reason
to recalculate the mix hash in software. The GPU has
already calculated it in order to find the nonce.

So, we get CUDA to provide us with the mix hashes
corresponding to each found solution, and send that
off to the pool insted of the recalculated one which
would be identical anyway!

What was it? Another 6ms. saved, I think.