### PR TITLE
Fixes #624 and others.

### DIFF
--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -29,7 +29,8 @@ static void diffToTarget(uint32_t *target, double diff)
 
 EthStratumClient::EthStratumClient(Farm* f, MinerType m, string const & host, string const & port, string const & user, string const & pass, int const & retries, int const & worktimeout, int const & protocol, string const & email)
         :       m_socket(m_io_service),
-	        m_worktimer(m_io_service)
+	        m_worktimer(m_io_service),
+	        m_resolver(m_io_service)
 {
 	m_minerType = m;
 	m_primary.host = host;
@@ -74,10 +75,9 @@ void EthStratumClient::setFailover(string const & host, string const & port, str
 
 void EthStratumClient::connect()
 {
-	tcp::resolver r(m_io_service);
 	tcp::resolver::query q(p_active->host, p_active->port);
 	
-	r.async_resolve(q, boost::bind(&EthStratumClient::resolve_handler,
+	m_resolver.async_resolve(q, boost::bind(&EthStratumClient::resolve_handler,
 					this, boost::asio::placeholders::error,
 					boost::asio::placeholders::iterator));
 

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -76,6 +76,8 @@ private:
 
 	boost::asio::deadline_timer m_worktimer;
 
+	boost::asio::ip::tcp::resolver m_resolver;
+
 	int m_protocol;
 	string m_email;
 


### PR DESCRIPTION
Local `boost::asio::ip::tcp::resolver` instance was destroyed before the request is finished, resulting in "Operation cancelled" error.