### PR TITLE
Add astyle support.

### DIFF
--- a/scripts/astyle.ini
+++ b/scripts/astyle.ini
@@ -1,0 +1,19 @@
+# http://astyle.sourceforge.net/astyle.html
+--indent=force-tab --style=allman
+--indent-switches --indent-namespaces --indent-col1-comments
+#--indent-preproc-cond
+--max-instatement-indent=65
+--attach-inlines
+--pad-header --pad-oper --unpad-paren
+--align-pointer=type --align-reference=type
+--close-templates
+--add-brackets
+#--convert-tabs
+--lineend=windows --preserve-date
+--suffix=none
+--ignore-exclude-errors --ignore-exclude-errors-x
+--formatted
+
+# directories
+--exclude=build
+--exclude=cov-int

--- a/scripts/run_astyle.bat
+++ b/scripts/run_astyle.bat
@@ -1,0 +1,43 @@
+@ECHO OFF
+
+SETLOCAL
+SET "FILE_DIR=%~dp0"
+PUSHD "%FILE_DIR%"
+
+SET "AStyleVerReq=3.0.1"
+astyle --ascii --version 2>NUL || (ECHO. & ECHO ERROR: AStyle not found & GOTO End)
+CALL :SubCheckVer || GOTO End
+
+
+:Start
+TITLE Running astyle using %FILE_DIR%astyle.ini
+
+IF "%~1" == "" (
+  astyle --ascii -r --options=astyle.ini ..\*.cpp
+  astyle --ascii -r --options=astyle.ini --keep-one-line-blocks ..\*.h
+) ELSE (
+  FOR %%G IN (%*) DO astyle --ascii --options=astyle.ini %%G
+)
+
+IF %ERRORLEVEL% NEQ 0 ECHO. & ECHO ERROR: Something went wrong!
+
+
+:End
+POPD
+ECHO. & ECHO Press any key to close this window...
+PAUSE >NUL
+ENDLOCAL
+EXIT /B
+
+
+:SubCheckVer
+TITLE Checking astyle version
+FOR /F "tokens=4 delims= " %%A IN ('astyle --ascii --version 2^>^&1 NUL') DO (
+  SET "AStyleVer=%%A"
+)
+
+IF %AStyleVer% NEQ %AStyleVerReq% (
+  ECHO. & ECHO ERROR: AStyle v%AStyleVerReq% is required.
+  EXIT /B 1
+)
+EXIT /B


### PR DESCRIPTION
This is my first implementation of this patch. The bat file only works on Windows but the plan is to add a precommit script (see below).

The goal is to add a precommit script which people contributing to this project can copy to their precommit script and thus being applied automatically on each commit.

It obviously requires astyle.

I can add the precommit script later after we decide on a specific style.

/CC @chfast @jean-m-cyr @smurfy @MariusVanDerWijden 