### PR TITLE
Use FIFO queue to track submission timings

### DIFF
--- a/libpoolprotocols/PoolManager.h
+++ b/libpoolprotocols/PoolManager.h
@@ -48,7 +48,7 @@ namespace dev
 			PoolClient *p_client;
 			Farm &m_farm;
 			MinerType m_minerType;
-			std::chrono::steady_clock::time_point m_submit_time;
+			std::queue<std::chrono::steady_clock::time_point> m_submit_times;
 
 		};
 	}


### PR DESCRIPTION
More precise tracking of submissions times using a fifo queue. Till now
the response time tracking was always referred to the "last" submission
which could be misleading when two or more submissions are posted in
sequence before the first one receives a response.
This behavior has more evidence on pools with low/adjustable diff