### PR TITLE
OpenCl and CUDA - Display consistent log output

### DIFF
--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -44,7 +44,7 @@ void help()
 	MinerCLI::streamHelp(cout);
 	cout
 		<< " General Options:" << endl
-		<< "    -v,--verbosity <0 - 9>  Set the log verbosity from 0 to 9 (default: 8)." << endl
+		<< "    -v,--verbosity <0 - 9>  Set the log verbosity from 0 to 9 (default: 5). Set to 9 for switch time logging." << endl
 		<< "    -V,--version  Show the version and exit." << endl
 		<< "    -h,--help  Show this help message and exit." << endl
 		<< " Envionment variables:" << endl

--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -63,19 +63,22 @@ LogOutputStreamBase::LogOutputStreamBase(char const* _id, std::type_info const* 
 	m_autospacing(_autospacing),
 	m_verbosity(_v)
 {
-	Guard l(x_logOverride);
-	auto it = s_logOverride.find(_info);
-	if ((it != s_logOverride.end() && it->second) || (it == s_logOverride.end() && (int)_v <= g_logVerbosity))
+	if ((int)_v <= g_logVerbosity)
 	{
-		time_t rawTime = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-		char buf[24];
-		if (strftime(buf, 24, "%X", localtime(&rawTime)) == 0)
-			buf[0] = '\0'; // empty if case strftime fails
-		static char const* c_begin = "  " EthViolet;
-		static char const* c_sep1 = EthReset EthBlack "|" EthNavy;
-		static char const* c_sep2 = EthReset EthBlack "|" EthTeal;
-		static char const* c_end = EthReset "  ";
-		m_sstr << _id << c_begin << buf << c_sep1 << std::left << std::setw(8) << getThreadName() << c_sep2 << c_end;
+		Guard l(x_logOverride);
+		auto it = s_logOverride.find(_info);
+		if ((it != s_logOverride.end() && it->second) || it == s_logOverride.end())
+		{
+			time_t rawTime = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+			char buf[24];
+			if (strftime(buf, 24, "%X", localtime(&rawTime)) == 0)
+				buf[0] = '\0'; // empty if case strftime fails
+			static char const* c_begin = "  " EthViolet;
+			static char const* c_sep1 = EthReset EthBlack "|" EthNavy;
+			static char const* c_sep2 = EthReset EthBlack "|" EthTeal;
+			static char const* c_end = EthReset "  ";
+			m_sstr << _id << c_begin << buf << c_sep1 << std::left << std::setw(8) << getThreadName() << c_sep2 << c_end;
+		}
 	}
 }
 

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -29,7 +29,14 @@ struct CLChannel: public LogChannel
 	static const int verbosity = 2;
 	static const bool debug = false;
 };
+struct CLSwitchChannel: public LogChannel
+{
+	static const char* name() { return EthOrange " cl"; }
+	static const int verbosity = 6;
+	static const bool debug = false;
+};
 #define cllog clog(CLChannel)
+#define clswitchlog clog(CLSwitchChannel)
 #define ETHCL_LOG(_contents) cllog << _contents
 
 /**
@@ -286,7 +293,7 @@ void CLMiner::workLoop()
 			if (current.header != w.header)
 			{
 				// New work received. Update GPU data.
-				auto localSwitchStart = std::chrono::high_resolution_clock::now();
+				auto switchStart = std::chrono::high_resolution_clock::now();
 
 				if (!w)
 				{
@@ -330,10 +337,9 @@ void CLMiner::workLoop()
 				else
 					startNonce = get_start_nonce();
 
-				auto switchEnd = std::chrono::high_resolution_clock::now();
-				auto globalSwitchTime = std::chrono::duration_cast<std::chrono::milliseconds>(switchEnd - workSwitchStart).count();
-				auto localSwitchTime = std::chrono::duration_cast<std::chrono::microseconds>(switchEnd - localSwitchStart).count();
-				cllog << "Switch time" << globalSwitchTime << "ms /" << localSwitchTime << "us";
+				clswitchlog << "Switch time"
+					<< std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - switchStart).count()
+					<< "ms.";
 			}
 
 			// Read results.

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -35,8 +35,15 @@ struct CUDAChannel: public LogChannel
 	static const bool debug = false;
 };
 
+struct CUDASwitchChannel: public LogChannel
+{
+	static const char* name() { return EthOrange " cu"; }
+	static const int verbosity = 6;
+	static const bool debug = false;
+};
+
 #define cudalog clog(CUDAChannel)
-#define ETHCUDA_LOG(_contents) cudalog << _contents
+#define cudaswitchlog clog(CUDASwitchChannel)
 
 CUDAMiner::CUDAMiner(FarmFace& _farm, unsigned _index) :
 	Miner("cuda-", _farm, _index),
@@ -140,6 +147,7 @@ void CUDAMiner::workLoop()
 void CUDAMiner::kick_miner()
 {
 	m_abort.store(true, std::memory_order_relaxed);
+	m_switch_start = std::chrono::high_resolution_clock::now();
 }
 
 void CUDAMiner::setNumInstances(unsigned _instances)
@@ -467,7 +475,7 @@ void CUDAMiner::search(
 				m_search_buf[i]->count = 0;
 		}
 	}
-	uint64_t batch_size = s_gridSize * s_blockSize;
+	const uint32_t batch_size = s_gridSize * s_blockSize;
 	while (true)
 	{
 		m_current_index++;
@@ -523,8 +531,12 @@ void CUDAMiner::search(
 
 			addHashCount(batch_size);
 			bool t = true;
-			if (m_abort.compare_exchange_strong(t, false))
+			if (m_abort.compare_exchange_strong(t, false)) {
+				cudaswitchlog << "Switch time "
+					<< std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - m_switch_start).count()
+					<< "ms.";
 				break;
+			}
 			if (shouldStop())
 			{
 				m_abort.store(false, std::memory_order_relaxed);

--- a/libethash-cuda/CUDAMiner.h
+++ b/libethash-cuda/CUDAMiner.h
@@ -119,6 +119,8 @@ private:
 	uint32_t m_dag_size = -1;
 	uint32_t m_device_num;
 
+	std::chrono::time_point<std::chrono::high_resolution_clock> m_switch_start;
+
 	volatile search_results** m_search_buf;
 	cudaStream_t  * m_streams;
 
@@ -137,6 +139,7 @@ private:
 	static vector<int> s_devices;
 
 	static bool s_noeval;
+
 };
 
 


### PR DESCRIPTION
Enable switch time logging by setting --verbosity
greater than 5.