### PR TITLE
Invoke stop mining.

### DIFF
--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -161,9 +161,15 @@ void PoolManager::stop()
 		if (p_client->isConnected()) 
 		{ 
 
-			// Disconnection will also trigger
-			// stop for mining
+			// Disconnect client and stop mining
 			p_client->disconnect(); 
+
+			if (m_farm.isMining())
+			{
+				cnote << "Shutting down miners...";
+				m_farm.stop();
+			}
+
 
 		}
 		else {

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -158,14 +158,14 @@ void PoolManager::stop()
 		cnote << "Shutting down...";
 
 		m_running.store(false, std::memory_order_relaxed);
-		if (p_client->isConnected()) 
-		{ 
 
-			// Disconnect client and stop mining
+		if (p_client->isConnected()) 
 			p_client->disconnect(); 
 
-		}
-
+		if (m_farm.isMining())
+		{
+			cnote << "Shutting down miners...";
+			m_farm.stop();
 		}
 
 	}

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -164,21 +164,7 @@ void PoolManager::stop()
 			// Disconnect client and stop mining
 			p_client->disconnect(); 
 
-			if (m_farm.isMining())
-			{
-				cnote << "Shutting down miners...";
-				m_farm.stop();
-			}
-
-
 		}
-		else {
-
-			if (m_farm.isMining())
-			{
-				cnote << "Shutting down miners...";
-				m_farm.stop();
-			}
 
 		}
 


### PR DESCRIPTION
Due to recent changes in workloop for PoolManager, stop mining may not
be invoked when program exits due to signal or CTRL-C