### PR TITLE
Remove unneeded include guards.

### DIFF
--- a/libpoolprotocols/PoolClient.h
+++ b/libpoolprotocols/PoolClient.h
@@ -1,6 +1,3 @@
-#ifndef POOL_CLIENT_H_
-#define POOL_CLIENT_H_
-
 #pragma once
 
 #include <boost/asio/ip/address.hpp>
@@ -99,6 +96,3 @@ namespace dev
 		};
 	}
 }
-
-#endif
-

--- a/libpoolprotocols/PoolManager.h
+++ b/libpoolprotocols/PoolManager.h
@@ -1,6 +1,3 @@
-#ifndef POOL_MANAGER_H_
-#define POOL_MANAGER_H_
-
 #pragma once
 
 #include <iostream>
@@ -51,6 +48,3 @@ namespace dev
 		};
 	}
 }
-
-#endif
-

--- a/libpoolprotocols/getwork/EthGetworkClient.h
+++ b/libpoolprotocols/getwork/EthGetworkClient.h
@@ -1,6 +1,3 @@
-#ifndef ETH_GETWORK_CLIENT_H_
-#define ETH_GETWORK_CLIENT_H_
-
 #pragma once
 
 #include <jsonrpccpp/client/connectors/httpclient.h>
@@ -38,6 +35,3 @@ private:
 	JsonrpcGetwork *p_client;
 	WorkPackage m_prevWorkPackage;
 };
-
-#endif
-


### PR DESCRIPTION
The headers already include `#pragma once` directives.