### PR TITLE
Minor change to EthStratumClient::resolve_handler 

### DIFF
--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -151,7 +151,8 @@ void EthStratumClient::resolve_handler(const boost::system::error_code& ec, tcp:
 {
 	if (!ec)
 	{
-		async_connect(m_socket, i, boost::bind(&EthStratumClient::connect_handler,
+		tcp::resolver::iterator end;
+		async_connect(m_socket, i, end, boost::bind(&EthStratumClient::connect_handler,
 						this, boost::asio::placeholders::error,
 						boost::asio::placeholders::iterator));
 	}


### PR DESCRIPTION
Minor change to EthStratumClient::resolve_handler in attempt to iterate through all resolved IPs if one fails.   Current behaviour does not appear to do so. Change builds & runs fine. 
Based on boost async_connect example code.
