### PR TITLE
A simple JSON API format for supporting Power Usage

### DIFF
--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -74,56 +74,23 @@ void ApiServer::getMinerStatHR(const Json::Value& request, Json::Value& response
 	
 	ostringstream version; 
 	ostringstream runtime; 
-	ostringstream ethhashrate; 
-	ostringstream ethshares; 
-	ostringstream ethrejects;  
-	ostringstream ethinvalid; 
-	ostringstream ethpoolsw;
-	ostringstream dcrhashrate; 
-	ostringstream dcrshares; 
-	ostringstream dcrrejects;   
-	ostringstream dcrinvalid; 
-	ostringstream dcrpoolsw;
-	ostringstream totalMhEth; 
-	ostringstream totalMhDcr; 
 	Json::Value detailedMhEth;
 	Json::Value detailedMhDcr;
-	ostringstream detailedMhEthStr;
-	ostringstream detailedMhDcrStr;
 	Json::Value temps;
 	Json::Value fans;
 	Json::Value powers;
-	ostringstream tempStr;
-	ostringstream fanStr;
-	ostringstream powerStr;
 	ostringstream poolAddresses;
-	ostringstream invalidStats;
 	
 	version << ETH_PROJECT_VERSION ;
 	runtime << toString(runningTime.count());
-
-	ethhashrate << std::fixed << std::setprecision(1) << (p.rate() / 1000.0f) << "h/s";
-	ethshares << std::fixed << std::setprecision(1) << s.getAccepts();
-	ethrejects << std::fixed << std::setprecision(1) << s.getRejects();	
-	dcrhashrate << std::fixed << std::setprecision(1) << 0.0 << "h/s"; // Not supported 
-	dcrshares << std::fixed << std::setprecision(1) << 0.0; // Not supported 
-	dcrrejects << std::fixed << std::setprecision(1) << 0.0; // Not supported 
-	ethinvalid << s.getFailures() ; // Invalid 
-	ethpoolsw << 0; // Pool switches
-	dcrinvalid << 0; // Not supported 
-	dcrpoolsw << 0; // Not supported 
     poolAddresses << m_farm.get_pool_addresses(); 
 	
 	int gpuIndex = 0;
 	int numGpus = p.minersHashes.size();
 	for (auto const& i: p.minersHashes)
 	{
-		detailedMhEthStr.str("");
-		detailedMhDcrStr.str("");
-		detailedMhEthStr << std::fixed << std::setprecision(1) << (p.minerRate(i) / 1000.0f) << "h/s";
-		detailedMhDcrStr << "off"; // DualMining not supported
-		detailedMhEth[gpuIndex] = detailedMhEthStr.str();
-		detailedMhDcr[gpuIndex] = detailedMhDcrStr.str();
+		detailedMhEth[gpuIndex] = (p.minerRate(i) / 1000.0f);
+		//detailedMhDcr[gpuIndex] = "off"; //Not supported
 		gpuIndex++;
 	}
 
@@ -131,34 +98,21 @@ void ApiServer::getMinerStatHR(const Json::Value& request, Json::Value& response
 	numGpus = p.minerMonitors.size();
 	for (auto const& i : p.minerMonitors)
 	{
-		tempStr.str("");
-		fanStr.str("");
-		powerStr.str("");
-		tempStr << std::fixed << std::setprecision(1) << i.tempC << "C"; // Fetching Temps 
-		fanStr << std::fixed << std::setprecision(1) << i.fanP << "%"; // Fetching Fans
-		powerStr << std::fixed << std::setprecision(1) << i.powerW << "W"; // Fetching Power
-		temps[gpuIndex] = tempStr.str(); // Fetching Temps 
-		fans[gpuIndex] = fanStr.str(); // Fetching Fans
-		powers[gpuIndex] = powerStr.str(); // Fetching Power
+		temps[gpuIndex] = i.tempC ; // Fetching Temps 
+		fans[gpuIndex] = i.fanP; // Fetching Fans
+		powers[gpuIndex] =  i.powerW; // Fetching Power
 		gpuIndex++;
 	}
 
 	response["version"] = version.str();		// miner version.
 	response["runtime"] = runtime.str();		// running time, in minutes.
 	// total ETH hashrate in MH/s, number of ETH shares, number of ETH rejected shares.
-	response["ethhashrate"] = ethhashrate.str();
+	response["ethhashrate"] = (p.rate() / 1000.0f);
 	response["ethhashrates"] = detailedMhEth;  
-	response["ethshares"] 	= ethshares.str(); 
-	response["ethrejected"] = ethrejects.str();   
-	response["ethinvalid"] 	= ethinvalid.str(); 
-	response["ethpoolsw"] 	= ethpoolsw.str();          
-	// DCR not supported
-	// response["dcrhashrate"] = dcrhashrate.str();
-	// response["dcrhashrates"] = detailedMhDcr;   
-	// response["dcrshares"] 	= dcrshares.str(); 
-	// response["dcrrejected"] = dcrrejects.str();       
-	// response["dcrinvalid"] 	= dcrinvalid.str(); 
-	// response["dcrpoolsw"] 	= dcrpoolsw.str();       
+	response["ethshares"] 	= s.getAccepts(); 
+	response["ethrejected"] = s.getRejects();   
+	response["ethinvalid"] 	= s.getFailures(); 
+	response["ethpoolsw"] 	= 0;             
 	// Hardware Info
 	response["temperatures"] = temps;             		// Temperatures(C) for all GPUs
 	response["fanpercentages"] = fans;             		// Fans speed(%) for all GPUs

--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -89,7 +89,7 @@ void ApiServer::getMinerStatHR(const Json::Value& request, Json::Value& response
 	int numGpus = p.minersHashes.size();
 	for (auto const& i: p.minersHashes)
 	{
-		detailedMhEth[gpuIndex] = (p.minerRate(i) / 1000.0f);
+		detailedMhEth[gpuIndex] = (p.minerRate(i));
 		//detailedMhDcr[gpuIndex] = "off"; //Not supported
 		gpuIndex++;
 	}
@@ -107,7 +107,7 @@ void ApiServer::getMinerStatHR(const Json::Value& request, Json::Value& response
 	response["version"] = version.str();		// miner version.
 	response["runtime"] = runtime.str();		// running time, in minutes.
 	// total ETH hashrate in MH/s, number of ETH shares, number of ETH rejected shares.
-	response["ethhashrate"] = (p.rate() / 1000.0f);
+	response["ethhashrate"] = (p.rate());
 	response["ethhashrates"] = detailedMhEth;  
 	response["ethshares"] 	= s.getAccepts(); 
 	response["ethrejected"] = s.getRejects();   

--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -70,28 +70,60 @@ void ApiServer::getMinerStatHR(const Json::Value& request, Json::Value& response
 	auto runningTime = std::chrono::duration_cast<std::chrono::minutes>(steady_clock::now() - this->m_farm.farmLaunched());
 	
 	SolutionStats s = m_farm.getSolutionStats();
-	WorkingProgress p = m_farm.miningProgress(true);
+	WorkingProgress p = m_farm.miningProgress(true,true);
 	
+	ostringstream version; 
+	ostringstream runtime; 
+	ostringstream ethhashrate; 
+	ostringstream ethshares; 
+	ostringstream ethrejects;  
+	ostringstream ethinvalid; 
+	ostringstream ethpoolsw;
+	ostringstream dcrhashrate; 
+	ostringstream dcrshares; 
+	ostringstream dcrrejects;   
+	ostringstream dcrinvalid; 
+	ostringstream dcrpoolsw;
 	ostringstream totalMhEth; 
 	ostringstream totalMhDcr; 
-	ostringstream detailedMhEth;
-	ostringstream detailedMhDcr;
-	ostringstream tempAndFans;
+	Json::Value detailedMhEth;
+	Json::Value detailedMhDcr;
+	ostringstream detailedMhEthStr;
+	ostringstream detailedMhDcrStr;
+	Json::Value temps;
+	Json::Value fans;
+	Json::Value powers;
+	ostringstream tempStr;
+	ostringstream fanStr;
+	ostringstream powerStr;
 	ostringstream poolAddresses;
 	ostringstream invalidStats;
 	
-	totalMhEth << std::fixed << std::setprecision(0) << (p.rate() / 1000.0f) << ";" << s.getAccepts() << ";" << s.getRejects();
-	totalMhDcr << "0;0;0"; // DualMining not supported
-	invalidStats << s.getFailures() << ";0"; // Invalid + Pool switches
+	version << ETH_PROJECT_VERSION ;
+	runtime << toString(runningTime.count());
+
+	ethhashrate << std::fixed << std::setprecision(1) << (p.rate() / 1000.0f) << "h/s";
+	ethshares << std::fixed << std::setprecision(1) << s.getAccepts();
+	ethrejects << std::fixed << std::setprecision(1) << s.getRejects();	
+	dcrhashrate << std::fixed << std::setprecision(1) << 0.0 << "h/s"; // Not supported 
+	dcrshares << std::fixed << std::setprecision(1) << 0.0; // Not supported 
+	dcrrejects << std::fixed << std::setprecision(1) << 0.0; // Not supported 
+	ethinvalid << s.getFailures() ; // Invalid 
+	ethpoolsw << 0; // Pool switches
+	dcrinvalid << 0; // Not supported 
+	dcrpoolsw << 0; // Not supported 
     poolAddresses << m_farm.get_pool_addresses(); 
-	invalidStats << ";0;0"; // DualMining not supported
 	
 	int gpuIndex = 0;
 	int numGpus = p.minersHashes.size();
 	for (auto const& i: p.minersHashes)
 	{
-		detailedMhEth << std::fixed << std::setprecision(0) << (p.minerRate(i) / 1000.0f) << (((numGpus -1) > gpuIndex) ? ";" : "");
-		detailedMhDcr << "off" << (((numGpus -1) > gpuIndex) ? ";" : ""); // DualMining not supported
+		detailedMhEthStr.str("");
+		detailedMhDcrStr.str("");
+		detailedMhEthStr << std::fixed << std::setprecision(1) << (p.minerRate(i) / 1000.0f) << "h/s";
+		detailedMhDcrStr << "off"; // DualMining not supported
+		detailedMhEth[gpuIndex] = detailedMhEthStr.str();
+		detailedMhDcr[gpuIndex] = detailedMhDcrStr.str();
 		gpuIndex++;
 	}
 
@@ -99,19 +131,39 @@ void ApiServer::getMinerStatHR(const Json::Value& request, Json::Value& response
 	numGpus = p.minerMonitors.size();
 	for (auto const& i : p.minerMonitors)
 	{
-		tempAndFans << i.tempC << "C;" << i.fanP << "%;" << i.powerW << (((numGpus - 1) > gpuIndex) ? "W; " : "W"); // Fetching Temp and Fans
+		tempStr.str("");
+		fanStr.str("");
+		powerStr.str("");
+		tempStr << std::fixed << std::setprecision(1) << i.tempC << "C"; // Fetching Temps 
+		fanStr << std::fixed << std::setprecision(1) << i.fanP << "%"; // Fetching Fans
+		powerStr << std::fixed << std::setprecision(1) << i.powerW << "W"; // Fetching Power
+		temps[gpuIndex] = tempStr.str(); // Fetching Temps 
+		fans[gpuIndex] = fanStr.str(); // Fetching Fans
+		powers[gpuIndex] = powerStr.str(); // Fetching Power
 		gpuIndex++;
 	}
 
-	response[0] = ETH_PROJECT_VERSION;           // miner version.
-	response[1] = toString(runningTime.count()); // running time, in minutes.
-	response[2] = totalMhEth.str();              // total ETH hashrate in MH/s, number of ETH shares, number of ETH rejected shares.
-	response[3] = detailedMhEth.str();           // detailed ETH hashrate for all GPUs.
-	response[4] = totalMhDcr.str();              // total DCR hashrate in MH/s, number of DCR shares, number of DCR rejected shares.
-	response[5] = detailedMhDcr.str();           // detailed DCR hashrate for all GPUs.
-	response[6] = tempAndFans.str();             // Temperature(C), Fan speed(%) and Power Usage(W) for all GPUs.
-	response[7] = poolAddresses.str();           // current mining pool. For dual mode, there will be two pools here.
-	response[8] = invalidStats.str();            // number of ETH invalid shares, number of ETH pool switches, number of DCR invalid shares, number of DCR pool switches.
+	response["version"] = version.str();		// miner version.
+	response["runtime"] = runtime.str();		// running time, in minutes.
+	// total ETH hashrate in MH/s, number of ETH shares, number of ETH rejected shares.
+	response["ethhashrate"] = ethhashrate.str();
+	response["ethhashrates"] = detailedMhEth;  
+	response["ethshares"] 	= ethshares.str(); 
+	response["ethrejected"] = ethrejects.str();   
+	response["ethinvalid"] 	= ethinvalid.str(); 
+	response["ethpoolsw"] 	= ethpoolsw.str();          
+	// DCR not supported
+	// response["dcrhashrate"] = dcrhashrate.str();
+	// response["dcrhashrates"] = detailedMhDcr;   
+	// response["dcrshares"] 	= dcrshares.str(); 
+	// response["dcrrejected"] = dcrrejects.str();       
+	// response["dcrinvalid"] 	= dcrinvalid.str(); 
+	// response["dcrpoolsw"] 	= dcrpoolsw.str();       
+	// Hardware Info
+	response["temperatures"] = temps;             		// Temperatures(C) for all GPUs
+	response["fanpercentages"] = fans;             		// Fans speed(%) for all GPUs
+	response["powerusages"] = powers;         			// Power Usages(W) for all GPUs
+	response["pooladdrs"] = poolAddresses.str();        // current mining pool. For dual mode, there will be two pools here.
 }
 
 void ApiServer::doMinerRestart(const Json::Value& request, Json::Value& response)

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -267,7 +267,6 @@ public:
 						wrap_nvml_get_fanpcnt(nvmlh, hwInfo.deviceIndex, &fanpcnt);
 						if(power) {
 							wrap_nvml_get_power_usage(nvmlh, hwInfo.deviceIndex, &powerW);
-							hw.powerW = powerW/((double)1000.0);
 						}
 					}
 					else if (hwInfo.deviceType == HwMonitorInfoType::AMD && adlh) {
@@ -275,7 +274,6 @@ public:
 						wrap_adl_get_fanpcnt(adlh, hwInfo.deviceIndex, &fanpcnt);
 						if(power) {
 							wrap_adl_get_power_usage(adlh, hwInfo.deviceIndex, &powerW);
-							hw.powerW = powerW/((double)1000.0);
 						}
 					}
 #if defined(__linux)
@@ -285,13 +283,13 @@ public:
 						wrap_amdsysfs_get_fanpcnt(sysfsh, hwInfo.deviceIndex, &fanpcnt);
 						if(power) {
 							wrap_amdsysfs_get_power_usage(sysfsh, hwInfo.deviceIndex, &powerW);
-							hw.powerW = powerW/((double)1000.0);
 						}
 					}
 #endif
 				}
 				hw.tempC = tempC;
 				hw.fanP = fanpcnt;
+				hw.powerW = powerW/((double)1000.0);
 				p.minerMonitors.push_back(hw);
 			}
         }

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -88,7 +88,7 @@ inline std::ostream& operator<<(std::ostream& os, HwMonitor _hw)
 	string power = "";
 	if(_hw.powerW != 0){
 		ostringstream stream;
-		stream << fixed << setprecision(2) << _hw.powerW << "W";
+		stream << fixed << setprecision(0) << _hw.powerW << "W";
 		power = stream.str();
 	}
 	return os << _hw.tempC << "C " << _hw.fanP << "% " << power;


### PR DESCRIPTION
Hello,

I worked on the API method for getting the power usage, I created my output format as simple as I could:

{
    "ethhashrate":"336745.9h/s",
    "ethhashrates":["20692.1h/s","21007.2h/s","21007.2h/s","21007.2h/s","21112.3h/s","21322.3h/s","21427.4h/s","21217.3h/s","21217.3h/s","20482.1h/s","21322.3h/s","21112.3h/s","21112.3h/s","20692.1h/s","21217.3h/s","20797.2h/s"],
    "ethinvalid":"0",
    "ethpoolsw":"0",
    "ethrejected":"0",
    "ethshares":"2",
    "fanpercentages":["66%","64%","70%","68%","66%","66%","74%","64%","70%","70%","66%","70%","70%","70%","70%","70%"],
    "pooladdrs":"us1.ethermine.org:4444",
    "powerusages":["73.6W","74.1W","74.6W","74.6W","74.2W","74.9W","74.6W","74.6W","74.8W","74.6W","74.4W","74.6W","74.7W","74.2W","73.6W","74.0W"],"runtime":"0","temperatures":["53C","52C","55C","54C","53C","53C","56C","52C","55C","55C","53C","55C","55C","55C","55C","55C"],
    "version":"0.14.0.dev1"
}

Let me know if you want to change something