### PR TITLE
No eval for OpenCL - One last thing on my ethminer todo list.

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -536,9 +536,9 @@ public:
 		}
 		else if (arg == "--cuda-streams" && i + 1 < argc)
 			m_numStreams = stol(argv[++i]);
-		else if (arg == "--cuda-noeval")
-			m_cudaNoEval = true;
 #endif
+		else if (arg == "--noeval")
+			m_noEval = true;
 		else if ((arg == "-L" || arg == "--dag-load-mode") && i + 1 < argc)
 		{
 			string mode = argv[++i];
@@ -696,6 +696,7 @@ public:
 					0,
 					m_dagLoadMode,
 					m_dagCreateDevice,
+					m_noEval,
 					m_exit
 				))
 				exit(1);
@@ -722,7 +723,7 @@ public:
 				m_cudaSchedule,
 				m_dagLoadMode,
 				m_dagCreateDevice,
-				m_cudaNoEval,
+				m_noEval,
 				m_exit
 				))
 				exit(1);
@@ -821,7 +822,7 @@ public:
 			<< "        sync  - Instruct CUDA to block the CPU thread on a synchronization primitive when waiting for the results from the device." << endl
 			<< "    --cuda-devices <0 1 ..n> Select which CUDA GPUs to mine on. Default is to use all" << endl
 			<< "    --cuda-parallel-hash <1 2 ..8> Define how many hashes to calculate in a kernel, can be scaled to achieve better performance. Default=4" << endl
-			<< "    --cuda-noeval  bypass host software re-evaluation of GPU solutions." << endl
+			<< "    --noeval  bypass host software re-evaluation of GPU solutions." << endl
 			<< "        This will trim some milliseconds off the time it takes to send a result to the pool." << endl
 			<< "        Use at your own risk! If GPU generates errored results they WILL be forwarded to the pool" << endl
 			<< "        Not recommended at high overclock." << endl
@@ -1009,9 +1010,9 @@ private:
 	unsigned m_cudaSchedule = 4; // sync
 	unsigned m_cudaGridSize = CUDAMiner::c_defaultGridSize;
 	unsigned m_cudaBlockSize = CUDAMiner::c_defaultBlockSize;
-	bool m_cudaNoEval = false;
 	unsigned m_parallelHash    = 4;
 #endif
+	bool m_noEval = false;
 	unsigned m_dagLoadMode = 0; // parallel
 	unsigned m_dagCreateDevice = 0;
 	bool m_exit = false;

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -536,6 +536,8 @@ public:
 		}
 		else if (arg == "--cuda-streams" && i + 1 < argc)
 			m_numStreams = stol(argv[++i]);
+		else if (arg == "--cuda-noeval")
+			m_noEval = true;
 #endif
 		else if (arg == "--noeval")
 			m_noEval = true;

--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -61,7 +61,7 @@ public:
 	static void listDevices();
     static bool configureGPU(unsigned _localWorkSize, unsigned _globalWorkSizeMultiplier,
         unsigned _platformId, int epoch, unsigned _dagLoadMode, unsigned _dagCreateDevice,
-        bool _exit);
+        bool _noeval, bool _exit);
     static void setNumInstances(unsigned _instances) { s_numInstances = std::min<unsigned>(_instances, getNumDevices()); }
 	static void setThreadsPerHash(unsigned _threadsPerHash){s_threadsPerHash = _threadsPerHash; }
 	static void setDevices(const vector<unsigned>& _devices, unsigned _selectedDeviceCount)

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -299,7 +299,6 @@ unsigned CUDAMiner::s_blockSize = CUDAMiner::c_defaultBlockSize;
 unsigned CUDAMiner::s_gridSize = CUDAMiner::c_defaultGridSize;
 unsigned CUDAMiner::s_numStreams = CUDAMiner::c_defaultNumStreams;
 unsigned CUDAMiner::s_scheduleFlag = 0;
-bool CUDAMiner::s_noeval = false;
 
 bool CUDAMiner::cuda_init(
     size_t numDevices,
@@ -514,7 +513,7 @@ void CUDAMiner::search(
                     else
                     {
                         Result r = EthashAux::eval(w.epoch, w.header, nonces[i]);
-                        if (r.value < w.boundary)
+                        if (r.value <= w.boundary)
                             farm.submitProof(Solution{nonces[i], r.mixHash, w, m_new_work});
                         else
                         {

--- a/libethash-cuda/CUDAMiner.h
+++ b/libethash-cuda/CUDAMiner.h
@@ -127,9 +127,6 @@ private:
 
 	static unsigned s_numInstances;
 	static vector<int> s_devices;
-
-	static bool s_noeval;
-
 };
 
 

--- a/libethcore/Miner.cpp
+++ b/libethcore/Miner.cpp
@@ -14,3 +14,5 @@ uint8_t* dev::eth::Miner::s_dagInHostMemory = NULL;
 
 bool dev::eth::Miner::s_exit = false;
 
+bool dev::eth::Miner::s_noeval = false;
+

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -234,6 +234,7 @@ protected:
 	static unsigned s_dagCreateDevice;
 	static uint8_t* s_dagInHostMemory;
 	static bool s_exit;
+	static bool s_noeval;
 
 	const size_t index = 0;
 	FarmFace& farm;


### PR DESCRIPTION
- Rename -cuda-noeval option to --noeval since it can now apply to
  both Cuda and OpenCl.
- Add support for using GPU mix hash result when noeval is set in
  CLMiner.
- Modify experimental opencl kernel to return mix hash on solution
  found.
- Modify stable opencl kernel to return mix hash on solution
  found.
- Move global s_noval bool to common miner.cpp