### PR TITLE
Make CUDA log New Epoch and add --keep-working (-KW) option 

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -79,6 +79,7 @@ inline std::string toJS(unsigned long _n)
 }
 
 bool g_running = false;
+bool g_keepworking = false;
 
 class MinerCLI
 {
@@ -396,6 +397,10 @@ public:
 				BOOST_THROW_EXCEPTION(BadArgument());
 			}
 
+		}
+		else if ((arg == "-KW" || arg == "--keep-working"))
+		{
+			g_keepworking = true;
 		}
 		else if ((arg == "-RH" || arg == "--report-hashrate"))
 		{
@@ -892,6 +897,7 @@ public:
 			<< "        0: Displays only temp and fan percent (default)" << endl
 			<< "        1: Also displays power usage" << endl
 			<< "    --exit Stops the miner whenever an error is encountered" << endl
+			<< "    -KW, --keep-working Do not stop working if server connection lost. Avoids DAG regeneration but continues using power while disconnected." << endl
 			<< "    -SE, --stratum-email <s> Email address used in eth-proxy (optional)" << endl
 			<< "    --farm-recheck <n>  Leave n ms between checks for changed work (default: 500). When using stratum, use a high value (i.e. 2000) to get more stable hashrate output" << endl
 			<< "    -P URL Specify a pool URL. Can be used multiple times. The 1st for for the primary pool, and the 2nd for the failover pool." << endl

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -102,8 +102,11 @@ void CUDAMiner::workLoop()
                     continue;
                 }
                 if (current.epoch != w.epoch)
+		{
+		    cudalog << "New epoch: " << w.epoch;
                     if(!init(w.epoch))
                         break;
+		}
                 current = w;
             }
             uint64_t upper64OfBoundary = (uint64_t)(u64)((u256)current.boundary >> 192);

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -36,6 +36,8 @@
 #include <libhwmon/wrapamdsysfs.h>
 #endif
 
+extern bool g_keepworking;
+
 namespace dev
 {
 

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -43,7 +43,7 @@ PoolManager::PoolManager(PoolClient * client, Farm &farm, MinerType const & mine
 	{
 		cnote << "Disconnected from " + m_connections[m_activeConnectionIdx].Host() << p_client->ActiveEndPoint();
 
-		if (m_farm.isMining()) {
+		if (m_farm.isMining() && !g_keepworking) {
 			cnote << "Shutting down miners...";
 			m_farm.stop();
 		}


### PR DESCRIPTION
- CLMiner.cpp logs new epoch, this is similar to CUDAMiner.cpp
- new command line option:
> -KW, --keep-working Do not stop working if server connection lost. Avoids DAG regeneration but continues using power while disconnected.