### PR TITLE
MSVC: remove `disable-warnings` from cuda switches.

### DIFF
--- a/libethash-cuda/CMakeLists.txt
+++ b/libethash-cuda/CMakeLists.txt
@@ -1,6 +1,10 @@
 find_package(CUDA REQUIRED)
 
-set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};--disable-warnings;--ptxas-options=-v;-use_fast_math;-lineinfo)
+set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};--ptxas-options=-v;-use_fast_math;-lineinfo)
+
+if (NOT MSVC)
+	list(APPEND CUDA_NVCC_FLAGS "--disable-warnings")
+endif()
 
 list(APPEND CUDA_NVCC_FLAGS_RELEASE -O3)
 list(APPEND CUDA_NVCC_FLAGS_DEBUG -G)


### PR DESCRIPTION
This resulted in Windows build warnings because it replaced `/W3` with `/w`.

Fixes #910.