### PR TITLE
Work around pool bugs (drop duplicate jobs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Reconnecting with mining pool improved [[#1135](https://github.com/ethereum-mining/ethminer/pull/1135)].
 - Stratum nicehash. Avoid recalculating target with every job [[#1156](https://github.com/ethereum-mining/ethminer/pull/1156)].
+- Drop duplicate stratum jobs (pool bug workaround) [[#1161](https://github.com/ethereum-mining/ethminer/pull/1161)].
 ### Removed
 - Disabled Debug configuration for Visual Studio [[#69](https://github.com/ethereum-mining/ethminer/issues/69)] [[#1131](https://github.com/ethereum-mining/ethminer/pull/1131)].

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -57,6 +57,15 @@ PoolManager::PoolManager(PoolClient * client, Farm &farm, MinerType const & mine
 
 	p_client->onWorkReceived([&](WorkPackage const& wp)
 	{
+		for (auto h : m_headers)
+			if (h == wp.header)
+			{
+				cwarn << EthYellow "Duplicate job" << wp.header << " discarded" EthReset;
+				return;
+			}
+		m_headers.push_back(wp.header);
+		while (m_headers.size() > 4)
+			m_headers.pop_front();
 
 		cnote << "New job" << wp.header << "  " + m_connections[m_activeConnectionIdx].Host() + p_client->ActiveEndPoint();
 		if (wp.boundary != m_lastBoundary)

--- a/libpoolprotocols/PoolManager.h
+++ b/libpoolprotocols/PoolManager.h
@@ -43,6 +43,7 @@ namespace dev
 			std::thread m_workThread;
 
 			h256 m_lastBoundary = h256();
+			std::list<h256> m_headers;
 
 			PoolClient *p_client;
 			Farm &m_farm;


### PR DESCRIPTION
There are two known cases where pools will send duplicate jobs
leading to rejected shares.

1 - Ethermine will occasionally incorrectly send a duplicate job.

    job A
    job B
    job C
    job B <- undexpected dup.
    job D

This occurs for reason unknown (pool bug?) causing the miner to
restart work on job B and finding the same solutions as the 1st
time through, these then rejected as duplicates.

Furthermore, this prevents any further results which might have
been found for job C.

2 - Protocol startum2 (nicehash) resends job after difficulty
    change.

    job A
    job B
    new diff
	job B <- incorrectly restarts job B.

Some nicehash pools (counfoundry) resend the previous job after
sending a difficulty update notification. Causes the same problem
as in case 1.

Solution.

Keep a list of for last 4 jobs and drop any incoming duplicates.