### PR TITLE
Get rid of unused or inconsistent protocol method

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -934,7 +934,7 @@ private:
 				client.reconnect();
 			});
 
-			while (client.isRunning())
+			while (true)
 			{
 				auto mp = f.miningProgress(m_show_hwmonitors);
 				if (client.isConnected())

--- a/libpoolprotocols/PoolClient.h
+++ b/libpoolprotocols/PoolClient.h
@@ -20,7 +20,6 @@ namespace dev
 
 			virtual void submitHashrate(string const & rate) = 0;
 			virtual void submitSolution(Solution solution) = 0;
-			virtual bool isRunning() = 0 ;
 			virtual bool isConnected() = 0;
 
 			using SolutionAccepted = std::function<void(bool const&)>;
@@ -38,7 +37,6 @@ namespace dev
 		protected:
 			bool m_authorized = false;
 			bool m_connected = false;
-			bool m_running = true;
 			string m_host;
 			string m_port;
 			string m_user;
@@ -55,3 +53,4 @@ namespace dev
 }
 
 #endif
+

--- a/libpoolprotocols/PoolManager.h
+++ b/libpoolprotocols/PoolManager.h
@@ -42,7 +42,6 @@ namespace dev
 			void stop();
 			void setReconnectTries(unsigned const & reconnectTries) { m_reconnectTries = reconnectTries; };
 			bool isConnected() { return p_client->isConnected(); };
-			bool isRunning() { return p_client->isRunning(); };
 
 		private:
 			unsigned m_hashrateReportingTime = 10;
@@ -65,3 +64,4 @@ namespace dev
 }
 
 #endif
+

--- a/libpoolprotocols/getwork/EthGetworkClient.h
+++ b/libpoolprotocols/getwork/EthGetworkClient.h
@@ -20,7 +20,6 @@ public:
 	void connect();
 	void disconnect();
 
-	bool isRunning() { return m_running; }
 	bool isConnected() { return m_connected; }
 
 	void submitHashrate(string const & rate);
@@ -39,3 +38,4 @@ private:
 };
 
 #endif
+

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -55,7 +55,6 @@ EthStratumClient::EthStratumClient(Farm* f, MinerType m, string const & host, st
 
 EthStratumClient::~EthStratumClient()
 {
-	m_running = false;
 	m_io_service.stop();
 	m_serviceThread.join();
 }

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -25,7 +25,6 @@ public:
 	void setFailover(string const & host, string const & port);
 	void setFailover(string const & host, string const & port, string const & user, string const & pass);
 
-	bool isRunning() { return m_running; }
 	bool isConnected() { return m_connected.load(std::memory_order_relaxed) && m_authorized; }
 	h256 currentHeaderHash() { return m_current.header; }
 	bool current() { return static_cast<bool>(m_current); }


### PR DESCRIPTION
The m_running variable and associated isRunning method
is only set to false in stratum where it was actually
used incorrectly!

In my view, if a pool protocol client is instantiated then
by definition it is running. The m_connected and m_registered
variables are sufficient to manage the protocol state.

The termination of the doStratum loop was conditioned
by the client's isRunning state, which was only ever
inappropriately set to false on a disconnect.

The loop now will never terminate, which is a problem
for controlled shutdown. I believe the coming conversion
of stratum to a full fledged pool protocol client
will correct the problem.

git diff complains about missing terminating newlines...