### PR TITLE
Exit on cuda run-time error

### DIFF
--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -92,6 +92,7 @@ void CUDAMiner::workLoop()
 	WorkPackage current;
 	current.header = h256{1u};
 	current.seed = h256{1u};
+
 	try
 	{
 		while(true)
@@ -108,10 +109,8 @@ void CUDAMiner::workLoop()
 					continue;
 				}
 				if (current.seed != w.seed)
-				{
 					if(!init(w.seed))
 						break;
-				}
 				current = w;
 			}
 			uint64_t upper64OfBoundary = (uint64_t)(u64)((u256)current.boundary >> 192);
@@ -122,10 +121,14 @@ void CUDAMiner::workLoop()
 
 			// Check if we should stop.
 			if (shouldStop())
-			{
 				break;
-			}
 		}
+	}
+	catch (cuda_runtime_error const& _e)
+	{
+		cwarn << "Fatal GPU error: " << _e.what();
+		cwarn << "Terminating.";
+		exit(-1);
 	}
 	catch (std::runtime_error const& _e)
 	{

--- a/libethash-cuda/ethash_cuda_miner_kernel.h
+++ b/libethash-cuda/ethash_cuda_miner_kernel.h
@@ -2,7 +2,8 @@
 #define _ETHASH_CUDA_MINER_KERNEL_H_
 
 #include <stdexcept>
-#include <stdio.h>
+#include <string>
+#include <sstream>
 #include <stdint.h>
 #include <cuda_runtime.h>
 
@@ -79,16 +80,24 @@ void ethash_generate_dag(
 	int device
 	);
 
-#define CUDA_SAFE_CALL(call)						\
-do {									\
-	cudaError_t err = call;						\
-	if (cudaSuccess != err) {					\
-		const char * errorString = cudaGetErrorString(err);	\
-		fprintf(stderr,						\
-			"CUDA error in func '%s' at line %i : %s.\n",	\
-			__FUNCTION__, __LINE__, errorString);		\
-		throw std::runtime_error(errorString);			\
-	}								\
+struct cuda_runtime_error : public virtual std::runtime_error
+{
+	cuda_runtime_error( std::string msg ) : std::runtime_error(msg) {}
+};
+
+#define CUDA_SAFE_CALL(call)				\
+do {							\
+	cudaError_t err = call;				\
+	if (cudaSuccess != err) {			\
+		std::stringstream ss;			\
+		ss << "CUDA error in func " 		\
+			<< __FUNCTION__ 		\
+			<< " at line "			\
+			<< __LINE__			\
+			<< ' '				\
+			<< cudaGetErrorString(err);	\
+		throw cuda_runtime_error(ss.str());	\
+	}						\
 } while (0)
 
 #endif


### PR DESCRIPTION
These errors typically occur on overclocked
CUDA GPUs and are presently unrecovered.
They often result in a miner that appears
to be mining but is finding no shares.

These usually can be recovered with a miner
restart. Give the user an opportunity  to do so
via script by exiting on such errors.