### PR TITLE
Clean up MSVC compiler options.

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -25,27 +25,28 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 
-	# enable parallel compilation
-	# specify Exception Handling Model in msvc
-	# enable LTCG for faster builds
-	# disable unknown pragma warning (4068)
-	# disable unsafe function warning (4996)
-	# disable decorated name length exceeded, name was truncated (4503)
-	# disable conversion from 'size_t' to 'type', possible loss of data (4267)
-	# disable qualifier applied to function type has no meaning; ignored (4180)
-	# disable C++ exception specification ignored except to indicate a function is not __declspec(nothrow) (4290)
-	# disable conversion from 'type1' to 'type2', possible loss of data (4244)
 	# declare Windows XP requirement
-	# undefine windows.h MAX & MIN macros because they cause conflicts with std::min & std::max functions
-	add_compile_options(/MP /EHsc /GL /wd4068 /wd4996 /wd4503 /wd4267 /wd4180 /wd4290 /wd4244 -D_WIN32_WINNT=0x0501 /DNOMINMAX)
-	# disable empty object file warning
-	set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /LTCG /ignore:4221")
+	# undefine windows.h MAX & MIN macros because they conflict with std::min & std::max functions
+	# disable unsafe CRT Library functions warnings
+	add_definitions(/D_WIN32_WINNT=0x0501 /DNOMINMAX /D_CRT_SECURE_NO_WARNINGS)
+
+	# enable parallel compilation
+	# specify Exception Handling Model
 	# enable LTCG for faster builds
-	# enable RELEASE so that the executable file has its checksum set
+	# disable qualifier applied to function type has no meaning; ignored (4180)
+	# disable conversion from 'type1' to 'type2', possible loss of data (4244)
+	# disable conversion from 'size_t' to 'type', possible loss of data (4267)
+	# disable C++ exception specification ignored except to indicate a function is not __declspec(nothrow) (4290)
+	# disable decorated name length exceeded, name was truncated (4503)
+	add_compile_options(/MP /EHsc /GL /wd4180 /wd4244 /wd4267 /wd4290 /wd4503)
+
+	# enable LTCG for faster builds
+	set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /LTCG")
+
+	# enable LTCG for faster builds
 	# enable unused references removal
-	# warning LNK4075: ignoring '/EDITANDCONTINUE' due to '/SAFESEH' specification
-	# warning LNK4099: pdb was not found with lib
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LTCG /RELEASE /OPT:REF /OPT:ICF /ignore:4099,4075")
+	# enable RELEASE so that the executable file has its checksum set
+	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LTCG /OPT:REF /OPT:ICF /RELEASE")
 else ()
 	message(WARNING "Your compiler is not tested, if you run into any issues, we'd welcome any patches.")
 endif ()
@@ -54,4 +55,3 @@ set(SANITIZE NO CACHE STRING "Instrument build with provided sanitizer")
 if(SANITIZE)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=${SANITIZE}")
 endif()
-

--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -23,11 +23,6 @@
 
 #pragma once
 
-// way to many unsigned to size_t warnings in 32 bit build
-#ifdef _M_IX86
-#pragma warning(disable:4244)
-#endif
-
 #include <map>
 #include <unordered_map>
 #include <vector>

--- a/libethash-cuda/CUDAMiner.h
+++ b/libethash-cuda/CUDAMiner.h
@@ -17,8 +17,6 @@ along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#define _CRT_SECURE_NO_WARNINGS
-
 #include <time.h>
 #include <functional>
 #include <libethash/ethash.h>


### PR DESCRIPTION
* specify `_CRT_SECURE_NO_WARNINGS` instead of disabling C4996
* move preprocessor definitions to `add_definitions`
* remove no longer needed warnings suppressions

@chfast: this should be a lot safer than the first attempt; this time I double-checked and there's no hashrate change, only cleanup :)