### PR TITLE
For AMD. Adjust global work size according to # of compute units.

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -554,7 +554,7 @@ public:
 		{
 			try
 			{
-				m_globalWorkSizeMultiplier = stol(argv[++i]);
+				m_globalWorkSizeMultiplier = stoi(argv[++i]);
 
 			}
 			catch (...)
@@ -932,6 +932,8 @@ public:
 			<< "        1: experimental kernel" << endl
 			<< "    --cl-local-work Set the OpenCL local work size. Default is " << CLMiner::c_defaultLocalWorkSize << endl
 			<< "    --cl-global-work Set the OpenCL global work size as a multiple of the local work size. Default is " << CLMiner::c_defaultGlobalWorkSizeMultiplier << " * " << CLMiner::c_defaultLocalWorkSize << endl
+			<< "        Can be specified as negative (ie. -8192) in which case it it will be made positive," << endl
+			<< "        and it will be ajusted appropriately based on the compute power of individual AMD GPUs." << endl
 			<< "    --cl-parallel-hash <1 2 ..8> Define how many threads to associate per hash. Default=8" << endl
 #endif
 #if ETH_ETHASHCUDA
@@ -1133,7 +1135,7 @@ private:
 	unsigned m_openclDeviceCount = 0;
 	vector<unsigned> m_openclDevices = vector<unsigned>(MAX_MINERS, -1);
 	unsigned m_openclThreadsPerHash = 8;
-	unsigned m_globalWorkSizeMultiplier = CLMiner::c_defaultGlobalWorkSizeMultiplier;
+	int m_globalWorkSizeMultiplier = CLMiner::c_defaultGlobalWorkSizeMultiplier;
 	unsigned m_localWorkSize = CLMiner::c_defaultLocalWorkSize;
 #endif
 #if ETH_ETHASHCUDA

--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -59,7 +59,7 @@ public:
 	static unsigned instances() { return s_numInstances > 0 ? s_numInstances : 1; }
 	static unsigned getNumDevices();
 	static void listDevices();
-    static bool configureGPU(unsigned _localWorkSize, unsigned _globalWorkSizeMultiplier,
+    static bool configureGPU(unsigned _localWorkSize, int _globalWorkSizeMultiplier,
         unsigned _platformId, int epoch, unsigned _dagLoadMode, unsigned _dagCreateDevice,
         bool _noeval, bool _exit);
     static void setNumInstances(unsigned _instances) { s_numInstances = std::min<unsigned>(_instances, getNumDevices()); }
@@ -101,6 +101,8 @@ private:
 	static unsigned s_workgroupSize;
 	/// The initial global work size for the searches
 	static unsigned s_initialGlobalWorkSize;
+	static bool s_adjustWorkSize;
+
 };
 
 }


### PR DESCRIPTION
The default parameters are ok for the 480, but less so for 460, and
470. The global work size is adjusted up or down depending on the
number of GPU compute units, allowing for better optimization of
rigs with mixed AMD GPU types.