### PR TITLE
Fixed benchmark inner mean calculation when several speeds are equal

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -870,7 +870,7 @@ private:
 		WorkPackage current = WorkPackage(genesis);
 		
 
-		map<uint64_t, WorkingProgress> results;
+		list<uint64_t> results;
 		uint64_t mean = 0;
 		uint64_t innerMean = 0;
 		for (unsigned i = 0; i <= _trials; ++i)
@@ -890,15 +890,16 @@ private:
 			auto rate = mp.rate();
 
 			cout << rate << endl;
-			results[rate] = mp;
+			results.push_back(rate);
 			mean += rate;
 		}
-		int j = -1;
-		for (auto const& r: results)
-			if (++j > 0 && j < (int)_trials - 1)
-				innerMean += r.second.rate();
+		results.sort();
+		cout << "min/mean/max: " << results.front() << "/" << (mean / _trials) << "/" << results.back() << " H/s" << endl;
+		results.pop_front();
+		results.pop_back();
+		for (auto it = results.begin(); it != results.end(); it++)
+			innerMean += *it;
 		innerMean /= (_trials - 2);
-		cout << "min/mean/max: " << results.begin()->second.rate() << "/" << (mean / _trials) << "/" << results.rbegin()->second.rate() << " H/s" << endl;
 		cout << "inner mean: " << innerMean << " H/s" << endl;
 
 		exit(0);


### PR DESCRIPTION
Previously, the benchmarking speed results were stored in a std::map. This had the advantage of being sorted automatically, which made access to min and max speeds very easy.
However, it had the logical problem of map collision in cases where several runs had identical speeds. While this would not affect min, mean and max speeds, it did affect inner mean calculations (duplicate speeds count only once)

Additionally, the map data structure was not used sensibly; The rate was used as key, but also was the only attribute ever accessed from the value. Thus, the data can be represented cleaner and more accurately with the usage of a list

This commit implements the required changes to fix the inner mean calculation.