### PR TITLE
Response timeout as configurable CLI argument

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -331,6 +331,9 @@ public:
 			try
 			{
 				m_responsetimeout = stoi(argv[++i]);
+				// Do not allow less than 2 seconds 
+				// or we may keep disconnecting and reconnecting
+				m_responsetimeout = (m_responsetimeout < 2 ? 2 : m_responsetimeout);
 			}
 			catch (...)
 			{

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -315,7 +315,29 @@ public:
 		}
 		else if ((arg == "--work-timeout") && i + 1 < argc)
 		{
-			m_worktimeout = atoi(argv[++i]);
+			try
+			{
+				m_worktimeout = atoi(argv[++i]);
+			}
+			catch (...)
+			{
+				cerr << "Bad " << arg << " option: " << argv[i] << endl;
+				BOOST_THROW_EXCEPTION(BadArgument());
+			}
+			
+		}
+		else if ((arg == "--response-timeout") && i + 1 < argc)
+		{
+			try
+			{
+				m_responsetimeout = atoi(argv[++i]);
+			}
+			catch (...)
+			{
+				cerr << "Bad " << arg << " option: " << argv[i] << endl;
+				BOOST_THROW_EXCEPTION(BadArgument());
+			}
+
 		}
 		else if ((arg == "-RH" || arg == "--report-hashrate"))
 		{
@@ -769,6 +791,7 @@ public:
 			<< "    -O, --userpass <username.workername:password> (deprecated) Stratum login credentials" << endl
 			<< "    -FO, --failover-userpass <username.workername:password> (deprecated) Failover stratum login credentials (optional, will use normal credentials when omitted)" << endl
 			<< "    --work-timeout <n> reconnect/failover after n seconds of working on the same (stratum) job. Defaults to 180. Don't set lower than max. avg. block time" << endl
+			<< "    --response-timeout <n> reconnect/failover after n seconds delay for response from (stratum) pool. Defaults to 2. Also affects connection timeout" << endl
 			<< "    --stratum-ssl [<n>]  (deprecated) Use encryption to connect to stratum server." << endl
 			<< "        0: Force TLS1.2 (default)" << endl
 			<< "        1: Allow any TLS version" << endl
@@ -936,7 +959,7 @@ private:
 		PoolClient *client = nullptr;
 
 		if (m_mode == OperationMode::Stratum) {
-			client = new EthStratumClient(m_worktimeout, m_email, m_report_stratum_hashrate);
+			client = new EthStratumClient(m_worktimeout, m_responsetimeout, m_email, m_report_stratum_hashrate);
 		}
 		else if (m_mode == OperationMode::Farm) {
 			client = new EthGetworkClient(m_farmRecheckPeriod);
@@ -1053,7 +1076,12 @@ private:
 	unsigned m_farmRecheckPeriod = 500;
 	unsigned m_displayInterval = 5;
 	bool m_farmRecheckSet = false;
+	
+	// Number of seconds to wait before triggering a no work timeout from pool
 	int m_worktimeout = 180;
+	// Number of seconds to wait before triggering a response timeout from pool
+	int m_responsetimeout = 2;
+
 	bool m_show_hwmonitors = false;
 	bool m_show_power = false;
 #if API_CORE

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -317,7 +317,7 @@ public:
 		{
 			try
 			{
-				m_worktimeout = atoi(argv[++i]);
+				m_worktimeout = stoi(argv[++i]);
 			}
 			catch (...)
 			{
@@ -330,7 +330,7 @@ public:
 		{
 			try
 			{
-				m_responsetimeout = atoi(argv[++i]);
+				m_responsetimeout = stoi(argv[++i]);
 			}
 			catch (...)
 			{

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -794,7 +794,7 @@ public:
 			<< "    -O, --userpass <username.workername:password> (deprecated) Stratum login credentials" << endl
 			<< "    -FO, --failover-userpass <username.workername:password> (deprecated) Failover stratum login credentials (optional, will use normal credentials when omitted)" << endl
 			<< "    --work-timeout <n> reconnect/failover after n seconds of working on the same (stratum) job. Defaults to 180. Don't set lower than max. avg. block time" << endl
-			<< "    --response-timeout <n> reconnect/failover after n seconds delay for response from (stratum) pool. Defaults to 2. Also affects connection timeout" << endl
+			<< "    --response-timeout <n> reconnect/failover after n seconds delay for response from (stratum) pool. Also affects connection timeout. Minimum value 2. Default 2." << endl
 			<< "    --stratum-ssl [<n>]  (deprecated) Use encryption to connect to stratum server." << endl
 			<< "        0: Force TLS1.2 (default)" << endl
 			<< "        1: Allow any TLS version" << endl

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -417,9 +417,9 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec, tcp:
 
 }
 
-string EthStratumClient::processError(Json::Value& responseObject)
+std::string EthStratumClient::processError(Json::Value& responseObject)
 {
-	string retVar = "";
+	std::string retVar = "";
 
 	if (responseObject.isMember("error") && !responseObject.get("error", Json::Value::null).isNull()) {
 
@@ -1134,7 +1134,13 @@ void EthStratumClient::onRecvSocketDataCompleted(const boost::system::error_code
 	else
 	{
 		if (isConnected()) {
-			cwarn << "Socket read failed:" << ec.message();
+			if (ec == boost::asio::error::eof)
+			{
+				cnote << "Connection remotely closed by" << m_conn.Host();
+			}
+			else {
+				cwarn << "Socket read failed:" << ec.message();
+			}
 			disconnect();
 		}
 	}

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -40,19 +40,18 @@ static void diffToTarget(uint32_t *target, double diff)
 }
 
 
-EthStratumClient::EthStratumClient(int const & worktimeout, int const & responsetimeout, string const & email, bool const & submitHashrate) : PoolClient(),
+EthStratumClient::EthStratumClient(int worktimeout, int responsetimeout, string const & email, bool const & submitHashrate) : PoolClient(),
 	m_socket(nullptr),
 	m_conntimer(m_io_service),
 	m_worktimer(m_io_service),
 	m_responsetimer(m_io_service),
-	m_resolver(m_io_service)
+	m_resolver(m_io_service),
+	m_worktimeout(worktimeout),
+	m_responsetimeout(responsetimeout),
+	m_email(email),
+	m_submit_hashrate(submitHashrate)
 {
 
-	m_worktimeout = worktimeout;
-	m_responsetimeout = responsetimeout;
-	m_email = email;
-
-	m_submit_hashrate = submitHashrate;
 	if (m_submit_hashrate)
 		m_submit_hashrate_id = h256::random().hex();
 }
@@ -419,7 +418,7 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec, tcp:
 
 std::string EthStratumClient::processError(Json::Value& responseObject)
 {
-	std::string retVar = "";
+	std::string retVar;
 
 	if (responseObject.isMember("error") && !responseObject.get("error", Json::Value::null).isNull()) {
 

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -40,7 +40,7 @@ static void diffToTarget(uint32_t *target, double diff)
 }
 
 
-EthStratumClient::EthStratumClient(int const & worktimeout, string const & email, bool const & submitHashrate) : PoolClient(),
+EthStratumClient::EthStratumClient(int const & worktimeout, int const & responsetimeout, string const & email, bool const & submitHashrate) : PoolClient(),
 	m_socket(nullptr),
 	m_conntimer(m_io_service),
 	m_worktimer(m_io_service),
@@ -49,6 +49,7 @@ EthStratumClient::EthStratumClient(int const & worktimeout, string const & email
 {
 
 	m_worktimeout = worktimeout;
+	m_responsetimeout = responsetimeout;
 	m_email = email;
 
 	m_submit_hashrate = submitHashrate;
@@ -250,7 +251,7 @@ void EthStratumClient::start_connect(tcp::resolver::iterator endpoint_iter)
 
 		cnote << ("Trying " + toString(endpoint_iter->endpoint()) + " ...");
 		
-		m_conntimer.expires_from_now(boost::posix_time::seconds(m_conntimeout));
+		m_conntimer.expires_from_now(boost::posix_time::seconds(m_responsetimeout));
 
 		// Start connecting async
 		m_socket->async_connect(endpoint_iter->endpoint(), 

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -24,7 +24,7 @@ public:
 
 	typedef enum { STRATUM = 0, ETHPROXY, ETHEREUMSTRATUM } StratumProtocol;
 
-	EthStratumClient(int const & worktimeout, string const & email, bool const & submitHashrate);
+	EthStratumClient(int const & worktimeout, int const & responsetimeout, string const & email, bool const & submitHashrate);
 	~EthStratumClient();
 
 	void connect();
@@ -73,14 +73,11 @@ private:
 	std::atomic<bool> m_connected = { false };
 	std::atomic<bool> m_disconnecting = { false };
 
-	// Fixed 120 seconds to trigger a work_timeout
-	int m_worktimeout = 120;
+	// 180 seconds to trigger a work_timeout (overwritten in constructor)
+	int m_worktimeout = 180;
 	
-	// Fixed 2 seconds timeout for a response to a submission of solution
+	// 2 seconds timeout for responses and connection (overwritten in constructor)
 	int m_responsetimeout = 2;
-
-	// Fixed 3 seconds timeout for a connection attempt
-	int m_conntimeout = 3;
 
 	WorkPackage m_current;
 

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -24,7 +24,7 @@ public:
 
 	typedef enum { STRATUM = 0, ETHPROXY, ETHEREUMSTRATUM } StratumProtocol;
 
-	EthStratumClient(int const & worktimeout, int const & responsetimeout, string const & email, bool const & submitHashrate);
+	EthStratumClient(int worktimeout, int responsetimeout, string const & email, bool const & submitHashrate);
 	~EthStratumClient();
 
 	void connect();

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -57,7 +57,7 @@ private:
 
 	void reset_work_timeout();
 	void processReponse(Json::Value& responseObject);
-	string processError(Json::Value& erroresponseObject);
+	std::string processError(Json::Value& erroresponseObject);
 	void processExtranonce(std::string& enonce);
 
 	void recvSocketData();
@@ -97,7 +97,6 @@ private:
 	boost::asio::streambuf m_sendBuffer;
 	boost::asio::streambuf m_recvBuffer;
 	Json::FastWriter m_jWriter;
-	int m_recvBufferSize = 1024;
 
 	boost::asio::deadline_timer m_conntimer;
 	boost::asio::deadline_timer m_worktimer;
@@ -115,6 +114,6 @@ private:
 	int m_extraNonceHexSize;
 	
 	bool m_submit_hashrate = false;
-	string m_submit_hashrate_id;
+	std::string m_submit_hashrate_id;
 
 };


### PR DESCRIPTION
Add --response-timeout as new cli argument to allow tuning on shared
network connections.