### PR TITLE
Reworked StratumClient to work with PoolManager

### DIFF
--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -210,9 +210,6 @@ public:
 	 */
 	void restart()
 	{
-		stop();
-		start(m_lastSealer, b_lastMixed);
-		
 		if (m_onMinerRestart) {
 			m_onMinerRestart();
 		}

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -27,31 +27,20 @@ static void diffToTarget(uint32_t *target, double diff)
 }
 
 
-EthStratumClient::EthStratumClient(Farm* f, MinerType m, string const & host, string const & port, string const & user, string const & pass, int const & retries, int const & worktimeout, int const & protocol, string const & email)
-        :       m_socket(m_io_service),
-	        m_worktimer(m_io_service),
-	        m_resolver(m_io_service)
+EthStratumClient::EthStratumClient(int const & worktimeout, int const & protocol, string const & email, bool const & submitHashrate) : PoolClient(),
+	 m_socket(m_io_service),
+	 m_worktimer(m_io_service),
+	 m_resolver(m_io_service)
 {
-	m_minerType = m;
-	m_primary.host = host;
-	m_primary.port = port;
-	m_primary.user = user;
-	m_primary.pass = pass;
-
-	p_active = &m_primary;
-
 	m_authorized = false;
 	m_pending = 0;
-	m_maxRetries = retries;
 	m_worktimeout = worktimeout;
 
 	m_protocol = protocol;
 	m_email = email;
 
+	m_submit_hashrate = submitHashrate;
 	m_submit_hashrate_id = h256::random().hex();
-	
-	p_farm = f;
-	connect();
 }
 
 EthStratumClient::~EthStratumClient()
@@ -60,30 +49,26 @@ EthStratumClient::~EthStratumClient()
 	m_serviceThread.join();
 }
 
-void EthStratumClient::setFailover(string const & host, string const & port)
-{
-	setFailover(host, port, p_active->user, p_active->pass);
-}
-
-void EthStratumClient::setFailover(string const & host, string const & port, string const & user, string const & pass)
-{
-	m_failover.host = host;
-	m_failover.port = port;
-	m_failover.user = user;
-	m_failover.pass = pass;
-}
-
 void EthStratumClient::connect()
 {
+	m_primary.host = m_host;
+	m_primary.port = m_port;
+	m_primary.user = m_user;
+	m_primary.pass = m_pass;
+	p_active = &m_primary;
+
+	m_authorized = false;
+	m_connected.store(false, std::memory_order_relaxed);
+
 	tcp::resolver::query q(p_active->host, p_active->port);
-	
+
+	//cnote << "Resolving stratum server " + p_active->host + ":" + p_active->port;
+
 	m_resolver.async_resolve(q, boost::bind(&EthStratumClient::resolve_handler,
-					this, boost::asio::placeholders::error,
-					boost::asio::placeholders::iterator));
+		this, boost::asio::placeholders::error,
+		boost::asio::placeholders::iterator));
 
-	cnote << "Connecting to stratum server " + p_active->host + ":" + p_active->port;
-
-	if (m_serviceThread.joinable())
+    if (m_serviceThread.joinable())
 	{
 		// If the service thread have been created try to reset the service.
 		m_io_service.reset();
@@ -97,68 +82,36 @@ void EthStratumClient::connect()
 
 #define BOOST_ASIO_ENABLE_CANCELIO 
 
-void EthStratumClient::reconnect()
+void EthStratumClient::disconnect()
 {
 	m_worktimer.cancel();
 
-	m_io_service.reset();
-	//m_socket.close(); // leads to crashes on Linux
+	m_io_service.stop();
+	m_socket.close();
+
 	m_authorized = false;
 	m_connected.store(false, std::memory_order_relaxed);
-		
-	if (!m_failover.host.empty())
-	{
-		m_retries++;
 
-		if (m_retries > m_maxRetries)
-		{
-			if (m_failover.host == "exit") {
-				disconnect();
-				return;
-			}
-			else if (p_active == &m_primary)
-			{
-				p_active = &m_failover;
-			}
-			else {
-				p_active = &m_primary;
-			}
-			m_retries = 0;
-		}
+	if (m_onDisconnected) {
+		m_onDisconnected();
 	}
-	
-	cnote << "Reconnecting in 3 seconds...";
-	boost::asio::deadline_timer timer(m_io_service, boost::posix_time::seconds(3));
-	timer.wait();
-
-	connect();
-}
-
-void EthStratumClient::disconnect()
-{
-	cnote << "Disconnecting";
-	m_connected.store(false, std::memory_order_relaxed);
-	if (p_farm->isMining())
-	{
-		cnote << "Stopping farm";
-		p_farm->stop();
-	}
-	m_socket.close();
-	m_io_service.stop();
 }
 
 void EthStratumClient::resolve_handler(const boost::system::error_code& ec, tcp::resolver::iterator i)
 {
 	if (!ec)
 	{
-		async_connect(m_socket, i, boost::bind(&EthStratumClient::connect_handler,
+		//cnote << "Connecting to stratum server " + p_active->host + ":" + p_active->port;
+
+		tcp::resolver::iterator end;
+		async_connect(m_socket, i, end, boost::bind(&EthStratumClient::connect_handler,
 						this, boost::asio::placeholders::error,
 						boost::asio::placeholders::iterator));
 	}
 	else
 	{
 		cerr << "Could not resolve host " << p_active->host + ":" + p_active->port + ", " << ec.message();
-		reconnect();
+		disconnect();
 	}
 }
 
@@ -169,19 +122,12 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec, tcp:
 	if (!ec)
 	{
 		m_connected.store(true, std::memory_order_relaxed);
-		cnote << "Connected to stratum server " + i->host_name() + ":" + p_active->port;
-		if (!p_farm->isMining())
-		{
-			cnote << "Starting farm";
-			if (m_minerType == MinerType::CL)
-				p_farm->start("opencl", false);
-			else if (m_minerType == MinerType::CUDA)
-				p_farm->start("cuda", false);
-			else if (m_minerType == MinerType::Mixed) {
-				p_farm->start("cuda", false);
-				p_farm->start("opencl", true);
-			}
+
+		//cnote << "Connected to stratum server " + i->host_name() + ":" + p_active->port;
+		if (m_onConnected) {
+			m_onConnected();
 		}
+
 		std::ostream os(&m_requestBuffer);
 
 		string user;
@@ -189,6 +135,7 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec, tcp:
 
 		switch (m_protocol) {
 			case STRATUM_PROTOCOL_STRATUM:
+				m_authorized = true;
 				os << "{\"id\": 1, \"method\": \"mining.subscribe\", \"params\": []}\n";
 				break;
 			case STRATUM_PROTOCOL_ETHPROXY:
@@ -209,6 +156,7 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec, tcp:
 				}
 				break;
 			case STRATUM_PROTOCOL_ETHEREUMSTRATUM:
+				m_authorized = true;
 				os << "{\"id\": 1, \"method\": \"mining.subscribe\", \"params\": [\"ethminer/" << ETH_PROJECT_VERSION << "\",\"EthereumStratum/1.0.0\"]}\n";
 				break;
 		}
@@ -220,7 +168,7 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec, tcp:
 	else
 	{
 		cwarn << "Could not connect to stratum server " + p_active->host + ":" + p_active->port + ", " + ec.message();
-		reconnect();
+		disconnect();
 	}
 
 }
@@ -287,7 +235,7 @@ void EthStratumClient::readResponse(const boost::system::error_code& ec, std::si
 	{
 		cwarn << "Read response failed: " + ec.message();
 		if (m_connected.load(std::memory_order_relaxed))
-			reconnect();
+			disconnect();
 	}
 }
 
@@ -355,15 +303,15 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
 		break;
 	case 4:
 		{
-			using namespace std::chrono;
-			auto ms = duration_cast<milliseconds>(steady_clock::now() - m_submit_time);
 			if (responseObject.get("result", false).asBool()) {
-				cnote << EthLime "**Accepted" EthReset " in" << ms.count() << "ms.";
-				p_farm->acceptedSolution(m_stale);
+				if (m_onSolutionAccepted) {
+					m_onSolutionAccepted(m_stale);
+				}
 			}
 			else {
-				cwarn << EthRed "**Rejected" EthReset " in" << ms.count() << "ms.";
-				p_farm->rejectedSolution(m_stale);
+				if (m_onSolutionRejected) {
+					m_onSolutionRejected(m_stale);
+				}
 			}
 		}
 		break;
@@ -412,8 +360,9 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
 							job.resize(64, '0');
 						m_current.job = h256(job);
 
-						p_farm->setWork(m_current);
-						cnote << "Received new job #" EthWhite + job.substr(0, m_current.job_len) + EthReset;
+						if (m_onWorkReceived) {
+							m_onWorkReceived(m_current);
+						}
 					}
 				}
 				else
@@ -443,8 +392,9 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
 							m_current.boundary = h256(sShareTarget);
 							m_current.job = h256(job);
 
-							p_farm->setWork(m_current);
-							cnote << "Received new job #" EthWhite + job.substr(0, m_current.job_len) + EthReset;
+							if (m_onWorkReceived) {
+								m_onWorkReceived(m_current);
+							}
 						}
 					}
 				}
@@ -484,20 +434,23 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
 void EthStratumClient::work_timeout_handler(const boost::system::error_code& ec) {
 	if (!ec) {
 		cnote << "No new work received in " << m_worktimeout << " seconds.";
-		reconnect();
+		disconnect();
 	}
 }
 
-bool EthStratumClient::submitHashrate(string const & rate) {
+void EthStratumClient::submitHashrate(string const & rate) {
+	if (!m_submit_hashrate || !m_connected.load(std::memory_order_relaxed)) {
+		return;
+	}
+
 	// There is no stratum method to submit the hashrate so we use the rpc variant.
 	string json = "{\"id\": 6, \"jsonrpc\":\"2.0\", \"method\": \"eth_submitHashrate\", \"params\": [\"" + rate + "\",\"0x" + this->m_submit_hashrate_id + "\"]}\n";
 	std::ostream os(&m_requestBuffer);
 	os << json;
 	write(m_socket, m_requestBuffer);
-	return true;
 }
 
-void EthStratumClient::submit(Solution solution) {
+void EthStratumClient::submitSolution(Solution solution) {
 
 	string nonceHex = toHex(solution.nonce);
 	string json;
@@ -527,16 +480,5 @@ void EthStratumClient::submit(Solution solution) {
 	async_write(m_socket, m_requestBuffer,
 		boost::bind(&EthStratumClient::handleResponse, this,
 		boost::asio::placeholders::error));
-	m_submit_time = std::chrono::steady_clock::now();
-	unsigned n = (m_protocol == STRATUM_PROTOCOL_ETHEREUMSTRATUM) ? m_extraNonceHexSize : 0;
-	string sub_nonce = nonceHex.substr(n, 16 - n);
-	if (m_stale)
-	{
-		cwarn << string(EthYellow "Stale nonce 0x") + sub_nonce + " submitted to " + p_active->host + EthReset;
-	}
-	else
-	{
-		cnote << string("Nonce 0x") +  sub_nonce + " submitted to " + p_active->host;
-	}
 }
 

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -10,6 +10,7 @@
 #include <libethcore/Farm.h>
 #include <libethcore/EthashAux.h>
 #include <libethcore/Miner.h>
+#include "../PoolClient.h"
 #include "BuildInfo.h"
 
 
@@ -18,24 +19,24 @@ using namespace dev;
 using namespace dev::eth;
 
 
-class EthStratumClient
+class EthStratumClient : public PoolClient
 {
 public:
-	EthStratumClient(Farm* f, MinerType m, string const & host, string const & port, string const & user, string const & pass, int const & retries, int const & worktimeout, int const & protocol, string const & email);
+	EthStratumClient(int const & worktimeout, int const & protocol, string const & email, bool const & submitHashrate);
 	~EthStratumClient();
 
-	void setFailover(string const & host, string const & port);
-	void setFailover(string const & host, string const & port, string const & user, string const & pass);
-
-	bool isConnected() { return m_connected.load(std::memory_order_relaxed) && m_authorized; }
-	h256 currentHeaderHash() { return m_current.header; }
-	bool current() { return static_cast<bool>(m_current); }
-	bool submitHashrate(string const & rate);
-	void submit(Solution solution);
-	void reconnect();
-private:
 	void connect();
 	void disconnect();
+	
+	bool isConnected() { return m_connected.load(std::memory_order_relaxed) && m_authorized; }
+	
+	void submitHashrate(string const & rate);
+	void submitSolution(Solution solution);
+
+	h256 currentHeaderHash() { return m_current.header; }
+	bool current() { return static_cast<bool>(m_current); }
+
+private:
 
 	void resolve_handler(const boost::system::error_code& ec, boost::asio::ip::tcp::resolver::iterator i);
 	void connect_handler(const boost::system::error_code& ec, boost::asio::ip::tcp::resolver::iterator i);
@@ -45,8 +46,6 @@ private:
 	void handleResponse(const boost::system::error_code& ec);
 	void readResponse(const boost::system::error_code& ec, std::size_t bytes_transferred);
 	void processReponse(Json::Value& responseObject);
-	
-	MinerType m_minerType;
 
 	cred_t * p_active;
 	cred_t m_primary;
@@ -57,14 +56,11 @@ private:
 	bool m_authorized;
 	std::atomic<bool> m_connected = {false};
 
-	int	m_retries = 0;
-	int	m_maxRetries;
 	int m_worktimeout = 60;
 
 	std::mutex x_pending;
 	int m_pending;
 
-	Farm* p_farm;
 	WorkPackage m_current;
 
 	bool m_stale = false;
@@ -88,9 +84,8 @@ private:
 	h64 m_extraNonce;
 	int m_extraNonceHexSize;
 	
+	bool m_submit_hashrate = false;
 	string m_submit_hashrate_id;
 
 	void processExtranonce(std::string& enonce);
-
-	std::chrono::steady_clock::time_point m_submit_time;
 };


### PR DESCRIPTION
* Adapted StartumClient to use PoolClient interface to work with PoolManager
* Deactivated stopping farm on "restartMiner" RPC command, which leaded to crashes/bugs. Needs a separate fix, see #744 and others. In fact, deactivated command alltogether
* Don't shutdown miner on disconnect, same as on restart miner, farm.stop is broken. But should be added back once farm.stop/pause  works again. see #734
* PoolManager now sets the active pool connection to farm.setPoolAddresses
* Does not contain a fix for ``-FS exit`` yet