### PR TITLE
Stratum SSL/TLS Support

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -200,6 +200,18 @@ public:
 				BOOST_THROW_EXCEPTION(BadArgument());
 			}
 		}
+		else if (arg == "--stratum-ssl")
+		{
+			m_stratumSecure = StratumSecure::TLS12;
+			if ((i + 1 < argc) && (*argv[i + 1] != '-')) {
+				int secMode = atoi(argv[++i]);
+				if (secMode == 1)
+					m_stratumSecure = StratumSecure::TLS;
+				if (secMode == 2)
+					m_stratumSecure = StratumSecure::ALLOW_SELFSIGNED;
+			}
+				
+		}
 		else if ((arg == "-SE" || arg == "--stratum-email") && i + 1 < argc)
 		{
 			try {
@@ -636,6 +648,10 @@ public:
 			<< "    -FO, --failover-userpass <username.workername:password> Failover stratum login credentials (optional, will use normal credentials when omitted)" << endl
 			<< "    --work-timeout <n> reconnect/failover after n seconds of working on the same (stratum) job. Defaults to 180. Don't set lower than max. avg. block time" << endl
 			<< "    -SC, --stratum-client <n>  Stratum client version. Version 1 support only." << endl
+			<< "    --stratum-ssl [<n>]  Use encryption to connect to stratum server." << endl
+			<< "        0: Force TLS1.2 (default)" << endl
+			<< "        1: Allow any TLS version" << endl
+			<< "        2: Allow self-signed or invalid certs and any TLS version" << endl
 			<< "    -SP, --stratum-protocol <n> Choose which stratum protocol to use:" << endl
 			<< "        0: official stratum spec: ethpool, ethermine, coinotron, mph, nanopool (default)" << endl
 			<< "        1: eth-proxy compatible: dwarfpool, f2pool, nanopool (required for hashrate reporting to work with nanopool)" << endl
@@ -783,7 +799,7 @@ private:
 		PoolClient *client = nullptr;
 
 		if (mode == OperationMode::Stratum) {
-			client = new EthStratumClient(m_worktimeout, m_stratumProtocol, m_email, m_report_stratum_hashrate, StratumSecure::FORCE_TLS12);
+			client = new EthStratumClient(m_worktimeout, m_stratumProtocol, m_email, m_report_stratum_hashrate, m_stratumSecure);
 		}
 		else if (mode == OperationMode::Farm) {
 			client = new EthGetworkClient(m_farmRecheckPeriod);
@@ -850,6 +866,7 @@ private:
 
 	/// Mining options
 	MinerType m_minerType = MinerType::Mixed;
+	StratumSecure m_stratumSecure = StratumSecure::NONE;
 	unsigned m_openclPlatform = 0;
 	unsigned m_miningThreads = UINT_MAX;
 	bool m_shouldListDevices = false;

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -783,7 +783,7 @@ private:
 		PoolClient *client = nullptr;
 
 		if (mode == OperationMode::Stratum) {
-			client = new EthStratumClient(m_worktimeout, m_stratumProtocol, m_email, m_report_stratum_hashrate);
+			client = new EthStratumClient(m_worktimeout, m_stratumProtocol, m_email, m_report_stratum_hashrate, StratumSecure::FORCE_TLS12);
 		}
 		else if (mode == OperationMode::Farm) {
 			client = new EthGetworkClient(m_farmRecheckPeriod);

--- a/libpoolprotocols/CMakeLists.txt
+++ b/libpoolprotocols/CMakeLists.txt
@@ -6,7 +6,11 @@ set(SOURCES
     getwork/EthGetworkClient.h getwork/EthGetworkClient.cpp getwork/jsonrpc_getwork.h
 )
 
+hunter_add_package(OpenSSL)
+find_package(OpenSSL REQUIRED)
+
 add_library(poolprotocols ${SOURCES})
 target_link_libraries(poolprotocols libjson-rpc-cpp::client)
 target_link_libraries(poolprotocols devcore Boost::system jsoncpp_lib_static)
+target_link_libraries(poolprotocols OpenSSL::SSL OpenSSL::Crypto)
 target_include_directories(poolprotocols PRIVATE ..)

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -117,11 +117,14 @@ void EthStratumClient::connect()
 
 			SSL_CTX_set_cert_store(ctx.native_handle(), store);
 #else
-			ctx.set_default_verify_paths();
+			char *certPath = getenv("SSL_CERT_FILE");
 			try {
-				ctx.load_verify_file("/etc/ssl/certs/ca-certificates.crt");
+				ctx.load_verify_file(certPath ? certPath : "/etc/ssl/certs/ca-certificates.crt");
 			}
 			catch (...) {
+				cwarn << "Failed to load ca certificates. Either the file '/etc/ssl/certs/ca-certificates.crt' does not exist";
+				cwarn << "or the environment variable SSL_CERT_FILE is set to an invalid or inaccessable file.";
+				cwarn << "It is possible that certificate verification can fail.";
 			}
 #endif
 		}

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -49,18 +49,49 @@ EthStratumClient::EthStratumClient(int const & worktimeout, int const & protocol
 	m_submit_hashrate_id = h256::random().hex();
 
 	m_secureMode = secureMode;
+}
 
-	if (secureMode != StratumSecure::NONE) {
+EthStratumClient::~EthStratumClient()
+{
+	m_io_service.stop();
+	m_serviceThread.join();
+
+	if (m_secureMode != StratumSecure::NONE) {
+		if (m_securesocket) 
+			delete m_securesocket;
+	}
+	else {
+		if (m_socket)
+			delete m_socket;
+	}
+}
+
+void EthStratumClient::connect()
+{
+	m_primary.host = m_host;
+	m_primary.port = m_port;
+	m_primary.user = m_user;
+	m_primary.pass = m_pass;
+	p_active = &m_primary;
+
+	m_authorized = false;
+	m_connected.store(false, std::memory_order_relaxed);
+
+	tcp::resolver::query q(p_active->host, p_active->port);
+
+	//cnote << "Resolving stratum server " + p_active->host + ":" + p_active->port;
+
+	if (m_secureMode != StratumSecure::NONE) {
 
 		boost::asio::ssl::context::method method = boost::asio::ssl::context::tls;
-		if (secureMode == StratumSecure::TLS12)
+		if (m_secureMode == StratumSecure::TLS12)
 			method = boost::asio::ssl::context::tlsv12;
 
 		boost::asio::ssl::context ctx(method);
 		m_securesocket = new boost::asio::ssl::stream<boost::asio::ip::tcp::socket>(m_io_service, ctx);
 		m_socket = &m_securesocket->next_layer();
 
-		if (secureMode != StratumSecure::ALLOW_SELFSIGNED) {
+		if (m_secureMode != StratumSecure::ALLOW_SELFSIGNED) {
 			m_securesocket->set_verify_mode(boost::asio::ssl::verify_peer);
 
 #ifdef _WIN32
@@ -94,36 +125,6 @@ EthStratumClient::EthStratumClient(int const & worktimeout, int const & protocol
 		m_socket = new boost::asio::ip::tcp::socket(m_io_service);
 	}
 
-}
-
-EthStratumClient::~EthStratumClient()
-{
-	m_io_service.stop();
-	m_serviceThread.join();
-
-	if (m_secureMode != StratumSecure::NONE) {
-		delete m_securesocket;
-	}
-	else {
-		delete m_socket;
-	}
-}
-
-void EthStratumClient::connect()
-{
-	m_primary.host = m_host;
-	m_primary.port = m_port;
-	m_primary.user = m_user;
-	m_primary.pass = m_pass;
-	p_active = &m_primary;
-
-	m_authorized = false;
-	m_connected.store(false, std::memory_order_relaxed);
-
-	tcp::resolver::query q(p_active->host, p_active->port);
-
-	//cnote << "Resolving stratum server " + p_active->host + ":" + p_active->port;
-
 	m_resolver.async_resolve(q, boost::bind(&EthStratumClient::resolve_handler,
 		this, boost::asio::placeholders::error,
 		boost::asio::placeholders::iterator));
@@ -146,8 +147,20 @@ void EthStratumClient::disconnect()
 {
 	m_worktimer.cancel();
 
+	if (m_secureMode != StratumSecure::NONE) {
+		boost::system::error_code sec;
+		m_securesocket->shutdown(sec);
+	}
+
 	m_io_service.stop();
 	m_socket->close();
+
+	if (m_secureMode != StratumSecure::NONE) {
+		delete m_securesocket;
+	}
+	else {
+		delete m_socket;
+	}
 
 	m_authorized = false;
 	m_connected.store(false, std::memory_order_relaxed);
@@ -162,7 +175,6 @@ void EthStratumClient::resolve_handler(const boost::system::error_code& ec, tcp:
 	if (!ec)
 	{
 		//cnote << "Connecting to stratum server " + p_active->host + ":" + p_active->port;
-
 		tcp::resolver::iterator end;
 		async_connect(*m_socket, i, end, boost::bind(&EthStratumClient::connect_handler,
 						this, boost::asio::placeholders::error,
@@ -171,20 +183,6 @@ void EthStratumClient::resolve_handler(const boost::system::error_code& ec, tcp:
 	else
 	{
 		cwarn << "Could not resolve host " << p_active->host + ":" + p_active->port + ", " << ec.message();
-		disconnect();
-	}
-}
-
-void EthStratumClient::handshake_handler(const boost::system::error_code& ec)
-{
-	dev::setThreadName("stratum");
-
-	if (!ec)
-	{
-		subscribe();
-	}
-	else {
-		cwarn << "SSL Handshake failed: " + ec.message();
 		disconnect();
 	}
 }
@@ -205,11 +203,57 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec, tcp:
 		}
 
 		if (m_secureMode != StratumSecure::NONE) {
-			m_securesocket->async_handshake(boost::asio::ssl::stream_base::client, boost::bind(&EthStratumClient::handshake_handler,
-				this, boost::asio::placeholders::error));
+			boost::system::error_code hec;
+			m_securesocket->handshake(boost::asio::ssl::stream_base::client, hec);
+			if (hec) {
+				cwarn << "SSL/TLS Handshake failed: " << hec.message();
+				disconnect();
+				return;
+			}
+		}
+
+		std::ostream os(&m_requestBuffer);
+
+		string user;
+		size_t p;
+
+		switch (m_protocol) {
+			case STRATUM_PROTOCOL_STRATUM:
+				m_authorized = true;
+				os << "{\"id\": 1, \"method\": \"mining.subscribe\", \"params\": []}\n";
+				break;
+			case STRATUM_PROTOCOL_ETHPROXY:
+				p = p_active->user.find_first_of(".");
+				user = p_active->user.substr(0, p);
+				if (p + 1 <= p_active->user.length())
+					m_worker = p_active->user.substr(p + 1);
+				else
+					m_worker = "";
+
+				if (m_email.empty())
+				{
+					os << "{\"id\": 1, \"worker\":\"" << m_worker << "\", \"method\": \"eth_submitLogin\", \"params\": [\"" << user << "\"]}\n";
+				}
+				else
+				{
+					os << "{\"id\": 1, \"worker\":\"" << m_worker << "\", \"method\": \"eth_submitLogin\", \"params\": [\"" << user << "\", \"" << m_email << "\"]}\n";
+				}
+				break;
+			case STRATUM_PROTOCOL_ETHEREUMSTRATUM:
+				m_authorized = true;
+				os << "{\"id\": 1, \"method\": \"mining.subscribe\", \"params\": [\"ethminer/" << ETH_PROJECT_VERSION << "\",\"EthereumStratum/1.0.0\"]}\n";
+				break;
+		}
+
+		if (m_secureMode != StratumSecure::NONE) {
+			async_write(*m_securesocket, m_requestBuffer,
+				boost::bind(&EthStratumClient::handleResponse, this,
+					boost::asio::placeholders::error));
 		}
 		else {
-			subscribe();
+			async_write(*m_socket, m_requestBuffer,
+				boost::bind(&EthStratumClient::handleResponse, this,
+					boost::asio::placeholders::error));
 		}
 	}
 	else
@@ -219,55 +263,6 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec, tcp:
 	}
 
 }
-
-
-void EthStratumClient::subscribe()
-{
-	std::ostream os(&m_requestBuffer);
-
-	string user;
-	size_t p;
-
-	switch (m_protocol) {
-	case STRATUM_PROTOCOL_STRATUM:
-		m_authorized = true;
-		os << "{\"id\": 1, \"method\": \"mining.subscribe\", \"params\": []}\n";
-		break;
-	case STRATUM_PROTOCOL_ETHPROXY:
-		p = p_active->user.find_first_of(".");
-		user = p_active->user.substr(0, p);
-		if (p + 1 <= p_active->user.length())
-			m_worker = p_active->user.substr(p + 1);
-		else
-			m_worker = "";
-
-		if (m_email.empty())
-		{
-			os << "{\"id\": 1, \"worker\":\"" << m_worker << "\", \"method\": \"eth_submitLogin\", \"params\": [\"" << user << "\"]}\n";
-		}
-		else
-		{
-			os << "{\"id\": 1, \"worker\":\"" << m_worker << "\", \"method\": \"eth_submitLogin\", \"params\": [\"" << user << "\", \"" << m_email << "\"]}\n";
-		}
-		break;
-	case STRATUM_PROTOCOL_ETHEREUMSTRATUM:
-		m_authorized = true;
-		os << "{\"id\": 1, \"method\": \"mining.subscribe\", \"params\": [\"ethminer/" << ETH_PROJECT_VERSION << "\",\"EthereumStratum/1.0.0\"]}\n";
-		break;
-	}
-
-	if (m_secureMode != StratumSecure::NONE) {
-		async_write(*m_securesocket, m_requestBuffer,
-			boost::bind(&EthStratumClient::handleResponse, this,
-				boost::asio::placeholders::error));
-	}
-	else {
-		async_write(*m_socket, m_requestBuffer,
-			boost::bind(&EthStratumClient::handleResponse, this,
-				boost::asio::placeholders::error));
-	}
-}
-
 
 void EthStratumClient::readline() {
 	x_pending.lock();

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <boost/array.hpp>
 #include <boost/asio.hpp>
+#include <boost/asio/ssl.hpp>
 #include <boost/bind.hpp>
 #include <json/json.h>
 #include <libdevcore/Log.h>
@@ -18,11 +19,19 @@ using namespace std;
 using namespace dev;
 using namespace dev::eth;
 
+enum class StratumSecure
+{
+	NONE,
+	FORCE_TLS12,
+	FORCE_TLS10,
+	ALLOW_UNSIGNED
+};
+
 
 class EthStratumClient : public PoolClient
 {
 public:
-	EthStratumClient(int const & worktimeout, int const & protocol, string const & email, bool const & submitHashrate);
+	EthStratumClient(int const & worktimeout, int const & protocol, string const & email, bool const & submitHashrate, StratumSecure const & secureMode);
 	~EthStratumClient();
 
 	void connect();
@@ -40,9 +49,11 @@ private:
 
 	void resolve_handler(const boost::system::error_code& ec, boost::asio::ip::tcp::resolver::iterator i);
 	void connect_handler(const boost::system::error_code& ec, boost::asio::ip::tcp::resolver::iterator i);
+	void handshake_handler(const boost::system::error_code& ec);
 	void work_timeout_handler(const boost::system::error_code& ec);
 
 	void readline();
+	void subscribe();
 	void handleResponse(const boost::system::error_code& ec);
 	void readResponse(const boost::system::error_code& ec, std::size_t bytes_transferred);
 	void processReponse(Json::Value& responseObject);
@@ -67,7 +78,9 @@ private:
 
 	std::thread m_serviceThread;  ///< The IO service thread.
 	boost::asio::io_service m_io_service;
-	boost::asio::ip::tcp::socket m_socket;
+	StratumSecure m_secureMode;
+	boost::asio::ip::tcp::socket *m_socket;
+	boost::asio::ssl::stream<boost::asio::ip::tcp::socket> *m_securesocket;
 
 	boost::asio::streambuf m_requestBuffer;
 	boost::asio::streambuf m_responseBuffer;

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -22,9 +22,9 @@ using namespace dev::eth;
 enum class StratumSecure
 {
 	NONE,
-	FORCE_TLS12,
-	FORCE_TLS10,
-	ALLOW_UNSIGNED
+	TLS12,
+	TLS,
+	ALLOW_SELFSIGNED
 };
 
 

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -49,11 +49,9 @@ private:
 
 	void resolve_handler(const boost::system::error_code& ec, boost::asio::ip::tcp::resolver::iterator i);
 	void connect_handler(const boost::system::error_code& ec, boost::asio::ip::tcp::resolver::iterator i);
-	void handshake_handler(const boost::system::error_code& ec);
 	void work_timeout_handler(const boost::system::error_code& ec);
 
 	void readline();
-	void subscribe();
 	void handleResponse(const boost::system::error_code& ec);
 	void readResponse(const boost::system::error_code& ec, std::size_t bytes_transferred);
 	void processReponse(Json::Value& responseObject);


### PR DESCRIPTION
ethermine.org starts testing SSL support for their pool.
This adds support for encrypted stratum pool connections.

Server to test with:
1) Valid ssl cert: stratum-ssl-test.ethermine.org:5555
2) SelfSigned: stratum-ssl-test.ethermine.org:6666

You need use ``--stratum-ssl``  to enable ssl for pool connections.
It should work for 1) but fail for 2) (certificate validation failed)

Optional options for the param:
* 0 = default, force tls1.2 connection
* 1 = allow any tls version
* 2 = disable certificate verification