### PR TITLE
make sure that connections are deleted on disconnect

### DIFF
--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -173,6 +173,16 @@ void EthStratumClient::disconnect()
 	catch (std::exception const& _e) {
 		cwarn << "Error while disconnecting:" << _e.what();
 	}
+
+        if (m_connection.SecLevel() != SecureLevel::NONE) {
+                if (m_securesocket)
+                        m_securesocket = nullptr;
+        }
+        else {
+                if (m_socket)
+                        m_socket = nullptr;
+        }
+
 	m_authorized = false;
 	m_connected.store(false, std::memory_order_relaxed);
 


### PR DESCRIPTION
This sets the shared pointers for the sockets to null so that the
destructors of the sockets will get called when the reference count
is zero.  Without the fix there are situations where the sockets
appear to be alive after disconnection.