### PR TITLE
Optimized farm.stop and worktimeout in stratum

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -832,7 +832,7 @@ private:
 		mgr.start();
 
 		// Run CLI in loop
-		while (g_running) {
+		while (g_running && mgr.isRunning()) {
 			if (mgr.isConnected()) {
 				auto mp = f.miningProgress(m_show_hwmonitors, m_show_power);
 				minelog << mp << f.getSolutionStats() << f.farmLaunchedFormatted();

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -286,7 +286,7 @@ void CLMiner::workLoop()
 	current.seed = h256{1u};
 
 	try {
-		while (true)
+		while (!shouldStop())
 		{
 			const WorkPackage w = work();
 
@@ -377,16 +377,11 @@ void CLMiner::workLoop()
 
 			// Report hash count
 			addHashCount(m_globalWorkSize);
-
-			// Check if we should stop.
-			if (shouldStop())
-			{
-				// Make sure the last buffer write has finished --
-				// it reads local variable.
-				m_queue.finish();
-				break;
-			}
 		}
+
+		// Make sure the last buffer write has finished --
+		// it reads local variable.
+		m_queue.finish();
 	}
 	catch (cl::Error const& _e)
 	{

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -102,7 +102,7 @@ void CUDAMiner::workLoop()
 
 	try
 	{
-		while(true)
+		while(!shouldStop())
 		{
 	                // take local copy of work since it may end up being overwritten.
 			const WorkPackage w = work();
@@ -128,11 +128,10 @@ void CUDAMiner::workLoop()
 				startN = current.startNonce | ((uint64_t)index << (64 - LOG2_MAX_MINERS - current.exSizeBits));
 			}
 			search(current.header.data(), upper64OfBoundary, (current.exSizeBits >= 0), startN, w);
-
-			// Check if we should stop.
-			if (shouldStop())
-				break;
 		}
+
+		// Reset miner and stop working
+		CUDA_SAFE_CALL(cudaDeviceReset());
 	}
 	catch (cuda_runtime_error const& _e)
 	{

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -56,7 +56,7 @@ public:
 		std::function<Miner*(FarmFace&, unsigned)> create;
 	};
 
-	Farm()
+	Farm(): m_hashrateTimer(m_io_service)
 	{
 		// Given that all nonces are equally likely to solve the problem
 		// we could reasonably always start the nonce search ranges
@@ -150,16 +150,17 @@ public:
 		m_lastSealer = _sealer;
 		b_lastMixed = mixed;
 
-		if (!p_hashrateTimer) {
-			p_hashrateTimer = new boost::asio::deadline_timer(m_io_service, boost::posix_time::milliseconds(1000));
-			p_hashrateTimer->async_wait(boost::bind(&Farm::processHashRate, this, boost::asio::placeholders::error));
-			if (m_serviceThread.joinable()) {
-				m_io_service.reset();
-			}
-			else {
-				m_serviceThread = std::thread{ boost::bind(&boost::asio::io_service::run, &m_io_service) };
-			}
+		// Start hashrate collector
+		m_hashrateTimer.cancel();
+		m_hashrateTimer.expires_from_now(boost::posix_time::milliseconds(1000));
+		m_hashrateTimer.async_wait(boost::bind(&Farm::processHashRate, this, boost::asio::placeholders::error));
+
+		if (m_serviceThread.joinable()) {
+			m_io_service.reset();
+			m_serviceThread.join();
 		}
+
+		m_serviceThread = std::thread{ boost::bind(&boost::asio::io_service::run, &m_io_service) };
 
 		return true;
 	}
@@ -175,13 +176,10 @@ public:
 			m_isMining = false;
 		}
 
+		m_hashrateTimer.cancel();
 		m_io_service.stop();
-		m_serviceThread.join();
 
-		if (p_hashrateTimer) {
-			p_hashrateTimer->cancel();
-			p_hashrateTimer = nullptr;
-		}
+		m_lastProgresses.clear();
 	}
 
     void collectHashRate()
@@ -222,11 +220,12 @@ public:
 
 		if (!ec) {
 			collectHashRate();
-		}
 
-		// Restart timer 	
-		p_hashrateTimer->expires_at(p_hashrateTimer->expires_at() + boost::posix_time::milliseconds(1000));
-		p_hashrateTimer->async_wait(boost::bind(&Farm::processHashRate, this, boost::asio::placeholders::error));
+			// Restart timer 	
+			m_hashrateTimer.cancel();
+			m_hashrateTimer.expires_from_now(boost::posix_time::milliseconds(1000));
+			m_hashrateTimer.async_wait(boost::bind(&Farm::processHashRate, this, boost::asio::placeholders::error));
+		}
 	}
 	
 	/**
@@ -443,7 +442,7 @@ private:
 	int m_hashrateSmoothInterval = 10000;
 	std::thread m_serviceThread;  ///< The IO service thread.
 	boost::asio::io_service m_io_service;
-	boost::asio::deadline_timer * p_hashrateTimer = nullptr;
+	boost::asio::deadline_timer m_hashrateTimer;
 	std::vector<WorkingProgress> m_lastProgresses;
 
 	mutable SolutionStats m_solutionStats;

--- a/libpoolprotocols/PoolManager.h
+++ b/libpoolprotocols/PoolManager.h
@@ -44,6 +44,7 @@ namespace dev
 			void stop();
 			void setReconnectTries(unsigned const & reconnectTries) { m_reconnectTries = reconnectTries; };
 			bool isConnected() { return p_client->isConnected(); };
+			bool isRunning() { return m_running; };
 
 		private:
 			unsigned m_hashrateReportingTime = 10;

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -183,6 +183,7 @@ void EthStratumClient::disconnect()
 
 void EthStratumClient::resolve_handler(const boost::system::error_code& ec, tcp::resolver::iterator i)
 {
+	dev::setThreadName("stratum");
 	if (!ec)
 	{
 		//cnote << "Connecting to stratum server " + p_active->host + ":" + p_active->port;

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -51,6 +51,7 @@ private:
 	void work_timeout_handler(const boost::system::error_code& ec);
 	void response_timeout_handler(const boost::system::error_code& ec);
 
+	void reset_work_timeout();
 	void readline();
 	void handleResponse(const boost::system::error_code& ec);
 	void readResponse(const boost::system::error_code& ec, std::size_t bytes_transferred);

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -102,4 +102,6 @@ private:
 	string m_submit_hashrate_id;
 
 	void processExtranonce(std::string& enonce);
+
+	bool m_linkdown = true;
 };


### PR DESCRIPTION
* More fixes for farm.stop
* Re-enabled api event for miner restart
* On disconnect shutdown all mining to save wasted power
* Start worktimeout in stratum right after a successful connection. So if connection is successfull but something else failes and you never get work, this triggers a reconnect after the timeout is reached 

Disclaimer:
farm.stop()  still can cause driver resets, i modified my simulator to disconnect after a while but never had a driver reset with this test after 2h of simulating. But i had driver resets by stopping the miner, which should do the same so i do not know what causes the driver reset.