### PR TITLE
fix for #1018

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -960,6 +960,13 @@ private:
 			mgr.addConnection(m_endpoints[i]);
 		}
 
+		// If we are in simulation mode we add a fake connection
+		if (m_mode == OperationMode::Simulation) {
+			PoolConnection con(URI("http://-:0"));
+			mgr.clearConnections();
+			mgr.addConnection(con);
+		}
+
 #if API_CORE
 		Api api(this->m_api_port, f);
 #endif


### PR DESCRIPTION
With new uri schema, no default connection exists and simulation broke.
This adds a new dummy connection if in Simulation Mode.

This fixes #1018 