### PR TITLE
Retain the stratum version control variable for future use

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -168,8 +168,10 @@ public:
 		{
 			try {
 				m_stratumClientVersion = atoi(argv[++i]);
-				if (m_stratumClientVersion > 2) m_stratumClientVersion = 2;
-				else if (m_stratumClientVersion < 1) m_stratumClientVersion = 1;
+				if (m_stratumClientVersion != 1) {
+					cerr << "Stratum " << m_stratumClientVersion << " not supported" << endl;
+					throw BadArgument();
+				}
 			}
 			catch (...)
 			{

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -605,7 +605,7 @@ public:
 			<< "    -O, --userpass <username.workername:password> Stratum login credentials" << endl
 			<< "    -FO, --failover-userpass <username.workername:password> Failover stratum login credentials (optional, will use normal credentials when omitted)" << endl
 			<< "    --work-timeout <n> reconnect/failover after n seconds of working on the same (stratum) job. Defaults to 180. Don't set lower than max. avg. block time" << endl
-			<< "    -SC, --stratum-client <n>  Stratum client version. Defaults to 1 (async client). Use 2 to use the new synchronous client." << endl
+			<< "    -SC, --stratum-client <n>  Stratum client version. Version 1 support only." << endl
 			<< "    -SP, --stratum-protocol <n> Choose which stratum protocol to use:" << endl
 			<< "        0: official stratum spec: ethpool, ethermine, coinotron, mph, nanopool (default)" << endl
 			<< "        1: eth-proxy compatible: dwarfpool, f2pool, nanopool (required for hashrate reporting to work with nanopool)" << endl

--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -63,25 +63,33 @@ int main(int argc, char** argv)
 
 	MinerCLI m(MinerCLI::OperationMode::Farm);
 
-	for (int i = 1; i < argc; ++i)
+	try
 	{
-		// Mining options:
-		if (m.interpretOption(i, argc, argv))
-			continue;
-
-		// Standard options:
-		string arg = argv[i];
-		if ((arg == "-v" || arg == "--verbosity") && i + 1 < argc)
-			g_logVerbosity = atoi(argv[++i]);
-		else if (arg == "-h" || arg == "--help")
-			help();
-		else if (arg == "-V" || arg == "--version")
-			version();
-		else
+		for (int i = 1; i < argc; ++i)
 		{
-			cerr << "Invalid argument: " << arg << endl;
-			exit(-1);
+			// Mining options:
+			if (m.interpretOption(i, argc, argv))
+				continue;
+
+			// Standard options:
+			string arg = argv[i];
+			if ((arg == "-v" || arg == "--verbosity") && i + 1 < argc)
+				g_logVerbosity = atoi(argv[++i]);
+			else if (arg == "-h" || arg == "--help")
+				help();
+			else if (arg == "-V" || arg == "--version")
+				version();
+			else
+			{
+				cerr << "Invalid argument: " << arg << endl;
+				exit(-1);
+			}
 		}
+	}
+	catch (BadArgument ex)
+	{
+		std::cerr << "Error: " << ex.what() << "\n";
+		exit(-1);
 	}
 
 	try


### PR DESCRIPTION
But since we only support stratum 1 enforce that choice.
I doubt anyone is using any other value successfully.

Also, it's probably not productive to core dump on a parameter
error.