### PR TITLE
Reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Fixed
+- Reconnecting with mining pool improved [[#1135](https://github.com/ethereum-mining/ethminer/pull/1135)].
 ### Removed
 - Disabled Debug configuration for Visual Studio [[#69](https://github.com/ethereum-mining/ethminer/issues/69)] [[#1131](https://github.com/ethereum-mining/ethminer/pull/1131)].

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -197,7 +197,7 @@ public:
 		{
 			string url = argv[++i];
 			if (url == "exit") // add fake scheme and port to 'exit' url
-				url = "stratum://exit:1";
+				url = "stratum+tcp://-:x@exit:0";
 			URI uri;
 			try {
 				uri = url;
@@ -809,8 +809,7 @@ private:
 		Farm f;
 		f.setSealers(sealers);
 
-		PoolManager mgr(client, f, m_minerType);
-		mgr.setReconnectTries(m_maxFarmRetries);
+		PoolManager mgr(client, f, m_minerType, m_maxFarmRetries);
 
 		// If we are in simulation mode we add a fake connection
 		if (m_mode == OperationMode::Simulation) {
@@ -848,7 +847,7 @@ private:
 		}
 
 		mgr.stop();
-
+		cnote << "Terminated !";
 		exit(0);
 	}
 

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -788,7 +788,7 @@ private:
 		//PoolClient *client = nullptr;
 
 		//if (m_mode == OperationMode::Stratum) {
-		//	client = new EthStratumClient(m_worktimeout, m_responsetimeout, m_email, m_report_stratum_hashrate);
+		//	// client = new EthStratumClient(m_worktimeout, m_responsetimeout, m_email, m_report_stratum_hashrate);
 		//}
 		//else if (m_mode == OperationMode::Farm) {
 		//	client = new EthGetworkClient(m_farmRecheckPeriod);

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -833,8 +833,6 @@ private:
 		sealers["cuda"] = Farm::SealerDescriptor{&CUDAMiner::instances, [](FarmFace& _farm, unsigned _index){ return new CUDAMiner(_farm, _index); }};
 #endif
 
-		//EthStratumClient::pointer client = EthStratumClient::create(m_worktimeout, m_responsetimeout, m_email, m_report_stratum_hashrate);
-
 		PoolClient *client = nullptr;
 
 		if (m_mode == OperationMode::Stratum) {

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -783,27 +783,29 @@ private:
 		sealers["cuda"] = Farm::SealerDescriptor{&CUDAMiner::instances, [](FarmFace& _farm, unsigned _index){ return new CUDAMiner(_farm, _index); }};
 #endif
 
-		PoolClient *client = nullptr;
+		EthStratumClient::pointer client = EthStratumClient::create(m_worktimeout, m_responsetimeout, m_email, m_report_stratum_hashrate);
 
-		if (m_mode == OperationMode::Stratum) {
-			client = new EthStratumClient(m_worktimeout, m_responsetimeout, m_email, m_report_stratum_hashrate);
-		}
-		else if (m_mode == OperationMode::Farm) {
-			client = new EthGetworkClient(m_farmRecheckPeriod);
-		}
-		else if (m_mode == OperationMode::Simulation) {
-			client = new SimulateClient(20, m_benchmarkBlock);
-		}
-		else {
-			cwarn << "Invalid OperationMode";
-			exit(1);
-		}
+		//PoolClient *client = nullptr;
 
-		// Should not happen!
-		if (!client) {
-			cwarn << "Invalid PoolClient";
-			exit(1);
-		}
+		//if (m_mode == OperationMode::Stratum) {
+		//	client = new EthStratumClient(m_worktimeout, m_responsetimeout, m_email, m_report_stratum_hashrate);
+		//}
+		//else if (m_mode == OperationMode::Farm) {
+		//	client = new EthGetworkClient(m_farmRecheckPeriod);
+		//}
+		//else if (m_mode == OperationMode::Simulation) {
+		//	client = new SimulateClient(20, m_benchmarkBlock);
+		//}
+		//else {
+		//	cwarn << "Invalid OperationMode";
+		//	exit(1);
+		//}
+
+		//// Should not happen!
+		//if (!client) {
+		//	cwarn << "Invalid PoolClient";
+		//	exit(1);
+		//}
 
 		//sealers, m_minerType
 		Farm f;

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -178,6 +178,7 @@ public:
 
 		m_hashrateTimer.cancel();
 		m_io_service.stop();
+		m_serviceThread.join();
 
 		m_lastProgresses.clear();
 	}

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -157,13 +157,6 @@ public:
 		m_hashrateTimer.expires_from_now(boost::posix_time::milliseconds(1000));
 		m_hashrateTimer.async_wait(m_io_strand.wrap(boost::bind(&Farm::processHashRate, this, boost::asio::placeholders::error)));
 
-		//if (m_serviceThread.joinable()) {
-		//	m_io_service.reset();
-		//	m_serviceThread.join();
-		//}
-
-		//m_serviceThread = std::thread{ boost::bind(&boost::asio::io_service::run, &m_io_service) };
-
 		return true;
 	}
 

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -431,8 +431,6 @@ private:
 	std::chrono::steady_clock::time_point m_lastStart;
 	uint64_t m_hashrateSmoothInterval = 10000;
 
-	// std::thread m_serviceThread;  ///< The IO service thread.
-
 	boost::asio::io_service::strand m_io_strand;
 	boost::asio::deadline_timer m_hashrateTimer;
 	std::vector<WorkingProgress> m_lastProgresses;

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -177,8 +177,8 @@ public:
 		}
 
 		m_hashrateTimer.cancel();
-		m_io_service.stop();
-		m_serviceThread.join();
+		//m_io_service.stop();
+		//m_serviceThread.join();
 
 		m_lastProgresses.clear();
 	}
@@ -446,7 +446,7 @@ private:
 	mutable SolutionStats m_solutionStats;
 	std::chrono::steady_clock::time_point m_farm_launched = std::chrono::steady_clock::now();
 
-    	string m_pool_addresses;
+    string m_pool_addresses;
 	uint64_t m_nonce_scrambler;
 
 	wrap_nvml_handle *nvmlh = NULL;

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -57,7 +57,6 @@ public:
 	};
 
 	Farm(boost::asio::io_service & io_service): 
-		m_io_service(io_service),
 		m_io_strand(io_service),
 		m_hashrateTimer(io_service)
 	{
@@ -441,7 +440,6 @@ private:
 
 	// std::thread m_serviceThread;  ///< The IO service thread.
 
-	boost::asio::io_service & m_io_service;							// The IO service reference passed in the constructor
 	boost::asio::io_service::strand m_io_strand;
 	boost::asio::deadline_timer m_hashrateTimer;
 	std::vector<WorkingProgress> m_lastProgresses;

--- a/libpoolprotocols/PoolClient.h
+++ b/libpoolprotocols/PoolClient.h
@@ -16,6 +16,9 @@ namespace dev
 		class PoolClient
 		{
 		public:
+			virtual ~PoolClient() noexcept = default;
+
+
 			void setConnection(URI &conn)
 			{
 				m_conn = conn;

--- a/libpoolprotocols/PoolClient.h
+++ b/libpoolprotocols/PoolClient.h
@@ -28,6 +28,7 @@ namespace dev
 			virtual void submitHashrate(string const & rate) = 0;
 			virtual void submitSolution(Solution solution) = 0;
 			virtual bool isConnected() = 0;
+			virtual bool isPendingState() = 0;
 			virtual string ActiveEndPoint() = 0;
 
 			using SolutionAccepted = std::function<void(bool const&)>;
@@ -46,7 +47,7 @@ namespace dev
 			bool m_authorized = false;
 			bool m_connected = false;
 			bool m_connection_changed = false;
-			boost::asio::ip::tcp::endpoint m_endpoint;
+			boost::asio::ip::basic_endpoint<boost::asio::ip::tcp> m_endpoint;
 
 			URI m_conn;
 

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -46,6 +46,7 @@ PoolManager::PoolManager(PoolClient * client, Farm &farm, MinerType const & mine
 
 	p_client->onDisconnected([&]()
 	{
+		dev::setThreadName("main");
 		cnote << "Disconnected from " + m_connections[m_activeConnectionIdx].Host() << p_client->ActiveEndPoint();
 
 		// Do not stop mining here
@@ -183,6 +184,8 @@ void PoolManager::workLoop()
 		// Otherwise do nothing and wait until connection state is NOT pending
 		if (!p_client->isPendingState()) {
 
+			dev::setThreadName("main");
+
 			if (!p_client->isConnected()) {
 
 				// Rotate connections if above max attempts threshold
@@ -224,7 +227,6 @@ void PoolManager::workLoop()
 				}
 				else {
 
-					dev::setThreadName("main");
 					cnote << "No more failover connections.";
 
 					// Stop mining if applicable

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -172,14 +172,15 @@ void PoolManager::stop()
 
 void PoolManager::workLoop()
 {
+
+	dev::setThreadName("main");
+
 	while (m_running.load(std::memory_order_relaxed))
 	{
 
 		// Take action only if not pending state (connecting/disconnecting)
 		// Otherwise do nothing and wait until connection state is NOT pending
 		if (!p_client->isPendingState()) {
-
-			dev::setThreadName("main");
 
 			if (!p_client->isConnected()) {
 
@@ -203,8 +204,6 @@ void PoolManager::workLoop()
 						}
 
 					}
-
-
 
 				}
 

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -53,11 +53,6 @@ PoolManager::PoolManager(PoolClient * client, Farm &farm, MinerType const & mine
 		// Workloop will determine if we're trying a fast reconnect to same pool
 		// or if we're switching to failover(s)
 
-		//if (m_farm.isMining()) {
-		//	cnote << "Shutting down miners...";
-		//	m_farm.stop();
-		//}
-
 	});
 
 	p_client->onWorkReceived([&](WorkPackage const& wp)

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -19,13 +19,42 @@ static string diffToDisplay(double diff)
 	return ss.str();
 }
 
-PoolManager::PoolManager(PoolClient * client, Farm &farm, MinerType const & minerType) : Worker("main"), m_farm(farm), m_minerType(minerType)
+PoolManager::PoolManager(PoolClient * client, Farm &farm, MinerType const & minerType, unsigned maxTries) : Worker("main"), m_farm(farm), m_minerType(minerType)
 {
 	p_client = client;
-
+	m_maxConnectionAttempts = maxTries;
+	
 	p_client->onConnected([&]()
 	{
+		m_connectionAttempt = 0;
 		cnote << "Connected to " << m_connections[m_activeConnectionIdx].Host() << p_client->ActiveEndPoint();
+	});
+
+	p_client->onDisconnected([&]()
+	{
+		cnote << "Disconnected from " + m_connections[m_activeConnectionIdx].Host() << p_client->ActiveEndPoint();
+
+		if (m_farm.isMining()) {
+			cnote << "Shutting down miners...";
+			m_farm.stop();
+		}
+
+	});
+
+	p_client->onWorkReceived([&](WorkPackage const& wp)
+	{
+
+		cnote << "New job" << wp.header << "  " + m_connections[m_activeConnectionIdx].Host() + p_client->ActiveEndPoint();
+		if (wp.boundary != m_lastBoundary)
+		{
+			using namespace boost::multiprecision;
+
+			m_lastBoundary = wp.boundary;
+			static const uint512_t dividend("0x10000000000000000000000000000000000000000000000000000000000000000");
+			const uint256_t divisor(string("0x") + m_lastBoundary.hex());
+			cnote << "New pool difficulty:" << EthWhite << diffToDisplay(double(dividend / divisor)) << EthReset;
+		}
+
 		if (!m_farm.isMining())
 		{
 			cnote << "Spinning up miners...";
@@ -38,34 +67,11 @@ PoolManager::PoolManager(PoolClient * client, Farm &farm, MinerType const & mine
 				m_farm.start("opencl", true);
 			}
 		}
-	});
-	p_client->onDisconnected([&]()
-	{
-		cnote << "Disconnected from " + m_connections[m_activeConnectionIdx].Host() << p_client->ActiveEndPoint();
 
-		if (m_farm.isMining()) {
-			cnote << "Shutting down miners...";
-			m_farm.stop();
-		}
-
-		if (m_running)
-			tryReconnect();
-	});
-	p_client->onWorkReceived([&](WorkPackage const& wp)
-	{
-		m_reconnectTry = 0;
 		m_farm.setWork(wp);
-		if (wp.boundary != m_lastBoundary)
-		{
-			using namespace boost::multiprecision;
-
-			m_lastBoundary = wp.boundary;
-			static const uint512_t dividend("0x10000000000000000000000000000000000000000000000000000000000000000");
-			const uint256_t divisor(string("0x") + m_lastBoundary.hex());
-			cnote << "New pool difficulty:" << EthWhite << diffToDisplay(double(dividend / divisor)) << EthReset;
-		}
-		cnote << "New job" << wp.header << "  " + m_connections[m_activeConnectionIdx].Host() + p_client->ActiveEndPoint();
+		
 	});
+
 	p_client->onSolutionAccepted([&](bool const& stale)
 	{
 		using namespace std::chrono;
@@ -76,6 +82,7 @@ PoolManager::PoolManager(PoolClient * client, Farm &farm, MinerType const & mine
 		cnote << EthLime "**Accepted" EthReset << (stale ? "(stale)" : "") << ss.str();
 		m_farm.acceptedSolution(stale);
 	});
+
 	p_client->onSolutionRejected([&](bool const& stale)
 	{
 		using namespace std::chrono;
@@ -139,9 +146,8 @@ void PoolManager::stop()
 	if (m_running) {
 		cnote << "Shutting down...";
 		m_running = false;
-
-		if (p_client->isConnected())
-			p_client->disconnect();
+		if (p_client->isConnected()) { p_client->disconnect(); }
+		stopWorking();
 
 		if (m_farm.isMining())
 		{
@@ -155,9 +161,50 @@ void PoolManager::workLoop()
 {
 	while (m_running)
 	{
-		this_thread::sleep_for(chrono::seconds(1));
-		m_hashrateReportingTimePassed++;
+
+		// Take action only if not pending state (connecting/disconnecting)
+		// Otherwise do nothing and wait until connection state is NOT pending
+		if (!p_client->isPendingState()) {
+
+			if (!p_client->isConnected()) {
+
+				// Rotate connections if above max attempts threshold
+				if (m_connectionAttempt >= m_maxConnectionAttempts) {
+
+					m_connectionAttempt = 0;
+					m_activeConnectionIdx++;
+					if (m_activeConnectionIdx == m_connections.size()) {
+						m_activeConnectionIdx = 0;
+					}
+
+				}
+
+				if (m_connections[m_activeConnectionIdx].Host() != "exit") {
+
+					// Count connectionAttempts
+					m_connectionAttempt++;
+
+					// Invoke connections
+					p_client->setConnection(m_connections[m_activeConnectionIdx]);
+					m_farm.set_pool_addresses(m_connections[m_activeConnectionIdx].Host(), m_connections[m_activeConnectionIdx].Port());
+					cnote << "Selected pool" << (m_connections[m_activeConnectionIdx].Host() + ":" + toString(m_connections[m_activeConnectionIdx].Port()));
+					p_client->connect();
+
+				}
+				else {
+
+					dev::setThreadName("main");
+					cnote << "No more failover connections.";
+					m_running = false;
+				}
+
+			}
+
+		}
+
 		// Hashrate reporting
+		m_hashrateReportingTimePassed++;
+		
 		if (m_hashrateReportingTimePassed > m_hashrateReportingTime) {
 			auto mp = m_farm.miningProgress();
 			std::string h = toHex(toCompactBigEndian(mp.rate(), 1));
@@ -171,6 +218,9 @@ void PoolManager::workLoop()
 			p_client->submitHashrate("0x" + ss.str());
 			m_hashrateReportingTimePassed = 0;
 		}
+
+		this_thread::sleep_for(chrono::seconds(1));
+
 	}
 }
 
@@ -178,10 +228,6 @@ void PoolManager::addConnection(URI &conn)
 {
 	m_connections.push_back(conn);
 
-	if (m_connections.size() == 1) {
-		p_client->setConnection(conn);
-		m_farm.set_pool_addresses(conn.Host(), conn.Port());
-	}
 }
 
 void PoolManager::clearConnections()
@@ -197,60 +243,9 @@ void PoolManager::start()
 	if (m_connections.size() > 0) {
 		m_running = true;
 		startWorking();
-
-		// Try to connect to pool
-		cnote << "Selected pool" << (m_connections[m_activeConnectionIdx].Host() + ":" + toString(m_connections[m_activeConnectionIdx].Port()));
-		p_client->connect();
 	}
 	else {
 		cwarn << "Manager has no connections defined!";
 	}
 }
 
-void PoolManager::tryReconnect()
-{
-	// No connections available, so why bother trying to reconnect
-	if (m_connections.size() <= 0) {
-		cwarn << "Manager has no connections defined!";
-		return;
-	}
-
-	for (auto i = 4; --i; this_thread::sleep_for(chrono::seconds(1))) {
-		cnote << "Retrying in " << i << "... \r";
-	}
-
-	// We do not need awesome logic here, we just have one connection anyway
-	if (m_connections.size() == 1) {
-
-		cnote << "Selected pool" << (m_connections[m_activeConnectionIdx].Host() + ":" + toString(m_connections[m_activeConnectionIdx].Port()));
-		p_client->connect();
-		return;
-	}
-	
-	// Fallback logic, tries current connection multiple times and then switches to
-	// one of the other connections.
-	if (m_reconnectTries > m_reconnectTry) {
-
-		m_reconnectTry++;
-		cnote << "Selected pool" << (m_connections[m_activeConnectionIdx].Host() + ":" + toString(m_connections[m_activeConnectionIdx].Port()));
-		p_client->connect();
-	}
-	else {
-		m_reconnectTry = 0;
-		m_activeConnectionIdx++;
-		if (m_activeConnectionIdx >= m_connections.size()) {
-			m_activeConnectionIdx = 0;
-		}
-		if (m_connections[m_activeConnectionIdx].Host() == "exit") {
-			dev::setThreadName("main");
-			cnote << "Exiting because reconnecting is not possible.";
-			stop();
-		}
-		else {
-			p_client->setConnection(m_connections[m_activeConnectionIdx]);
-			m_farm.set_pool_addresses(m_connections[m_activeConnectionIdx].Host(), m_connections[m_activeConnectionIdx].Port());
-			cnote << "Selected pool" << (m_connections[m_activeConnectionIdx].Host() + ":" + toString(m_connections[m_activeConnectionIdx].Port()));
-			p_client->connect();
-		}
-	}
-}

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -188,27 +188,24 @@ void PoolManager::workLoop()
 				// Rotate connections if above max attempts threshold
 				if (m_connectionAttempt >= m_maxConnectionAttempts) {
 
-					unsigned lastConnectionIdx = m_activeConnectionIdx;
-
 					m_connectionAttempt = 0;
 					m_activeConnectionIdx++;
 					if (m_activeConnectionIdx == m_connections.size()) {
 						m_activeConnectionIdx = 0;
 					}
 
-					if (lastConnectionIdx != m_activeConnectionIdx) {
-
-						// Stop mining if applicable as we're switching
-						if (m_farm.isMining()) {
-							cnote << "Shutting down miners...";
-							m_farm.stop();
-						}
+					// Stop mining if applicable as we're switching
+					if (m_farm.isMining()) {
+						cnote << "Shutting down miners...";
+						m_farm.stop();
 
 						// Give some time to mining threads to shutdown
 						for (auto i = 4; --i; this_thread::sleep_for(chrono::seconds(1))) {
 							cnote << "Retrying in " << i << "... \r";
 						}
+
 					}
+
 
 
 				}

--- a/libpoolprotocols/PoolManager.h
+++ b/libpoolprotocols/PoolManager.h
@@ -6,11 +6,6 @@
 #include <libethcore/Miner.h>
 
 #include "PoolClient.h"
-#include "stratum/EthStratumClient.h"
-#include "getwork/EthGetworkClient.h"
-#include "testing/SimulateClient.h"
-
-
 
 #if ETH_DBUS
 #include "DBusInt.h"
@@ -25,7 +20,7 @@ namespace dev
 		class PoolManager
 		{
 		public:
-			PoolManager(EthStratumClient::pointer client, Farm &farm, MinerType const & minerType, unsigned maxTries);
+			PoolManager(PoolClient * client, Farm &farm, MinerType const & minerType, unsigned maxTries);
 			void addConnection(URI &conn);
 			void clearConnections();
 			void start();
@@ -49,8 +44,7 @@ namespace dev
 
 			h256 m_lastBoundary = h256();
 
-			EthStratumClient::pointer p_client;
-			//PoolClient *p_client;
+			PoolClient *p_client;
 			Farm &m_farm;
 			MinerType m_minerType;
 			std::chrono::steady_clock::time_point m_submit_time;

--- a/libpoolprotocols/PoolManager.h
+++ b/libpoolprotocols/PoolManager.h
@@ -6,6 +6,12 @@
 #include <libethcore/Miner.h>
 
 #include "PoolClient.h"
+#include "stratum/EthStratumClient.h"
+#include "getwork/EthGetworkClient.h"
+#include "testing/SimulateClient.h"
+
+
+
 #if ETH_DBUS
 #include "DBusInt.h"
 #endif
@@ -16,10 +22,10 @@ namespace dev
 {
 	namespace eth
 	{
-		class PoolManager : public Worker
+		class PoolManager
 		{
 		public:
-			PoolManager(PoolClient * client, Farm &farm, MinerType const & minerType, unsigned maxTries);
+			PoolManager(EthStratumClient::pointer client, Farm &farm, MinerType const & minerType, unsigned maxTries);
 			void addConnection(URI &conn);
 			void clearConnections();
 			void start();
@@ -31,18 +37,20 @@ namespace dev
 			unsigned m_hashrateReportingTime = 60;
 			unsigned m_hashrateReportingTimePassed = 0;
 
-			bool m_running = false;
-			void workLoop() override;
+			std::atomic<bool> m_running = { false };
+			void workLoop();
 
 			unsigned m_connectionAttempt = 0;
 			unsigned m_maxConnectionAttempts = 0;
 			unsigned m_activeConnectionIdx = 0;
 
 			std::vector <URI> m_connections;
+			std::thread m_workThread;
 
 			h256 m_lastBoundary = h256();
 
-			PoolClient *p_client;
+			EthStratumClient::pointer p_client;
+			//PoolClient *p_client;
 			Farm &m_farm;
 			MinerType m_minerType;
 			std::chrono::steady_clock::time_point m_submit_time;

--- a/libpoolprotocols/PoolManager.h
+++ b/libpoolprotocols/PoolManager.h
@@ -19,12 +19,11 @@ namespace dev
 		class PoolManager : public Worker
 		{
 		public:
-			PoolManager(PoolClient * client, Farm &farm, MinerType const & minerType);
+			PoolManager(PoolClient * client, Farm &farm, MinerType const & minerType, unsigned maxTries);
 			void addConnection(URI &conn);
 			void clearConnections();
 			void start();
 			void stop();
-			void setReconnectTries(unsigned const & reconnectTries) { m_reconnectTries = reconnectTries; };
 			bool isConnected() { return p_client->isConnected(); };
 			bool isRunning() { return m_running; };
 
@@ -34,17 +33,20 @@ namespace dev
 
 			bool m_running = false;
 			void workLoop() override;
-			unsigned m_reconnectTries = 3;
-			unsigned m_reconnectTry = 0;
-			std::vector <URI> m_connections;
+
+			unsigned m_connectionAttempt = 0;
+			unsigned m_maxConnectionAttempts = 0;
 			unsigned m_activeConnectionIdx = 0;
+
+			std::vector <URI> m_connections;
+
 			h256 m_lastBoundary = h256();
 
 			PoolClient *p_client;
 			Farm &m_farm;
 			MinerType m_minerType;
 			std::chrono::steady_clock::time_point m_submit_time;
-			void tryReconnect();
+
 		};
 	}
 }

--- a/libpoolprotocols/getwork/EthGetworkClient.h
+++ b/libpoolprotocols/getwork/EthGetworkClient.h
@@ -20,6 +20,8 @@ public:
 	void disconnect() override;
 
 	bool isConnected() override { return m_connected; }
+	bool isPendingState() override { return false; }
+
 	string ActiveEndPoint() override { return ""; };
 
 	void submitHashrate(string const & rate) override;

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -276,6 +276,11 @@ void EthStratumClient::resolve_handler(const boost::system::error_code& ec, tcp:
 	{
 		dev::setThreadName("stratum");
 		cwarn << "Could not resolve host " << m_conn.Host() << ", " << ec.message();
+
+		// Release locking flag and set connection status
+		m_connected.store(false, std::memory_order_relaxed);
+		m_disconnecting.store(false, std::memory_order::memory_order_relaxed);
+
 		// Trigger handlers
 		if (m_onDisconnected) { m_onDisconnected(); }
 

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -279,7 +279,7 @@ void EthStratumClient::resolve_handler(const boost::system::error_code& ec, tcp:
 
 		// Release locking flag and set connection status
 		m_connected.store(false, std::memory_order_relaxed);
-		m_disconnecting.store(false, std::memory_order::memory_order_relaxed);
+		m_connecting.store(false, std::memory_order::memory_order_relaxed);
 
 		// Trigger handlers
 		if (m_onDisconnected) { m_onDisconnected(); }

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -98,14 +98,13 @@ private:
 	boost::asio::io_service m_io_service;						// The IO service itself
 	boost::asio::io_service::work m_io_work;					// The IO work which prevents io_service.run() to return on no work thus terminating thread
 	boost::asio::deadline_timer m_io_work_timer;				// A dummy timer to keep io_service with something to do
+	boost::asio::io_service::strand m_io_strand;
 	boost::asio::ip::tcp::socket *m_socket;
 
 	// Use shared ptrs to avoid crashes due to async_writes
 	// see https://stackoverflow.com/questions/41526553/can-async-write-cause-segmentation-fault-when-this-is-deleted
-	std::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket> >
-	  m_securesocket;
-	std::shared_ptr<boost::asio::ip::tcp::socket>
-	  m_nonsecuresocket;
+	std::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket>>	m_securesocket;
+	std::shared_ptr<boost::asio::ip::tcp::socket> m_nonsecuresocket;
 
 	boost::asio::streambuf m_sendBuffer;
 	boost::asio::streambuf m_recvBuffer;

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -4,8 +4,6 @@
 #include <boost/array.hpp>
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/enable_shared_from_this.hpp>
 #include <boost/bind.hpp>
 #include <json/json.h>
 #include <libdevcore/Log.h>
@@ -20,20 +18,13 @@ using namespace std;
 using namespace dev;
 using namespace dev::eth;
 
-class EthStratumClient : public PoolClient, public boost::enable_shared_from_this<EthStratumClient>
+class EthStratumClient : public PoolClient
 {
 public:
 
-	typedef boost::shared_ptr<EthStratumClient> pointer;
-
-	static pointer create(int worktimeout, int responsetimeout, string const & email, bool const & submitHashrate) 
-	{
-		return pointer(new EthStratumClient(worktimeout, responsetimeout, email, submitHashrate));
-	};
-
 	typedef enum { STRATUM = 0, ETHPROXY, ETHEREUMSTRATUM } StratumProtocol;
 
-	EthStratumClient(int worktimeout, int responsetimeout, string const & email, bool const & submitHashrate);
+	EthStratumClient(boost::asio::io_service & io_service, int worktimeout, int responsetimeout, string const & email, bool const & submitHashrate);
 	~EthStratumClient();
 
 	void connect();
@@ -61,7 +52,6 @@ private:
 	void start_connect();
 	void check_connect_timeout(const boost::system::error_code& ec);
 	void connect_handler(const boost::system::error_code& ec);
-	void io_work_timer_handler(const boost::system::error_code& ec);
 	void work_timeout_handler(const boost::system::error_code& ec);
 	void response_timeout_handler(const boost::system::error_code& ec);
 
@@ -94,10 +84,7 @@ private:
 
 	bool m_stale = false;
 
-	std::thread m_serviceThread;								// The IO service thread.
-	boost::asio::io_service m_io_service;						// The IO service itself
-	boost::asio::io_service::work m_io_work;					// The IO work which prevents io_service.run() to return on no work thus terminating thread
-	boost::asio::deadline_timer m_io_work_timer;				// A dummy timer to keep io_service with something to do
+	boost::asio::io_service & m_io_service;						// The IO service reference passed in the constructor
 	boost::asio::io_service::strand m_io_strand;
 	boost::asio::ip::tcp::socket *m_socket;
 

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -27,8 +27,8 @@ public:
 	EthStratumClient(boost::asio::io_service & io_service, int worktimeout, int responsetimeout, string const & email, bool const & submitHashrate);
 	~EthStratumClient();
 
-	void connect();
-	void disconnect();
+	void connect() override;
+	void disconnect() override;
 	
 	// Connected and Connection Statuses
 	bool isConnected() override { return m_connected.load(std::memory_order_relaxed) && !isPendingState(); }
@@ -36,10 +36,10 @@ public:
 
 	bool isSubscribed() { return m_subscribed.load(std::memory_order_relaxed); }
 	bool isAuthorized() { return m_authorized.load(std::memory_order_relaxed); }
-	string ActiveEndPoint() { return " [" + toString(m_endpoint) + "]"; };
+	string ActiveEndPoint() override { return " [" + toString(m_endpoint) + "]"; };
 
-	void submitHashrate(string const & rate);
-	void submitSolution(Solution solution);
+	void submitHashrate(string const & rate) override;
+	void submitSolution(Solution solution) override;
 
 	h256 currentHeaderHash() { return m_current.header; }
 	bool current() { return static_cast<bool>(m_current); }

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -4,6 +4,8 @@
 #include <boost/array.hpp>
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/enable_shared_from_this.hpp>
 #include <boost/bind.hpp>
 #include <json/json.h>
 #include <libdevcore/Log.h>
@@ -18,9 +20,16 @@ using namespace std;
 using namespace dev;
 using namespace dev::eth;
 
-class EthStratumClient : public PoolClient
+class EthStratumClient : public PoolClient, public boost::enable_shared_from_this<EthStratumClient>
 {
 public:
+
+	typedef boost::shared_ptr<EthStratumClient> pointer;
+
+	static pointer create(int worktimeout, int responsetimeout, string const & email, bool const & submitHashrate) 
+	{
+		return pointer(new EthStratumClient(worktimeout, responsetimeout, email, submitHashrate));
+	};
 
 	typedef enum { STRATUM = 0, ETHPROXY, ETHEREUMSTRATUM } StratumProtocol;
 

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -31,11 +31,9 @@ public:
 	void disconnect();
 	
 	// Connected and Connection Statuses
-	bool isConnected()
-	{
-		return m_connected.load(std::memory_order_relaxed) &&
-				!m_disconnecting.load(std::memory_order_relaxed);
-	}
+	bool isConnected() override { return m_connected.load(std::memory_order_relaxed) && !isPendingState(); }
+	bool isPendingState() override { return (m_connecting.load(std::memory_order_relaxed) || m_disconnecting.load(std::memory_order_relaxed));}
+
 	bool isSubscribed() { return m_subscribed.load(std::memory_order_relaxed); }
 	bool isAuthorized() { return m_authorized.load(std::memory_order_relaxed); }
 	string ActiveEndPoint() { return " [" + toString(m_endpoint) + "]"; };
@@ -48,10 +46,13 @@ public:
 
 private:
 
+	void disconnect_finalize();
+
 	void resolve_handler(const boost::system::error_code& ec, boost::asio::ip::tcp::resolver::iterator i);
-	void start_connect(boost::asio::ip::tcp::resolver::iterator endpoint_iter);
+	void start_connect();
 	void check_connect_timeout(const boost::system::error_code& ec);
-	void connect_handler(const boost::system::error_code& ec, boost::asio::ip::tcp::resolver::iterator i);
+	void connect_handler(const boost::system::error_code& ec);
+	void io_work_timer_handler(const boost::system::error_code& ec);
 	void work_timeout_handler(const boost::system::error_code& ec);
 	void response_timeout_handler(const boost::system::error_code& ec);
 
@@ -64,7 +65,7 @@ private:
 	void onRecvSocketDataCompleted(const boost::system::error_code& ec, std::size_t bytes_transferred);
 	void sendSocketData(Json::Value const & jReq);
 	void onSendSocketDataCompleted(const boost::system::error_code& ec);
-
+	void onSSLShutdownCompleted(const boost::system::error_code& ec);
 
 	string m_worker; // eth-proxy only; No ! It's for all !!!
 
@@ -72,6 +73,7 @@ private:
 	std::atomic<bool> m_authorized = { false };
 	std::atomic<bool> m_connected = { false };
 	std::atomic<bool> m_disconnecting = { false };
+	std::atomic<bool> m_connecting = { false };
 
 	// seconds to trigger a work_timeout (overwritten in constructor)
 	int m_worktimeout;
@@ -83,8 +85,10 @@ private:
 
 	bool m_stale = false;
 
-	std::thread m_serviceThread;  ///< The IO service thread.
-	boost::asio::io_service m_io_service;
+	std::thread m_serviceThread;								// The IO service thread.
+	boost::asio::io_service m_io_service;						// The IO service itself
+	boost::asio::io_service::work m_io_work;					// The IO work which prevents io_service.run() to return on no work thus terminating thread
+	boost::asio::deadline_timer m_io_work_timer;				// A dummy timer to keep io_service with something to do
 	boost::asio::ip::tcp::socket *m_socket;
 
 	// Use shared ptrs to avoid crashes due to async_writes
@@ -104,6 +108,7 @@ private:
 	bool m_response_pending = false;
 
 	boost::asio::ip::tcp::resolver m_resolver;
+	std::queue<boost::asio::ip::basic_endpoint<boost::asio::ip::tcp>> m_endpoints;
 
 	string m_email;
 	string m_rate;

--- a/libpoolprotocols/testing/SimulateClient.h
+++ b/libpoolprotocols/testing/SimulateClient.h
@@ -21,6 +21,7 @@ public:
 	void disconnect() override;
 
 	bool isConnected() override { return m_connected; }
+	bool isPendingState() override { return false; }
 	string ActiveEndPoint() override { return ""; };
 
 	void submitHashrate(string const & rate) override;


### PR DESCRIPTION
* Made boost's io_service global
* No stops of io_service which prevent restart of resolver or sockets
* On disconnects this behavior is implemented : mining is stopped only
if switching pools (failovers) otherwise it keeps mining trying a fast
reconnect on same pool
* SSL and plain TCP reconnect properly on Linux

Feed back needed on Windows.