### PR TITLE
Changed HWMON to init library only once.

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -502,30 +502,6 @@ bool CLMiner::configureGPU(
 	return false;
 }
 
-HwMonitor CLMiner::hwmon()
-{
-	HwMonitor hw;
-	unsigned int tempC = 0, fanpcnt = 0;
-	if (nvmlh) {
-		wrap_nvml_get_tempC(nvmlh, index, &tempC);
-		wrap_nvml_get_fanpcnt(nvmlh, index, &fanpcnt);
-	}
-	if (adlh) {
-		wrap_adl_get_tempC(adlh, index, &tempC);
-		wrap_adl_get_fanpcnt(adlh, index, &fanpcnt);
-	}
-#if defined(__linux)
-	if (sysfsh) {
-		wrap_amdsysfs_get_tempC(sysfsh, index, &tempC);
-		wrap_amdsysfs_get_fanpcnt(sysfsh, index, &fanpcnt);
-	}
-#endif
-	hw.tempC = tempC;
-	hw.fanP = fanpcnt;
-	return hw;
-}
-
-
 bool CLMiner::init(const h256& seed)
 {
 	EthashAux::LightType light = EthashAux::light(seed);
@@ -552,15 +528,12 @@ bool CLMiner::init(const h256& seed)
 			if (platformName == "NVIDIA CUDA")
 			{
 				platformId = OPENCL_PLATFORM_NVIDIA;
-				nvmlh = wrap_nvml_create();
+				m_hwmoninfo.deviceType = HwMonitorInfoType::NVIDIA;
 			}
 			else if (platformName == "AMD Accelerated Parallel Processing")
 			{
 				platformId = OPENCL_PLATFORM_AMD;
-				adlh = wrap_adl_create();
-#if defined(__linux)
-				sysfsh = wrap_amdsysfs_create();
-#endif
+				m_hwmoninfo.deviceType = HwMonitorInfoType::AMD;
 			}
 			else if (platformName == "Clover")
 			{
@@ -578,6 +551,7 @@ bool CLMiner::init(const h256& seed)
 
 		// use selected device
 		unsigned deviceId = s_devices[index] > -1 ? s_devices[index] : index;
+		m_hwmoninfo.deviceIndex = deviceId;
 		cl::Device& device = devices[min<unsigned>(deviceId, devices.size() - 1)];
 		string device_version = device.getInfo<CL_DEVICE_VERSION>();
 		ETHCL_LOG("Device:   " << device.getInfo<CL_DEVICE_NAME>() << " / " << device_version);

--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -8,11 +8,6 @@
 #include <libdevcore/Worker.h>
 #include <libethcore/EthashAux.h>
 #include <libethcore/Miner.h>
-#include <libhwmon/wrapnvml.h>
-#include <libhwmon/wrapadl.h>
-#if defined(__linux)
-#include <libhwmon/wrapamdsysfs.h>
-#endif
 
 #define CL_USE_DEPRECATED_OPENCL_1_2_APIS true
 #define CL_HPP_ENABLE_EXCEPTIONS true
@@ -82,7 +77,6 @@ public:
 		}
 	}
 	static void setCLKernel(unsigned _clKernel) { s_clKernelName = _clKernel == 1 ? CLKernelName::Experimental : CLKernelName::Stable; }
-	HwMonitor hwmon() override;
 protected:
 	void kick_miner() override;
 
@@ -113,12 +107,6 @@ private:
 	static unsigned s_workgroupSize;
 	/// The initial global work size for the searches
 	static unsigned s_initialGlobalWorkSize;
-
-	wrap_nvml_handle *nvmlh = NULL;
-	wrap_adl_handle *adlh = NULL;
-#if defined(__linux)
-	wrap_amdsysfs_handle *sysfsh = NULL;
-#endif
 };
 
 }

--- a/libethash-cl/CMakeLists.txt
+++ b/libethash-cl/CMakeLists.txt
@@ -45,5 +45,5 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(..)
 
 add_library(ethash-cl ${SOURCES})
-target_link_libraries(ethash-cl PUBLIC ethcore ethash hwmon)
+target_link_libraries(ethash-cl PUBLIC ethcore ethash)
 target_link_libraries(ethash-cl PRIVATE OpenCL::OpenCL)

--- a/libethash-cuda/CMakeLists.txt
+++ b/libethash-cuda/CMakeLists.txt
@@ -27,6 +27,6 @@ file(GLOB sources "*.cpp" "*.cu")
 file(GLOB headers "*.h" "*.cuh")
 
 cuda_add_library(ethash-cuda STATIC ${sources} ${headers})
-target_link_libraries(ethash-cuda ethcore ethash hwmon)
+target_link_libraries(ethash-cuda ethcore ethash)
 target_include_directories(ethash-cuda PUBLIC ${CUDA_INCLUDE_DIRS})
 target_include_directories(ethash-cuda PRIVATE .. ${CMAKE_CURRENT_BINARY_DIR})

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -196,19 +196,6 @@ void CUDAMiner::listDevices()
 	}
 }
 
-HwMonitor CUDAMiner::hwmon()
-{
-	dev::eth::HwMonitor hw;
-	if (nvmlh) {
-		unsigned int tempC = 0, fanpcnt = 0;
-		wrap_nvml_get_tempC(nvmlh, nvmlh->cuda_nvml_device_id[m_device_num], &tempC);
-		wrap_nvml_get_fanpcnt(nvmlh, nvmlh->cuda_nvml_device_id[m_device_num], &fanpcnt);
-		hw.tempC = tempC;
-		hw.fanP = fanpcnt;
-	}
-	return hw;
-}
-
 bool CUDAMiner::configureGPU(
 	unsigned _blockSize,
 	unsigned _gridSize,
@@ -323,7 +310,8 @@ bool CUDAMiner::cuda_init(
 
 		// use selected device
 		m_device_num = _deviceId < numDevices -1 ? _deviceId : numDevices - 1;
-		nvmlh = wrap_nvml_create();
+		m_hwmoninfo.deviceType = HwMonitorInfoType::NVIDIA;
+		m_hwmoninfo.deviceIndex = m_device_num;
 
 		cudaDeviceProp device_props;
 		CUDA_SAFE_CALL(cudaGetDeviceProperties(&device_props, m_device_num));

--- a/libethash-cuda/CUDAMiner.h
+++ b/libethash-cuda/CUDAMiner.h
@@ -25,8 +25,6 @@ along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 #include <libdevcore/Worker.h>
 #include <libethcore/EthashAux.h>
 #include <libethcore/Miner.h>
-#include <libethcore/Miner.h>
-#include <libhwmon/wrapnvml.h>
 #include "ethash_cuda_miner_kernel.h"
 #include "libethash/internal.h"
 
@@ -61,7 +59,6 @@ public:
 		);
 	static void setNumInstances(unsigned _instances);
 	static void setDevices(const vector<unsigned>& _devices, unsigned _selectedDeviceCount);
-	HwMonitor hwmon() override;
 	static bool cuda_configureGPU(
 		size_t numDevices,
 		const vector<int>& _devices,
@@ -91,7 +88,6 @@ public:
 		bool _ethStratum,
 		uint64_t _startN,
 		const dev::eth::WorkPackage& w);
-		dev::eth::HwMonitor cuda_hwmon();
 
 	/* -- default values -- */
 	/// Default value of the block size. Also known as workgroup size.
@@ -136,8 +132,6 @@ private:
 	static unsigned s_scheduleFlag;
 
 	static unsigned m_parallelHash;
-
-	wrap_nvml_handle *nvmlh = nullptr;
 
 	static unsigned s_numInstances;
 	static vector<int> s_devices;

--- a/libethcore/CMakeLists.txt
+++ b/libethcore/CMakeLists.txt
@@ -9,7 +9,7 @@ set(SOURCES
 include_directories(BEFORE ..)
 
 add_library(ethcore ${SOURCES})
-target_link_libraries(ethcore ethash devcore)
+target_link_libraries(ethcore ethash devcore hwmon)
 
 if(ETHASHCL)
 	target_link_libraries(ethcore ethash-cl)

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -77,10 +77,10 @@ public:
 	{
 		// Deinit HWMON
 		if (adlh)
-			wrap_adl_destory(adlh);
+			wrap_adl_destroy(adlh);
 #if defined(__linux)
 		if (sysfsh)
-			wrap_amdsysfs_destory(sysfsh);
+			wrap_amdsysfs_destroy(sysfsh);
 #endif
 		if (nvmlh)
 			wrap_nvml_destroy(nvmlh);

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -263,21 +263,23 @@ public:
 				HwMonitorInfo hwInfo = i->hwmonInfo();
 				HwMonitor hw;
 				unsigned int tempC = 0, fanpcnt = 0;
-				if (hwInfo.deviceType == HwMonitorInfoType::NVIDIA && nvmlh) {
-					wrap_nvml_get_tempC(nvmlh, hwInfo.deviceIndex, &tempC);
-					wrap_nvml_get_fanpcnt(nvmlh, hwInfo.deviceIndex, &fanpcnt);
-				} 
-				else if (hwInfo.deviceType == HwMonitorInfoType::AMD && adlh) {
-					wrap_adl_get_tempC(adlh, hwInfo.deviceIndex, &tempC);
-					wrap_adl_get_fanpcnt(adlh, hwInfo.deviceIndex, &fanpcnt);
-				}
+				if (hwInfo.deviceIndex >= 0) {
+					if (hwInfo.deviceType == HwMonitorInfoType::NVIDIA && nvmlh) {
+						wrap_nvml_get_tempC(nvmlh, hwInfo.deviceIndex, &tempC);
+						wrap_nvml_get_fanpcnt(nvmlh, hwInfo.deviceIndex, &fanpcnt);
+					}
+					else if (hwInfo.deviceType == HwMonitorInfoType::AMD && adlh) {
+						wrap_adl_get_tempC(adlh, hwInfo.deviceIndex, &tempC);
+						wrap_adl_get_fanpcnt(adlh, hwInfo.deviceIndex, &fanpcnt);
+					}
 #if defined(__linux)
-				// Overwrite with sysfs data if present
-				if (hwInfo.deviceType == HwMonitorInfoType::AMD && sysfsh) {
-					wrap_amdsysfs_get_tempC(sysfsh, hwInfo.deviceIndex, &tempC);
-					wrap_amdsysfs_get_fanpcnt(sysfsh, hwInfo.deviceIndex, &fanpcnt);
-				}
+					// Overwrite with sysfs data if present
+					if (hwInfo.deviceType == HwMonitorInfoType::AMD && sysfsh) {
+						wrap_amdsysfs_get_tempC(sysfsh, hwInfo.deviceIndex, &tempC);
+						wrap_amdsysfs_get_fanpcnt(sysfsh, hwInfo.deviceIndex, &fanpcnt);
+					}
 #endif
+				}
 				hw.tempC = tempC;
 				hw.fanP = fanpcnt;
 				p.minerMonitors.push_back(hw);

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -30,6 +30,11 @@
 #include <libdevcore/Worker.h>
 #include <libethcore/Miner.h>
 #include <libethcore/BlockHeader.h>
+#include <libhwmon/wrapnvml.h>
+#include <libhwmon/wrapadl.h>
+#if defined(__linux)
+#include <libhwmon/wrapamdsysfs.h>
+#endif
 
 namespace dev
 {
@@ -59,10 +64,28 @@ public:
 		// per run randomized start place, without creating much overhead.
 		random_device engine;
 		m_nonce_scrambler = uniform_int_distribution<uint64_t>()(engine);
+
+		// Init HWMON
+		adlh = wrap_adl_create();
+#if defined(__linux)
+		sysfsh = wrap_amdsysfs_create();
+#endif
+		nvmlh = wrap_nvml_create();
 	}
 
 	~Farm()
 	{
+		// Deinit HWMON
+		if (adlh)
+			wrap_adl_destory(adlh);
+#if defined(__linux)
+		if (sysfsh)
+			wrap_amdsysfs_destory(sysfsh);
+#endif
+		if (nvmlh)
+			wrap_nvml_destroy(nvmlh);
+
+		// Stop mining
 		stop();
 	}
 
@@ -236,8 +259,29 @@ public:
         for (auto const& i : m_miners)
         {
             p.minersHashes.push_back(0);
-            if (hwmon)
-                p.minerMonitors.push_back(i->hwmon());
+			if (hwmon) {
+				HwMonitorInfo hwInfo = i->hwmonInfo();
+				HwMonitor hw;
+				unsigned int tempC = 0, fanpcnt = 0;
+				if (hwInfo.deviceType == HwMonitorInfoType::NVIDIA && nvmlh) {
+					wrap_nvml_get_tempC(nvmlh, hwInfo.deviceIndex, &tempC);
+					wrap_nvml_get_fanpcnt(nvmlh, hwInfo.deviceIndex, &fanpcnt);
+				} 
+				else if (hwInfo.deviceType == HwMonitorInfoType::AMD && adlh) {
+					wrap_adl_get_tempC(adlh, hwInfo.deviceIndex, &tempC);
+					wrap_adl_get_fanpcnt(adlh, hwInfo.deviceIndex, &fanpcnt);
+				}
+#if defined(__linux)
+				// Overwrite with sysfs data if present
+				if (hwInfo.deviceType == HwMonitorInfoType::AMD && sysfsh) {
+					wrap_amdsysfs_get_tempC(sysfsh, hwInfo.deviceIndex, &tempC);
+					wrap_amdsysfs_get_fanpcnt(sysfsh, hwInfo.deviceIndex, &fanpcnt);
+				}
+#endif
+				hw.tempC = tempC;
+				hw.fanP = fanpcnt;
+				p.minerMonitors.push_back(hw);
+			}
         }
 
         for (auto const& cp : m_lastProgresses)
@@ -370,6 +414,12 @@ private:
 
     	string m_pool_addresses;
 	uint64_t m_nonce_scrambler;
+
+	wrap_nvml_handle *nvmlh = NULL;
+	wrap_adl_handle *adlh = NULL;
+#if defined(__linux)
+	wrap_amdsysfs_handle *sysfsh = NULL;
+#endif
 }; 
 
 }

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -63,6 +63,19 @@ enum class MinerType
 	CUDA
 };
 
+enum class HwMonitorInfoType
+{
+	UNKNOWN,
+	NVIDIA,
+	AMD
+};
+
+struct HwMonitorInfo
+{
+	HwMonitorInfoType deviceType;
+	int deviceIndex;
+};
+
 struct HwMonitor
 {
 	int tempC = 0;
@@ -113,7 +126,6 @@ public:
 
 	void acceptedStale() { acceptedStales++; }
 	void rejectedStale() { rejectedStales++; }
-
 
 	void reset() { accepts = rejects = failures = acceptedStales = rejectedStales = 0; }
 
@@ -192,9 +204,8 @@ public:
 
 	void resetHashCount() { m_hashCount.store(0, std::memory_order_relaxed); }
 
-	virtual HwMonitor hwmon() = 0;
-
 	unsigned Index() { return index; };
+	HwMonitorInfo hwmonInfo() { return m_hwmoninfo; }
 
 	uint64_t get_start_nonce()
 	{
@@ -221,7 +232,7 @@ protected:
 	const size_t index = 0;
 	FarmFace& farm;
 	std::chrono::high_resolution_clock::time_point workSwitchStart;
-
+	HwMonitorInfo m_hwmoninfo;
 private:
 	std::atomic<uint64_t> m_hashCount = {0};
 

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -72,8 +72,8 @@ enum class HwMonitorInfoType
 
 struct HwMonitorInfo
 {
-	HwMonitorInfoType deviceType;
-	int deviceIndex;
+	HwMonitorInfoType deviceType = HwMonitorInfoType::UNKNOWN;
+	int deviceIndex = -1;
 };
 
 struct HwMonitor

--- a/libhwmon/wrapadl.cpp
+++ b/libhwmon/wrapadl.cpp
@@ -70,11 +70,11 @@ return NULL;
 		wrap_dlsym(adlh->adl_dll, "ADL_Overdrive5_FanSpeed_Get");
 	adlh->adlMainControlRefresh = (wrap_adlReturn_t(*)(void))
 		wrap_dlsym(adlh->adl_dll, "ADL_Main_Control_Refresh");
-	adlh->adlMainControlDestory = (wrap_adlReturn_t(*)(void))
+	adlh->adlMainControlDestroy = (wrap_adlReturn_t(*)(void))
 		wrap_dlsym(adlh->adl_dll, "ADL_Main_Control_Destroy");
 
 	if (adlh->adlMainControlCreate == NULL ||
-		adlh->adlMainControlDestory == NULL ||
+		adlh->adlMainControlDestroy == NULL ||
 		adlh->adlMainControlRefresh == NULL ||
 		adlh->adlAdapterNumberOfAdapters == NULL ||
 		adlh->adlAdapterAdapterInfoGet == NULL ||
@@ -131,9 +131,9 @@ return NULL;
 	return adlh;
 }
 
-int wrap_adl_destory(wrap_adl_handle *adlh)
+int wrap_adl_destroy(wrap_adl_handle *adlh)
 {
-	adlh->adlMainControlDestory();
+	adlh->adlMainControlDestroy();
 	wrap_dlclose(adlh->adl_dll);
 	free(adlh);
 	return 0;

--- a/libhwmon/wrapadl.h
+++ b/libhwmon/wrapadl.h
@@ -118,11 +118,11 @@ typedef struct {
 	wrap_adlReturn_t(*adlOverdrive5TemperatureGet)(int, int, ADLTemperature*);
 	wrap_adlReturn_t(*adlOverdrive5FanSpeedGet)(int, int, ADLFanSpeedValue*);
 	wrap_adlReturn_t(*adlMainControlRefresh)(void);
-	wrap_adlReturn_t(*adlMainControlDestory)(void);
+	wrap_adlReturn_t(*adlMainControlDestroy)(void);
 } wrap_adl_handle;
 
 wrap_adl_handle * wrap_adl_create();
-int wrap_adl_destory(wrap_adl_handle *adlh);
+int wrap_adl_destroy(wrap_adl_handle *adlh);
 
 int wrap_adl_get_gpucount(wrap_adl_handle *adlh, int *gpucount);
 

--- a/libhwmon/wrapamdsysfs.cpp
+++ b/libhwmon/wrapamdsysfs.cpp
@@ -49,6 +49,7 @@ wrap_amdsysfs_handle * wrap_amdsysfs_create()
 
 	unsigned int gpucount = 0;
 	struct dirent* dire;
+	errno = 0;
 	while ((dire = readdir(dirp)) != nullptr)
 	{
 		if (::strncmp(dire->d_name, "card", 4) != 0)

--- a/libhwmon/wrapamdsysfs.cpp
+++ b/libhwmon/wrapamdsysfs.cpp
@@ -144,7 +144,7 @@ wrap_amdsysfs_handle * wrap_amdsysfs_create()
 
 	return sysfsh;
 }
-int wrap_amdsysfs_destory(wrap_amdsysfs_handle *sysfsh)
+int wrap_amdsysfs_destroy(wrap_amdsysfs_handle *sysfsh)
 {
 	free(sysfsh);
 	return 0;

--- a/libhwmon/wrapamdsysfs.h
+++ b/libhwmon/wrapamdsysfs.h
@@ -13,7 +13,7 @@ typedef struct {
 } wrap_amdsysfs_handle;
 
 wrap_amdsysfs_handle * wrap_amdsysfs_create();
-int wrap_amdsysfs_destory(wrap_amdsysfs_handle *sysfsh);
+int wrap_amdsysfs_destroy(wrap_amdsysfs_handle *sysfsh);
 
 int wrap_amdsysfs_get_gpucount(wrap_amdsysfs_handle *sysfsh, int *gpucount);
 

--- a/libhwmon/wrapnvml.cpp
+++ b/libhwmon/wrapnvml.cpp
@@ -125,7 +125,6 @@ return NULL;
 #endif
   nvmlh->devs = (wrap_nvmlDevice_t *) calloc(nvmlh->nvml_gpucount, sizeof(wrap_nvmlDevice_t));
 
-#if ETH_ETHASHCUDA
   nvmlh->nvml_pci_domain_id = (unsigned int*) calloc(nvmlh->nvml_gpucount, sizeof(unsigned int));
   nvmlh->nvml_pci_bus_id = (unsigned int*) calloc(nvmlh->nvml_gpucount, sizeof(unsigned int));
   nvmlh->nvml_pci_device_id = (unsigned int*) calloc(nvmlh->nvml_gpucount, sizeof(unsigned int));
@@ -151,6 +150,7 @@ return NULL;
   for (int i=0; i<nvmlh->nvml_gpucount; i++) {
     nvmlh->nvml_cuda_device_id[i] = -1;
   }
+#if ETH_ETHASHCUDA
   for (int i=0; i<nvmlh->cuda_gpucount; i++) {
     cudaDeviceProp props;
     nvmlh->cuda_nvml_device_id[i] = -1;


### PR DESCRIPTION
This should fix problems with ADL, which does not like using multiple instances of the driver interface. #541

I also changed the nvml wrapper to work without CUDA, so if you want to use nvidia with ocl and have access to HWMON you now can, without the need to compile with CUDA.

Possible also fixes some problems with mixed cards, but i'm not sure. or other hwmon problems. #540

I also had no time actually testing this, that much.