### PR TITLE
Clean up MSVC compiler options.

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -25,28 +25,36 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 
-	# enable parallel compilation
-	# specify Exception Handling Model in msvc
-	# enable LTCG for faster builds
-	# disable unknown pragma warning (4068)
-	# disable unsafe function warning (4996)
-	# disable decorated name length exceeded, name was truncated (4503)
-	# disable conversion from 'size_t' to 'type', possible loss of data (4267)
-	# disable qualifier applied to function type has no meaning; ignored (4180)
-	# disable C++ exception specification ignored except to indicate a function is not __declspec(nothrow) (4290)
-	# disable conversion from 'type1' to 'type2', possible loss of data (4244)
-	# disable forcing value to bool 'true' or 'false' (performance warning) (4800)
 	# declare Windows XP requirement
-	# undefine windows.h MAX & MIN macros because they cause conflicts with std::min & std::max functions
-	add_compile_options(/MP /EHsc /GL /wd4068 /wd4996 /wd4503 /wd4267 /wd4180 /wd4290 /wd4244 /wd4800 -D_WIN32_WINNT=0x0501 /DNOMINMAX)
-	# disable empty object file warning
-	set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /LTCG /ignore:4221")
+	# undefine windows.h MAX & MIN macros because they conflict with std::min & std::max functions
+	# disable Unsafe CRT Library functions warnings
+	add_definitions(/D_WIN32_WINNT=0x0501 /DNOMINMAX /D_CRT_SECURE_NO_WARNINGS)
+
+	# specify Exception Handling Model
+	# disable conversion from "type1" to "type2", possible loss of data (C4244)
+	# disable conversion from "size_t" to "type", possible loss of data (C4267)
+	# disable C++ exception specification ignored except to indicate a function is not __declspec(nothrow) (C4290)
+	add_compile_options(/EHsc /wd4244 /wd4267 /wd4290)
+
+	# Release/RelWithDebInfo builds
+	# enable parallel compilation
 	# enable LTCG for faster builds
-	# enable RELEASE so that the executable file has its checksum set
+	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MP /GL")
+	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELEASE}")
+	set(CMAKE_C_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+	set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELEASE}")
+
+	# enable LTCG for faster builds
+	set(CMAKE_STATIC_LINKER_FLAGS_RELEASE "${CMAKE_STATIC_LINKER_FLAGS_RELEASE} /LTCG")
+	set(CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_STATIC_LINKER_FLAGS_RELEASE}")
+
+	# disable incremental linking
+	# enable LTCG for faster builds
 	# enable unused references removal
-	# warning LNK4075: ignoring '/EDITANDCONTINUE' due to '/SAFESEH' specification
-	# warning LNK4099: pdb was not found with lib
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LTCG /RELEASE /OPT:REF /OPT:ICF /ignore:4099,4075")
+	# enable RELEASE so that the executable file has its checksum set
+	set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /INCREMENTAL:NO /LTCG /OPT:REF /OPT:ICF /RELEASE")
+	set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELEASE}")
+
 else ()
 	message(WARNING "Your compiler is not tested, if you run into any issues, we'd welcome any patches.")
 endif ()
@@ -55,4 +63,3 @@ set(SANITIZE NO CACHE STRING "Instrument build with provided sanitizer")
 if(SANITIZE)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=${SANITIZE}")
 endif()
-

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -334,9 +334,9 @@ public:
 		{
 			m_show_hwmonitors = true;
 			if ((i + 1 < argc) && (*argv[i + 1] != '-'))
-				m_show_power = (bool)atoi(argv[++i]);
+				m_show_power = atoi(argv[++i]) != 0;
 		}
-		else if ((arg == "--exit"))
+		else if (arg == "--exit")
 		{
 			m_exit = true;
 		}

--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -23,11 +23,6 @@
 
 #pragma once
 
-// way to many unsigned to size_t warnings in 32 bit build
-#ifdef _M_IX86
-#pragma warning(disable:4244)
-#endif
-
 #include <map>
 #include <unordered_map>
 #include <vector>

--- a/libethash-cuda/CMakeLists.txt
+++ b/libethash-cuda/CMakeLists.txt
@@ -1,13 +1,14 @@
 find_package(CUDA REQUIRED)
 
-set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};--ptxas-options=-v;-use_fast_math;-lineinfo)
+set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};--ptxas-options=-v;-use_fast_math)
 
 if (NOT MSVC)
 	list(APPEND CUDA_NVCC_FLAGS "--disable-warnings")
 endif()
 
-list(APPEND CUDA_NVCC_FLAGS_RELEASE -O3)
-list(APPEND CUDA_NVCC_FLAGS_DEBUG -G)
+list(APPEND CUDA_NVCC_FLAGS_DEBUG "-G")
+list(APPEND CUDA_NVCC_FLAGS_RELEASE "-O3;-lineinfo")
+list(APPEND CUDA_NVCC_FLAGS_RELWITHDEBINFO "${CUDA_NVCC_FLAGS_RELEASE}")
 
 if(COMPUTE AND (COMPUTE GREATER 0))
 	list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_${COMPUTE},code=sm_${COMPUTE}")

--- a/libethash-cuda/CUDAMiner.h
+++ b/libethash-cuda/CUDAMiner.h
@@ -17,8 +17,6 @@ along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#define _CRT_SECURE_NO_WARNINGS
-
 #include <time.h>
 #include <functional>
 #include <libethash/ethash.h>


### PR DESCRIPTION
*  remove C4800 suppression; change the check instead
* split preprocessor definitions from compiler switches
* disable Unsafe CRT Library functions warnings via a preprocessor definition

TODO:

- [x] RelWithDebInfo yields a linker warning regarding `INCREMENTAL` and `LTCG` even though I have specified `/INCREMENTAL:NO` in this PR; the same linker warning is on master

PS. I'm no expert with CMake, so please let me know if something is done wrong or can be improved.