### PR TITLE
Make cuda eval bypass optional

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -394,6 +394,8 @@ public:
 		}
 		else if (arg == "--cuda-streams" && i + 1 < argc)
 			m_numStreams = stol(argv[++i]);
+		else if (arg == "--cuda-noeval")
+			m_cudaNoEval = true;
 #endif
 		else if ((arg == "-L" || arg == "--dag-load-mode") && i + 1 < argc)
 		{
@@ -571,7 +573,8 @@ public:
 				m_cudaSchedule,
 				0,
 				m_dagLoadMode,
-				m_dagCreateDevice
+				m_dagCreateDevice,
+				m_cudaNoEval
 				))
 				exit(1);
 
@@ -655,6 +658,10 @@ public:
 			<< "        sync  - Instruct CUDA to block the CPU thread on a synchronization primitive when waiting for the results from the device." << endl
 			<< "    --cuda-devices <0 1 ..n> Select which CUDA GPUs to mine on. Default is to use all" << endl
 			<< "    --cuda-parallel-hash <1 2 ..8> Define how many hashes to calculate in a kernel, can be scaled to achieve better performance. Default=4" << endl
+			<< "    --cuda-noeval  bypass host software re-evalution of GPU solutions." << endl
+			<< "        This will trim some milliseconds off the time it takes to send a result to the pool." << endl
+			<< "        Use at your own risk! If GPU generates errored results they WILL be forwarded to the pool" << endl
+			<< "        Not recommended at high overclock." << endl
 #endif
 #if API_CORE
 			<< " API core configuration:" << endl
@@ -1051,6 +1058,7 @@ private:
 	unsigned m_cudaSchedule = 4; // sync
 	unsigned m_cudaGridSize = CUDAMiner::c_defaultGridSize;
 	unsigned m_cudaBlockSize = CUDAMiner::c_defaultBlockSize;
+	bool m_cudaNoEval = false;
 #endif
 	unsigned m_dagLoadMode = 0; // parallel
 	unsigned m_dagCreateDevice = 0;

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -212,7 +212,8 @@ bool CUDAMiner::configureGPU(
 	unsigned _scheduleFlag,
 	uint64_t _currentBlock,
 	unsigned _dagLoadMode,
-	unsigned _dagCreateDevice
+	unsigned _dagCreateDevice,
+	bool _noeval
 	)
 {
 	s_dagLoadMode = _dagLoadMode;
@@ -225,7 +226,8 @@ bool CUDAMiner::configureGPU(
 		_gridSize,
 		_numStreams,
 		_scheduleFlag,
-		_currentBlock)
+		_currentBlock,
+		_noeval)
 		)
 	{
 		cout << "No CUDA device with sufficient memory was found. Can't CUDA mine. Remove the -U argument" << endl;
@@ -250,7 +252,8 @@ bool CUDAMiner::cuda_configureGPU(
 	unsigned _gridSize,
 	unsigned _numStreams,
 	unsigned _scheduleFlag,
-	uint64_t _currentBlock
+	uint64_t _currentBlock,
+	bool _noeval
 	)
 {
 	try
@@ -259,6 +262,7 @@ bool CUDAMiner::cuda_configureGPU(
 		s_gridSize = _gridSize;
 		s_numStreams = _numStreams;
 		s_scheduleFlag = _scheduleFlag;
+		s_noeval = _noeval;
 
 		cudalog << "Using grid size " << s_gridSize << ", block size " << s_blockSize;
 
@@ -296,6 +300,7 @@ unsigned CUDAMiner::s_blockSize = CUDAMiner::c_defaultBlockSize;
 unsigned CUDAMiner::s_gridSize = CUDAMiner::c_defaultGridSize;
 unsigned CUDAMiner::s_numStreams = CUDAMiner::c_defaultNumStreams;
 unsigned CUDAMiner::s_scheduleFlag = 0;
+bool CUDAMiner::s_noeval = false;
 
 bool CUDAMiner::cuda_init(
 	size_t numDevices,
@@ -492,14 +497,16 @@ void CUDAMiner::search(
 					found_count = SEARCH_RESULTS;
 				for (unsigned int j = 0; j < found_count; j++) {
 					nonces[j] = nonce_base + buffer->result[j].gid;
-					mixes[j][0] = buffer->result[j].mix[0];
-					mixes[j][1] = buffer->result[j].mix[1];
-					mixes[j][2] = buffer->result[j].mix[2];
-					mixes[j][3] = buffer->result[j].mix[3];
-					mixes[j][4] = buffer->result[j].mix[4];
-					mixes[j][5] = buffer->result[j].mix[5];
-					mixes[j][6] = buffer->result[j].mix[6];
-					mixes[j][7] = buffer->result[j].mix[7];
+					if (s_noeval) {
+						mixes[j][0] = buffer->result[j].mix[0];
+						mixes[j][1] = buffer->result[j].mix[1];
+						mixes[j][2] = buffer->result[j].mix[2];
+						mixes[j][3] = buffer->result[j].mix[3];
+						mixes[j][4] = buffer->result[j].mix[4];
+						mixes[j][5] = buffer->result[j].mix[5];
+						mixes[j][6] = buffer->result[j].mix[6];
+						mixes[j][7] = buffer->result[j].mix[7];
+					}
 				}
 			}
 		}
@@ -508,11 +515,20 @@ void CUDAMiner::search(
 		{
 			if (found_count)
 				for (uint32_t i = 0; i < found_count; i++)
-					farm.submitProof(
-						Solution{nonces[i],
-						*((const h256 *)mixes[i]),
-						w,
-						m_abort});
+					if (s_noeval)
+						farm.submitProof(Solution{nonces[i], *((const h256 *)mixes[i]), w, m_abort});
+					else
+					{
+						Result r = EthashAux::eval(w.seed, w.header, nonces[i]);
+						if (r.value < w.boundary)
+							farm.submitProof(Solution{nonces[i], r.mixHash, w, m_abort});
+						else
+						{
+							farm.failedSolution();
+							cwarn << "GPU gave incorrect result!";
+						}
+					}
+
 			addHashCount(batch_size);
 			bool t = true;
 			if (m_abort.compare_exchange_strong(t, false))

--- a/libethash-cuda/CUDAMiner.h
+++ b/libethash-cuda/CUDAMiner.h
@@ -56,7 +56,8 @@ public:
 		unsigned _scheduleFlag,
 		uint64_t _currentBlock,
 		unsigned _dagLoadMode,
-		unsigned _dagCreateDevice
+		unsigned _dagCreateDevice,
+		bool _noeval
 		);
 	static void setNumInstances(unsigned _instances);
 	static void setDevices(const unsigned* _devices, unsigned _selectedDeviceCount);
@@ -68,7 +69,8 @@ public:
 		unsigned _gridSize,
 		unsigned _numStreams,
 		unsigned _scheduleFlag,
-		uint64_t _currentBlock
+		uint64_t _currentBlock,
+		bool _noeval
 		);
 
 	static void cuda_setParallelHash(unsigned _parallelHash);
@@ -139,6 +141,8 @@ private:
 
 	static unsigned s_numInstances;
 	static int s_devices[16];
+
+	static bool s_noeval;
 };
 
 


### PR DESCRIPTION
It is prudent to make the re-evaluation of cuda search
results optional in host software. The default mode is the
legacy behavior.

Benefits:
- No one is caught by surprise inadvertantly flooding the
  pool with invalid solutions due to overclocked GPU errors.
- The software eval is a necessary piece of overclock
  tuning, again to avoid sending invalid solutions.
- Bypassing eval can be turned on for configurations known
  to be stable. In that state, GPUs actually WILL always
  yield valid solutions.