### PR TITLE
Fix: Failover exit when option `-FS exit` is given

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -951,7 +951,7 @@ private:
 				client.reconnect();
 			});
 
-			while (g_running)
+			while (client.isRunning())
 			{
 				auto mp = f.miningProgress(m_show_hwmonitors);
 				if (client.isConnected())

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -93,7 +93,7 @@ void CUDAMiner::workLoop()
 
 	try
 	{
-		while(true)
+		while(!shouldStop())
 		{
 	                // take local copy of work since it may end up being overwritten.
 			const WorkPackage w = work();
@@ -119,10 +119,6 @@ void CUDAMiner::workLoop()
 				startN = current.startNonce | ((uint64_t)index << (64 - LOG2_MAX_MINERS - current.exSizeBits));
 			}
 			search(current.header.data(), upper64OfBoundary, (current.exSizeBits >= 0), startN, w);
-
-			// Check if we should stop.
-			if (shouldStop())
-				break;
 		}
 	}
 	catch (cuda_runtime_error const& _e)

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -147,6 +147,14 @@ public:
 	{
 		{
 			Guard l(x_minerWork);
+			// miners do not get deleted (->destructed->stopped) by clearing vector,
+			// m_miners vector contains shared_ptr objects, those are not freed on clear
+			for (auto const& m : m_miners)
+			{
+				// call destructor functions
+				m->stopWorking();
+				//m->kick_miner();
+			}
 			m_miners.clear();
 			m_isMining = false;
 		}

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -56,6 +56,7 @@ EthStratumClient::EthStratumClient(Farm* f, MinerType m, string const & host, st
 
 EthStratumClient::~EthStratumClient()
 {
+	m_running = false;
 	m_io_service.stop();
 	m_serviceThread.join();
 }
@@ -145,6 +146,7 @@ void EthStratumClient::disconnect()
 	}
 	m_socket.close();
 	m_io_service.stop();
+	m_running = false;
 }
 
 void EthStratumClient::resolve_handler(const boost::system::error_code& ec, tcp::resolver::iterator i)
@@ -168,6 +170,7 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec, tcp:
 	
 	if (!ec)
 	{
+		m_running = true;
 		m_connected.store(true, std::memory_order_relaxed);
 		cnote << "Connected to stratum server " + i->host_name() + ":" + p_active->port;
 		if (!p_farm->isMining())

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -27,6 +27,7 @@ public:
 	void setFailover(string const & host, string const & port);
 	void setFailover(string const & host, string const & port, string const & user, string const & pass);
 
+	bool isRunning() { return m_running; }
 	bool isConnected() { return m_connected.load(std::memory_order_relaxed) && m_authorized; }
 	h256 currentHeaderHash() { return m_current.header; }
 	bool current() { return static_cast<bool>(m_current); }
@@ -56,6 +57,7 @@ private:
 
 	bool m_authorized;
 	std::atomic<bool> m_connected = {false};
+	bool m_running = true;
 
 	int	m_retries = 0;
 	int	m_maxRetries;


### PR DESCRIPTION
This addresses issues #425 (closed) #652 (closed) #672 (feature request). However, there could be other issues related to the mentioned bugs. For details see original comment.