### PR TITLE
Rename alternate kernel to more representative name

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -643,8 +643,7 @@ public:
 			<< " OpenCL configuration:" << endl
 			<< "    --cl-kernel <n>  Use a different OpenCL kernel (default: use stable kernel)" << endl
 			<< "        0: stable kernel" << endl
-			<< "        1: unstable kernel" << endl
-//			<< "        2: experimental kernel" << endl
+			<< "        1: experimental kernel" << endl
 			<< "    --cl-local-work Set the OpenCL local work size. Default is " << CLMiner::c_defaultLocalWorkSize << endl
 			<< "    --cl-global-work Set the OpenCL global work size as a multiple of the local work size. Default is " << CLMiner::c_defaultGlobalWorkSizeMultiplier << " * " << CLMiner::c_defaultLocalWorkSize << endl
 			<< "    --cl-parallel-hash <1 2 ..8> Define how many threads to associate per hash. Default=8" << endl

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -6,7 +6,7 @@
 #include "CLMiner.h"
 #include <libethash/internal.h>
 #include "CLMiner_kernel_stable.h"
-#include "CLMiner_kernel_unstable.h"
+#include "CLMiner_kernel_experimental.h"
 
 using namespace dev;
 using namespace eth;
@@ -630,7 +630,7 @@ bool CLMiner::init(const h256& seed)
 
 		if ( s_clKernelName == CLKernelName::Unstable ) {
 			cllog << "OpenCL kernel: Unstable kernel";
-			code = string(CLMiner_kernel_unstable, CLMiner_kernel_unstable + sizeof(CLMiner_kernel_unstable));
+			code = string(CLMiner_kernel_experimental, CLMiner_kernel_experimental + sizeof(CLMiner_kernel_experimental));
 		}
 		else { //if(s_clKernelName == CLKernelName::Stable)
 			cllog << "OpenCL kernel: Stable kernel";

--- a/libethash-cl/CLMiner_kernel_experimental.cl
+++ b/libethash-cl/CLMiner_kernel_experimental.cl
@@ -32,7 +32,7 @@
 
 // Either 8, 4, 2, or 1
 #ifndef THREADS_PER_HASH
-    #define THREADS_PER_HASH 1
+    #define THREADS_PER_HASH 2
 #endif
 #define HASHES_PER_LOOP (GROUP_SIZE / THREADS_PER_HASH)
 

--- a/libethash-cl/CMakeLists.txt
+++ b/libethash-cl/CMakeLists.txt
@@ -16,21 +16,21 @@ add_custom_command(
 add_custom_target(clbin2h_stable DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/CLMiner_kernel_stable.h ${CMAKE_CURRENT_SOURCE_DIR}/CLMiner_kernel_stable.cl)
 
 add_custom_command(
-	OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/CLMiner_kernel_unstable.h
+	OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/CLMiner_kernel_experimental.h
 	COMMAND ${CMAKE_COMMAND} ARGS
-	-DBIN2H_SOURCE_FILE="${CMAKE_CURRENT_SOURCE_DIR}/CLMiner_kernel_unstable.cl"
-	-DBIN2H_VARIABLE_NAME=CLMiner_kernel_unstable
-	-DBIN2H_HEADER_FILE="${CMAKE_CURRENT_BINARY_DIR}/CLMiner_kernel_unstable.h"
+	-DBIN2H_SOURCE_FILE="${CMAKE_CURRENT_SOURCE_DIR}/CLMiner_kernel_experimental.cl"
+	-DBIN2H_VARIABLE_NAME=CLMiner_kernel_experimental
+	-DBIN2H_HEADER_FILE="${CMAKE_CURRENT_BINARY_DIR}/CLMiner_kernel_experimental.h"
 	-P "${CMAKE_CURRENT_SOURCE_DIR}/bin2h.cmake"
 	COMMENT "Generating OpenCL Kernel Byte Array"
-	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/CLMiner_kernel_unstable.cl
+	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/CLMiner_kernel_experimental.cl
 )
-add_custom_target(clbin2h_unstable DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/CLMiner_kernel_unstable.h ${CMAKE_CURRENT_SOURCE_DIR}/CLMiner_kernel_unstable.cl)
+add_custom_target(clbin2h_experimental DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/CLMiner_kernel_experimental.h ${CMAKE_CURRENT_SOURCE_DIR}/CLMiner_kernel_experimental.cl)
 
 set(SOURCES
 	CLMiner.h CLMiner.cpp
 	${CMAKE_CURRENT_BINARY_DIR}/CLMiner_kernel_stable.h
-	${CMAKE_CURRENT_BINARY_DIR}/CLMiner_kernel_unstable.h
+	${CMAKE_CURRENT_BINARY_DIR}/CLMiner_kernel_experimental.h
 )
 
 if(APPLE)


### PR DESCRIPTION
As I understand this so called unstable kernel was
indeed faster and stable on some GPUs