### PR TITLE
Segfault by m_endpoints

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -92,7 +92,7 @@ public:
 		Stratum
 	};
 
-	MinerCLI() {m_endpoints.reserve(k_max_endpoints);}
+	MinerCLI() {m_endpoints.resize(k_max_endpoints);}
 
 	static void signalHandler(int sig)
 	{


### PR DESCRIPTION
Accessing reserved range of m_endpoints with operator[] produces undefined results and leads to segfault in some systems.