### PR TITLE
Stratum nicehash. Avoid recalculating target with every job.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
 - Reconnecting with mining pool improved [[#1135](https://github.com/ethereum-mining/ethminer/pull/1135)].
+- Stratum nicehash. Avoid recalculating target with every job [[#1156](https://github.com/ethereum-mining/ethminer/pull/1156)].
 ### Removed
 - Disabled Debug configuration for Visual Studio [[#69](https://github.com/ethereum-mining/ethminer/issues/69)] [[#1131](https://github.com/ethereum-mining/ethminer/pull/1131)].

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -108,7 +108,7 @@ private:
 	string m_email;
 	string m_rate;
 
-	double m_nextWorkDifficulty;
+	h256 m_nextWorkBoundary = h256("0xffff000000000000000000000000000000000000000000000000000000000000");
 
 	h64 m_extraNonce;
 	int m_extraNonceHexSize;


### PR DESCRIPTION
nicehash will periodically adjust difficulty, sending it as
a float value to be converted to 32 byte target. There is no
need to do the conversion with every job.