### PR TITLE
improving CLMiner::configureGPU() if a subset of the available GPUs is selected

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -484,6 +484,7 @@ bool CLMiner::configureGPU(unsigned _localWorkSize, unsigned _globalWorkSizeMult
         return false;
 
     vector<cl::Device> devices = getDevices(platforms, _platformId);
+    bool foundSuitableDevice = false;
     for (auto const& device: devices)
     {
         cl_ulong result = 0;
@@ -493,15 +494,20 @@ bool CLMiner::configureGPU(unsigned _localWorkSize, unsigned _globalWorkSizeMult
             cnote <<
                 "Found suitable OpenCL device [" << device.getInfo<CL_DEVICE_NAME>()
                                                  << "] with " << result << " bytes of GPU memory";
-            return true;
-        }
-
+            foundSuitableDevice = true;
+        } 
+        else 
+        {
         cnote <<
             "OpenCL device " << device.getInfo<CL_DEVICE_NAME>()
                              << " has insufficient GPU memory." << result <<
                              " bytes of memory found < " << dagSize << " bytes of memory required";
+        }
     }
-
+    if (foundSuitableDevice) 
+    {
+        return true;
+    }
     cout << "No GPU device with sufficient memory was found. Can't GPU mine. Remove the -G argument" << endl;
     return false;
 }


### PR DESCRIPTION
[improving output/behavior of CLMiner::configureGPU() if a subset of the available GPUs is selected]

What I think CLMiner::configureGPU() intends to do: 
Check for each OpenCL device [GPU] that is has sufficient Memory in order to contain the DAG file.

What it currently does:
It checks if the first (and only the first) OpenCL device in the given platform has sufficient memory.
It ignores any GPU selection settings. If the first device does not fulfill the memory requirement, it quits.

What it does after including my change:
It checks every OpenCL device in the given platform, and only quits if none of them fulfill the memory requirement.