### PR TITLE
Add --tstop and --tstart option preventing GPU overheating.

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -296,6 +296,13 @@ void CLMiner::workLoop()
     try {
         while (!shouldStop())
         {
+            if (is_mining_paused())
+            {
+                // cnote << "Paused for 3 s due temperature -tstop.";
+                std::this_thread::sleep_for(std::chrono::seconds(3));
+                continue;
+            }
+
             const WorkPackage w = work();
 
             if (current.header != w.header)

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -90,6 +90,13 @@ void CUDAMiner::workLoop()
     {
         while(!shouldStop())
         {
+            if (is_mining_paused())
+            {
+                // cnote << "Paused for 3 s due temperature -tstop.";
+                std::this_thread::sleep_for(std::chrono::seconds(3));
+                continue;
+            }
+
             // take local copy of work since it may end up being overwritten.
             const WorkPackage w = work();
             

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -50,6 +50,8 @@ namespace eth
 class Farm: public FarmFace
 {
 public:
+	unsigned tstart, tstop;
+
 	struct SealerDescriptor
 	{
 		std::function<unsigned()> instances;
@@ -252,7 +254,8 @@ public:
         p.hashes = 0;
         for (auto const& i : m_miners)
         {
-            p.minersHashes.push_back(0);
+			p.miningIsPaused.push_back(i->is_mining_paused());
+			p.minersHashes.push_back(0);
 			if (hwmon) {
 				HwMonitorInfo hwInfo = i->hwmonInfo();
 				HwMonitor hw;
@@ -310,6 +313,9 @@ public:
 					}
 #endif
 				}
+
+				i->update_temperature(tempC);
+
 				hw.tempC = tempC;
 				hw.fanP = fanpcnt;
 				hw.powerW = powerW/((double)1000.0);
@@ -407,6 +413,22 @@ public:
 		return m_nonce_scrambler;
 	}
 
+	void setTStartTStop(unsigned tstart, unsigned tstop)
+	{
+		m_tstart = tstart;
+		m_tstop = tstop;
+	}
+
+	unsigned get_tstart() override
+	{
+		return m_tstart;
+	}
+
+	unsigned get_tstop() override
+	{
+		return m_tstop;
+	}
+
 private:
 	/**
 	 * @brief Called from a Miner to note a WorkPackage has a solution.
@@ -447,6 +469,8 @@ private:
 
     	string m_pool_addresses;
 	uint64_t m_nonce_scrambler;
+
+	unsigned m_tstart, m_tstop;
 
 	wrap_nvml_handle *nvmlh = NULL;
 	wrap_adl_handle *adlh = NULL;

--- a/libethcore/Miner.cpp
+++ b/libethcore/Miner.cpp
@@ -15,4 +15,3 @@ uint8_t* dev::eth::Miner::s_dagInHostMemory = NULL;
 bool dev::eth::Miner::s_exit = false;
 
 bool dev::eth::Miner::s_noeval = false;
-


### PR DESCRIPTION
As we're getting summer here:

To be sure not to burn the GPUs the miner stops mining on a GPU
if a specific temperature (--tstop) is reached.
After cooling down and reaching --tstart temperature (default 40)
mining will be (re)started on the GPU.