### PR TITLE
added --exit parameter to exit whenever an error occurred

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -253,6 +253,10 @@ public:
 		{
 			m_show_hwmonitors = true;
 		}
+		else if ((arg == "--exit"))
+		{
+			m_exit = true;
+		}
 
 #if API_CORE
 		else if ((arg == "--api-port") && i + 1 < argc)
@@ -557,7 +561,8 @@ public:
 					m_openclPlatform,
 					0,
 					m_dagLoadMode,
-					m_dagCreateDevice
+					m_dagCreateDevice,
+					m_exit
 				))
 				exit(1);
 			CLMiner::setNumInstances(m_miningThreads);
@@ -584,7 +589,8 @@ public:
 				0,
 				m_dagLoadMode,
 				m_dagCreateDevice,
-				m_cudaNoEval
+				m_cudaNoEval,
+				m_exit
 				))
 				exit(1);
 
@@ -626,6 +632,7 @@ public:
 			<< "        2: EthereumStratum/1.0.0: nicehash" << endl
 			<< "    -RH, --report-hashrate Report current hashrate to pool (please only enable on pools supporting this)" << endl
 			<< "    -HWMON Displays gpu temp and fan percent." << endl
+			<< "    --exit Stops the miner whenever an error is encountered" << endl
 			<< "    -SE, --stratum-email <s> Email address used in eth-proxy (optional)" << endl
 			<< "    --farm-recheck <n>  Leave n ms between checks for changed work (default: 500). When using stratum, use a high value (i.e. 2000) to get more stable hashrate output" << endl
 			<< endl
@@ -927,6 +934,7 @@ private:
 #endif
 	unsigned m_dagLoadMode = 0; // parallel
 	unsigned m_dagCreateDevice = 0;
+	bool m_exit = false;
 	/// Benchmarking params
 	unsigned m_benchmarkWarmup = 15;
 	unsigned m_benchmarkTrial = 3;

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -19,6 +19,7 @@ namespace eth
 unsigned CLMiner::s_workgroupSize = CLMiner::c_defaultLocalWorkSize;
 unsigned CLMiner::s_initialGlobalWorkSize = CLMiner::c_defaultGlobalWorkSizeMultiplier * CLMiner::c_defaultLocalWorkSize;
 unsigned CLMiner::s_threadsPerHash = 8;
+bool Miner::s_exit = false;
 CLKernelName CLMiner::s_clKernelName = CLMiner::c_defaultKernelName;
 
 constexpr size_t c_maxSearchResults = 1;
@@ -393,6 +394,8 @@ void CLMiner::workLoop()
 	catch (cl::Error const& _e)
 	{
 		cwarn << ethCLErrorHelper("OpenCL Error", _e);
+		if(s_exit)
+			exit(1);
 	}
 }
 
@@ -459,11 +462,13 @@ bool CLMiner::configureGPU(
 	unsigned _platformId,
 	uint64_t _currentBlock,
 	unsigned _dagLoadMode,
-	unsigned _dagCreateDevice
+	unsigned _dagCreateDevice,
+	bool _exit
 )
 {
 	s_dagLoadMode = _dagLoadMode;
 	s_dagCreateDevice = _dagCreateDevice;
+	s_exit = _exit;
 
 	s_platformId = _platformId;
 
@@ -710,6 +715,8 @@ bool CLMiner::init(const h256& seed)
 	catch (cl::Error const& err)
 	{
 		cwarn << ethCLErrorHelper("OpenCL init failed", err);
+		if(s_exit)
+			exit(1);
 		return false;
 	}
 	return true;

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -19,7 +19,6 @@ namespace eth
 unsigned CLMiner::s_workgroupSize = CLMiner::c_defaultLocalWorkSize;
 unsigned CLMiner::s_initialGlobalWorkSize = CLMiner::c_defaultGlobalWorkSizeMultiplier * CLMiner::c_defaultLocalWorkSize;
 unsigned CLMiner::s_threadsPerHash = 8;
-bool Miner::s_exit = false;
 CLKernelName CLMiner::s_clKernelName = CLMiner::c_defaultKernelName;
 
 constexpr size_t c_maxSearchResults = 1;

--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -65,7 +65,8 @@ public:
 		unsigned _platformId,
 		uint64_t _currentBlock,
 		unsigned _dagLoadMode,
-		unsigned _dagCreateDevice
+		unsigned _dagCreateDevice,
+		bool _exit
 	);
 	static void setNumInstances(unsigned _instances) { s_numInstances = std::min<unsigned>(_instances, getNumDevices()); }
 	static void setThreadsPerHash(unsigned _threadsPerHash){s_threadsPerHash = _threadsPerHash; }

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -81,6 +81,8 @@ bool CUDAMiner::init(const h256& seed)
 	catch (std::runtime_error const& _e)
 	{
 		cwarn << "Error CUDA mining: " << _e.what();
+		if(s_exit)
+			exit(1);
 		return false;
 	}
 }
@@ -134,6 +136,8 @@ void CUDAMiner::workLoop()
 	catch (std::runtime_error const& _e)
 	{
 		cwarn << "Error CUDA mining: " << _e.what();
+		if(s_exit)
+			exit(1);
 	}
 }
 
@@ -193,6 +197,8 @@ void CUDAMiner::listDevices()
 	catch(std::runtime_error const& err)
 	{
 		cwarn << "CUDA error: " << err.what();
+		if(s_exit)
+			exit(1);
 	}
 }
 
@@ -204,11 +210,13 @@ bool CUDAMiner::configureGPU(
 	uint64_t _currentBlock,
 	unsigned _dagLoadMode,
 	unsigned _dagCreateDevice,
-	bool _noeval
+	bool _noeval,
+	bool _exit
 	)
 {
 	s_dagLoadMode = _dagLoadMode;
 	s_dagCreateDevice = _dagCreateDevice;
+	s_exit  = _exit;
 
 	if (!cuda_configureGPU(
 		getNumDevices(),
@@ -282,6 +290,8 @@ bool CUDAMiner::cuda_configureGPU(
 	}
 	catch (runtime_error)
 	{
+		if(s_exit)
+			exit(1);
 		return false;
 	}
 }
@@ -292,6 +302,7 @@ unsigned CUDAMiner::s_gridSize = CUDAMiner::c_defaultGridSize;
 unsigned CUDAMiner::s_numStreams = CUDAMiner::c_defaultNumStreams;
 unsigned CUDAMiner::s_scheduleFlag = 0;
 bool CUDAMiner::s_noeval = false;
+bool Miner::s_exit = false;
 
 bool CUDAMiner::cuda_init(
 	size_t numDevices,
@@ -415,6 +426,8 @@ cpyDag:
 	}
 	catch (runtime_error const&)
 	{
+		if(s_exit)
+			exit(1);
 		return false;
 	}
 }

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -302,7 +302,6 @@ unsigned CUDAMiner::s_gridSize = CUDAMiner::c_defaultGridSize;
 unsigned CUDAMiner::s_numStreams = CUDAMiner::c_defaultNumStreams;
 unsigned CUDAMiner::s_scheduleFlag = 0;
 bool CUDAMiner::s_noeval = false;
-bool Miner::s_exit = false;
 
 bool CUDAMiner::cuda_init(
 	size_t numDevices,

--- a/libethash-cuda/CUDAMiner.h
+++ b/libethash-cuda/CUDAMiner.h
@@ -55,7 +55,8 @@ public:
 		uint64_t _currentBlock,
 		unsigned _dagLoadMode,
 		unsigned _dagCreateDevice,
-		bool _noeval
+		bool _noeval,
+		bool _exit
 		);
 	static void setNumInstances(unsigned _instances);
 	static void setDevices(const vector<unsigned>& _devices, unsigned _selectedDeviceCount);

--- a/libethcore/Miner.cpp
+++ b/libethcore/Miner.cpp
@@ -12,3 +12,5 @@ unsigned dev::eth::Miner::s_dagCreateDevice = 0;
 
 uint8_t* dev::eth::Miner::s_dagInHostMemory = NULL;
 
+bool dev::eth::Miner::s_exit = false;
+

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -228,6 +228,7 @@ protected:
 	static unsigned s_dagLoadIndex;
 	static unsigned s_dagCreateDevice;
 	static uint8_t* s_dagInHostMemory;
+	static bool s_exit;
 
 	const size_t index = 0;
 	FarmFace& farm;


### PR DESCRIPTION
You can now use --exit to shut down the miner whenever an error occurred.
Note, that this is not recommended, and only useful for people with additional software to restart the miner
https://github.com/ethereum-mining/ethminer/issues/97
