### PR TITLE
Use epoch number instead of seed hash

### DIFF
--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -84,7 +84,7 @@ protected:
 private:
 	void workLoop() override;
 
-	bool init(const h256& seed);
+	bool init(int epoch);
 
 	cl::Context m_context;
 	cl::CommandQueue m_queue;

--- a/libethash-cuda/CUDAMiner.h
+++ b/libethash-cuda/CUDAMiner.h
@@ -104,7 +104,7 @@ private:
 
 	void workLoop() override;
 
-	bool init(const h256& seed);
+	bool init(int epoch);
 
 	hash32_t m_current_header;
 	uint64_t m_current_target;

--- a/libethcore/EthashAux.cpp
+++ b/libethcore/EthashAux.cpp
@@ -14,10 +14,6 @@
 	You should have received a copy of the GNU General Public License
 	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** @file EthashAux.cpp
- * @author Gav Wood <i@gavwood.com>
- * @date 2014
- */
 
 #include "EthashAux.h"
 #include <libethash/internal.h>
@@ -33,66 +29,51 @@ EthashAux& EthashAux::get()
 	return instance;
 }
 
-h256 EthashAux::seedHash(unsigned _number)
+int EthashAux::toEpoch(h256 const& _seedHash)
 {
-	unsigned epoch = _number / ETHASH_EPOCH_LENGTH;
-	EthashAux& ethash = EthashAux::get();
-	Guard l(ethash.x_epochs);
-	if (epoch >= ethash.m_seedHashes.size())
-	{
-		h256 ret;
-		unsigned n = 0;
-		if (!ethash.m_seedHashes.empty())
-		{
-			ret = ethash.m_seedHashes.back();
-			n = ethash.m_seedHashes.size() - 1;
-		}
-		ethash.m_seedHashes.resize(epoch + 1);
-		for (; n <= epoch; ++n, ret = sha3(ret))
-			ethash.m_seedHashes[n] = ret;
-	}
-	return ethash.m_seedHashes[epoch];
+    EthashAux& ethash = EthashAux::get();
+    Guard l(ethash.x_epochs);
+    int epoch = 0;
+    auto epochIter = ethash.m_epochs.find(_seedHash);
+    if (epochIter == ethash.m_epochs.end())
+    {
+        for (h256 h; h != _seedHash && epoch < 2048;
+             ++epoch, h = sha3(h), ethash.m_epochs[h] = epoch)
+        {
+        }
+        if (epoch == 2048)
+        {
+            std::ostringstream error;
+            error << "apparent block number for " << _seedHash << " is too high; max is "
+                  << (ETHASH_EPOCH_LENGTH * 2048);
+            throw std::invalid_argument(error.str());
+        }
+    }
+    else
+        epoch = epochIter->second;
+    return epoch;
 }
 
-uint64_t EthashAux::number(h256 const& _seedHash)
+EthashAux::LightType EthashAux::light(int epoch)
 {
-	EthashAux& ethash = EthashAux::get();
-	Guard l(ethash.x_epochs);
-	unsigned epoch = 0;
-	auto epochIter = ethash.m_epochs.find(_seedHash);
-	if (epochIter == ethash.m_epochs.end())
-	{
-		for (h256 h; h != _seedHash && epoch < 2048; ++epoch, h = sha3(h), ethash.m_epochs[h] = epoch) {}
-		if (epoch == 2048)
-		{
-			std::ostringstream error;
-			error << "apparent block number for " << _seedHash << " is too high; max is " << (ETHASH_EPOCH_LENGTH * 2048);
-			throw std::invalid_argument(error.str());
-		}
-	}
-	else
-		epoch = epochIter->second;
-	return epoch * ETHASH_EPOCH_LENGTH;
+    // TODO: Use epoch number instead of seed hash?
+
+    EthashAux& ethash = EthashAux::get();
+
+    Guard l(ethash.x_lights);
+
+    auto it = ethash.m_lights.find(epoch);
+    if (it != ethash.m_lights.end())
+        return it->second;
+
+    return (ethash.m_lights[epoch] = make_shared<LightAllocation>(epoch));
 }
 
-EthashAux::LightType EthashAux::light(h256 const& _seedHash)
+EthashAux::LightAllocation::LightAllocation(int epoch)
 {
-	// TODO: Use epoch number instead of seed hash?
-
-	EthashAux& ethash = EthashAux::get();
-	Guard l(ethash.x_lights);
-	if (ethash.m_lights.count(_seedHash))
-		return ethash.m_lights.at(_seedHash);
-	return (ethash.m_lights[_seedHash] = make_shared<LightAllocation>(_seedHash));
-}
-
-EthashAux::LightAllocation::LightAllocation(h256 const& _seedHash)
-{
-	uint64_t blockNumber = EthashAux::number(_seedHash);
-	light = ethash_light_new(blockNumber);
-	if (!light)
-		BOOST_THROW_EXCEPTION(ExternalFunctionFailure("ethash_light_new()"));
-	size = ethash_get_cachesize(blockNumber);
+    int blockNumber = epoch * ETHASH_EPOCH_LENGTH;
+    light = ethash_light_new(blockNumber);
+    size = ethash_get_cachesize(blockNumber);
 }
 
 EthashAux::LightAllocation::~LightAllocation()
@@ -113,11 +94,11 @@ Result EthashAux::LightAllocation::compute(h256 const& _headerHash, uint64_t _no
 	return Result{h256((uint8_t*)&r.result, h256::ConstructFromPointer), h256((uint8_t*)&r.mix_hash, h256::ConstructFromPointer)};
 }
 
-Result EthashAux::eval(h256 const& _seedHash, h256 const& _headerHash, uint64_t _nonce) noexcept
+Result EthashAux::eval(int epoch, h256 const& _headerHash, uint64_t _nonce) noexcept
 {
 	try
 	{
-		return get().light(_seedHash)->compute(_headerHash, _nonce);
+		return get().light(epoch)->compute(_headerHash, _nonce);
 	}
 	catch(...)
 	{

--- a/libethcore/EthashAux.cpp
+++ b/libethcore/EthashAux.cpp
@@ -32,26 +32,26 @@ EthashAux& EthashAux::get()
 int EthashAux::toEpoch(h256 const& _seedHash)
 {
     EthashAux& ethash = EthashAux::get();
-    Guard l(ethash.x_epochs);
-    int epoch = 0;
-    auto epochIter = ethash.m_epochs.find(_seedHash);
-    if (epochIter == ethash.m_epochs.end())
+
+    if (_seedHash != ethash.m_cached_seed)
     {
-        for (h256 h; h != _seedHash && epoch < 2048;
-             ++epoch, h = sha3(h), ethash.m_epochs[h] = epoch)
+        // Find epoch number corresponding to given seed hash.
+        int epoch = 0;
+        for (h256 h; h != _seedHash && epoch < 2048; ++epoch, h = sha3(h))
         {
         }
         if (epoch == 2048)
         {
             std::ostringstream error;
-            error << "apparent block number for " << _seedHash << " is too high; max is "
-                  << (ETHASH_EPOCH_LENGTH * 2048);
+            error << "apparent epoch number for " << _seedHash << " is too high; max is " << 2048;
             throw std::invalid_argument(error.str());
         }
+
+        ethash.m_cached_seed = _seedHash;
+        ethash.m_cached_epoch = epoch;
     }
-    else
-        epoch = epochIter->second;
-    return epoch;
+
+    return ethash.m_cached_epoch;
 }
 
 EthashAux::LightType EthashAux::light(int epoch)

--- a/libethcore/EthashAux.h
+++ b/libethcore/EthashAux.h
@@ -14,10 +14,6 @@
 	You should have received a copy of the GNU General Public License
 	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** @file EthashAux.cpp
- * @author Gav Wood <i@gavwood.com>
- * @date 2014
- */
 
 #pragma once
 
@@ -43,7 +39,7 @@ class EthashAux
 public:
 	struct LightAllocation
 	{
-		LightAllocation(h256 const& _seedHash);
+		explicit LightAllocation(int epoch);
 		~LightAllocation();
 		bytesConstRef data() const;
 		Result compute(h256 const& _headerHash, uint64_t _nonce) const;
@@ -53,44 +49,41 @@ public:
 
 	using LightType = std::shared_ptr<LightAllocation>;
 
-	static h256 seedHash(unsigned _number);
-	static uint64_t number(h256 const& _seedHash);
+	static int toEpoch(h256 const& _seedHash);
 
-	static LightType light(h256 const& _seedHash);
+	static LightType light(int epoch);
 
-	static Result eval(h256 const& _seedHash, h256 const& _headerHash, uint64_t  _nonce) noexcept;
+	static Result eval(int epoch, h256 const& _headerHash, uint64_t  _nonce) noexcept;
 
 private:
-	EthashAux() = default;
-	static EthashAux& get();
+    EthashAux() = default;
+    static EthashAux& get();
 
-	Mutex x_lights;
-	std::unordered_map<h256, LightType> m_lights;
+    Mutex x_lights;
+    std::unordered_map<int, LightType> m_lights;
 
-	Mutex x_epochs;
-	std::unordered_map<h256, unsigned> m_epochs;
-	h256s m_seedHashes;
+    Mutex x_epochs;
+    std::unordered_map<h256, unsigned> m_epochs;
 };
 
 struct WorkPackage
 {
-	WorkPackage() = default;
-	explicit WorkPackage(BlockHeader const& _bh) :
-		boundary(_bh.boundary()),
-		header(_bh.hashWithout()),
-		seed(EthashAux::seedHash(static_cast<unsigned>(_bh.number())))
-	{ }
-	void reset() { header = h256(); }
-	explicit operator bool() const { return header != h256(); }
+    WorkPackage() = default;
+    explicit WorkPackage(BlockHeader const& _bh)
+      : boundary(_bh.boundary()),
+        header(_bh.hashWithout()),
+        epoch(static_cast<int>(_bh.number()) / ETHASH_EPOCH_LENGTH)
+    {}
+    explicit operator bool() const { return header != h256(); }
 
-	h256 boundary;
-	h256 header;	///< When h256() means "pause until notified a new work package is available".
-	h256 seed;
-	h256 job;
+    h256 boundary;
+    h256 header;  ///< When h256() means "pause until notified a new work package is available".
+    h256 job;
+    int epoch = -1;
 
-	uint64_t startNonce = 0;
-	int exSizeBits = -1;
-	int job_len = 8;
+    uint64_t startNonce = 0;
+    int exSizeBits = -1;
+    int job_len = 8;
 };
 
 struct Solution

--- a/libethcore/EthashAux.h
+++ b/libethcore/EthashAux.h
@@ -62,8 +62,8 @@ private:
     Mutex x_lights;
     std::unordered_map<int, LightType> m_lights;
 
-    Mutex x_epochs;
-    std::unordered_map<h256, unsigned> m_epochs;
+    int m_cached_epoch = 0;
+    h256 m_cached_seed;  // Seed for epoch 0 is the null hash.
 };
 
 struct WorkPackage

--- a/libpoolprotocols/getwork/EthGetworkClient.cpp
+++ b/libpoolprotocols/getwork/EthGetworkClient.cpp
@@ -95,7 +95,7 @@ void EthGetworkClient::workLoop()
 				Json::Value v = p_client->eth_getWork();
 				WorkPackage newWorkPackage;
 				newWorkPackage.header = h256(v[0].asString());
-				newWorkPackage.seed = h256(v[1].asString());
+				newWorkPackage.epoch = EthashAux::toEpoch(h256(v[1].asString()));
 
 				// Since we do not have a real connected state with getwork, we just fake it.
 				// If getting work succeeds we know that the connection works
@@ -108,7 +108,7 @@ void EthGetworkClient::workLoop()
 				// Check if header changes so the new workpackage is really new
 				if (newWorkPackage.header != m_prevWorkPackage.header) {
 					m_prevWorkPackage.header = newWorkPackage.header;
-					m_prevWorkPackage.seed = newWorkPackage.seed;
+					m_prevWorkPackage.epoch = newWorkPackage.epoch;
 					m_prevWorkPackage.boundary = h256(fromHex(v[2].asString()), h256::AlignRight);
 
 					if (m_onWorkReceived) {

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -489,15 +489,15 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
 					m_stale = true;
 				if (m_connection.Version() == EthStratumClient::ETHEREUMSTRATUM)
 				{
-					string sSeedHash = params.get((Json::Value::ArrayIndex)1, "").asString();
-					string sHeaderHash = params.get((Json::Value::ArrayIndex)2, "").asString();
+					string sSeedHash = params.get(1, "").asString();
+					string sHeaderHash = params.get(2, "").asString();
 
 					if (sHeaderHash != "" && sSeedHash != "")
 					{
 						reset_work_timeout();
 
 						m_current.header = h256(sHeaderHash);
-						m_current.seed = h256(sSeedHash);
+						m_current.epoch = EthashAux::toEpoch(h256(sSeedHash));
 						m_current.boundary = h256();
 						diffToTarget((uint32_t*)m_current.boundary.data(), m_nextWorkDifficulty);
 						m_current.startNonce = ethash_swap_u64(*((uint64_t*)m_extraNonce.data()));
@@ -533,7 +533,7 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
 							reset_work_timeout();
 
 							m_current.header = h256(sHeaderHash);
-							m_current.seed = h256(sSeedHash);
+							m_current.epoch = EthashAux::toEpoch(h256(sSeedHash));
 							m_current.boundary = h256(sShareTarget);
 							m_current.job = h256(job);
 

--- a/libpoolprotocols/testing/SimulateClient.cpp
+++ b/libpoolprotocols/testing/SimulateClient.cpp
@@ -49,7 +49,7 @@ void SimulateClient::submitSolution(Solution solution)
 {
 	m_uppDifficulty = true;
 	cnote << "Difficulty:" << m_difficulty;
-	if (EthashAux::eval(solution.work.seed, solution.work.header, solution.nonce).value < solution.work.boundary)
+	if (EthashAux::eval(solution.work.epoch, solution.work.header, solution.nonce).value < solution.work.boundary)
 	{
 		if (m_onSolutionAccepted) {
 			m_onSolutionAccepted(false);


### PR DESCRIPTION
The epoch number is needed anyway to build light cache. Still provide a helper toEpoch() to recreate the epoch number from seed hash.