### PR TITLE
More log logic cleanup

### DIFF
--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -50,9 +50,8 @@ using namespace dev::eth;
 
 struct MiningChannel: public LogChannel
 {
-	static const char* name() { return EthGreen "  m"; }
+	static const char* name() { return EthGreen " m"; }
 	static const int verbosity = 2;
-	static const bool debug = false;
 };
 
 #define minelog clog(MiningChannel)
@@ -196,7 +195,15 @@ public:
 		app.add_option("-P,--pool,pool", pools,
 			"Specify one or more pool URLs. See below for URL syntax")
 			->group(CommonGroup);
-	
+
+        app.add_flag("--nocolor", g_logNoColor,
+            "Display monochrome log")
+            ->group(CommonGroup);
+
+        app.add_flag("--syslog", g_logSyslog,
+            "Use syslog appropriate log output (drop timestamp and channel prefix)")
+            ->group(CommonGroup);
+
 #if API_CORE
 
 		app.add_option("--api-port", m_api_port,
@@ -813,16 +820,13 @@ int main(int argc, char** argv)
 	setenv("GPU_SINGLE_ALLOC_PERCENT", "100");
 
 	if (getenv("SYSLOG"))
-	{
-		g_syslog = true;
-		g_useColor = false;
-	}
-	if (getenv("NO_COLOR"))
-		g_useColor = false;
+		g_logSyslog = true;
+	if (g_logSyslog || (getenv("NO_COLOR")))
+		g_logNoColor = true;
 #if defined(_WIN32)
-	if (g_useColor)
+	if (!g_logNoColor)
 	{
-		g_useColor = false;
+		g_logNoColor = true;
 		// Set output mode to handle virtual terminal sequences
 		// Only works on Windows 10, but most users should use it anyway
 		HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
@@ -833,7 +837,7 @@ int main(int argc, char** argv)
 			{
 				dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
 				if (SetConsoleMode(hOut, dwMode))
-					g_useColor = true;
+					g_logNoColor = false;
 			}
 		}
 	}

--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -31,50 +31,26 @@ using namespace dev;
 
 // Logging
 int g_logVerbosity = 5;
-bool g_useColor = true;
-bool g_syslog = false;
+bool g_logNoColor = false;
+bool g_logSyslog = false;
 
-mutex x_logOverride;
+const char* LogChannel::name() { return EthGray ".."; }
+const char* WarnChannel::name() { return EthRed " X"; }
+const char* NoteChannel::name() { return EthBlue " i"; }
 
-/// Map of Log Channel types to bool, false forces the channel to be disabled, true forces it to be enabled.
-/// If a channel has no entry, then it will output as long as its verbosity (LogChannel::verbosity) is less than
-/// or equal to the currently output verbosity (g_logVerbosity).
-static map<type_info const*, bool> s_logOverride;
-
-#ifdef _WIN32
-const char* LogChannel::name() { return EthGray "..."; }
-const char* WarnChannel::name() { return EthOnRed EthBlackBold "  X"; }
-const char* NoteChannel::name() { return EthBlue "  i"; }
-#else
-const char* LogChannel::name() { return EthGray "···"; }
-const char* WarnChannel::name() { return EthOnRed EthBlackBold "  ✘"; }
-const char* NoteChannel::name() { return EthBlue "  ℹ"; }
-#endif
-
-LogOutputStreamBase::LogOutputStreamBase(char const* _id, std::type_info const* _info, unsigned _v):
+LogOutputStreamBase::LogOutputStreamBase(char const* _id, unsigned _v):
 	m_verbosity(_v)
 {
 	if ((int)_v <= g_logVerbosity)
 	{
-		Guard l(x_logOverride);
-		auto it = s_logOverride.find(_info);
-		if ((it != s_logOverride.end() && it->second) || it == s_logOverride.end())
-		{
-			static char const* c_begin = "  " EthViolet;
-			static char const* c_sep1 = EthReset EthBlack "|" EthNavy;
-			static char const* c_sep2 = EthReset EthBlack "|" EthTeal;
-			static char const* c_end = EthReset "  ";
-			if (g_syslog) 
-			{
-				c_begin = "  " EthNavy;
-				m_sstr << c_begin << std::left << std::setw(8) << getThreadName() << c_sep2 << c_end;
-			} else {
-				time_t rawTime = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-				char buf[24];
-				if (strftime(buf, 24, "%X", localtime(&rawTime)) == 0)
-					buf[0] = '\0'; // empty if case strftime fails
-				m_sstr << _id << c_begin << buf << c_sep1 << std::left << std::setw(8) << getThreadName() << c_sep2 << c_end;
-			}
+		if (g_logSyslog)
+			m_sstr << std::left << std::setw(8) << getThreadName() << " " EthReset;
+		else {
+			time_t rawTime = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+			char buf[24];
+			if (strftime(buf, 24, "%X", localtime(&rawTime)) == 0)
+				buf[0] = '\0'; // empty if case strftime fails
+			m_sstr << _id << " " EthViolet << buf << " " EthNavy << std::left << std::setw(8) << getThreadName() << " " EthReset;
 		}
 	}
 }
@@ -115,7 +91,7 @@ void dev::setThreadName(char const* _n)
 
 void dev::simpleDebugOut(std::string const& _s)
 {
-	if (g_useColor)
+	if (!g_logNoColor)
 	{
 		std::cerr << _s + '\n';
 		return;

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -33,8 +33,8 @@
 
 /// The logging system's current verbosity.
 extern int g_logVerbosity;
-extern bool g_useColor;
-extern bool g_syslog;
+extern bool g_logNoColor;
+extern bool g_logSyslog;
 
 namespace dev
 {
@@ -57,7 +57,7 @@ struct LogChannel {
 struct WarnChannel: public LogChannel
 {
 	static const char* name();
-	static const int verbosity = 0;
+	static const int verbosity = 2;
 };
 struct NoteChannel: public LogChannel
 {
@@ -67,12 +67,8 @@ struct NoteChannel: public LogChannel
 class LogOutputStreamBase
 {
 public:
-	LogOutputStreamBase(char const* _id, std::type_info const* _info, unsigned _v);
+	LogOutputStreamBase(char const* _id, unsigned _v);
 
-	template <unsigned N> void append(FixedHash<N> const& _t)
-	{
-		m_sstr << "#" << _t.abridged();
-	}
 	template <class T> void append(T const& _t)
 	{
 		m_sstr << toString(_t);
@@ -90,17 +86,10 @@ class LogOutputStream: LogOutputStreamBase
 public:
 	/// Construct a new object.
 	/// If _term is true the the prefix info is terminated with a ']' character; if not it ends only with a '|' character.
-	LogOutputStream(): LogOutputStreamBase(Id::name(), &typeid(Id), Id::verbosity) {}
+	LogOutputStream(): LogOutputStreamBase(Id::name(), Id::verbosity) {}
 
 	/// Destructor. Posts the accrued log entry to the g_logPost function.
 	~LogOutputStream() { if (Id::verbosity <= g_logVerbosity) simpleDebugOut(m_sstr.str()); }
-
-	LogOutputStream& operator<<(std::string const& _t)
-	{
-		if (Id::verbosity <= g_logVerbosity)
-			m_sstr << _t;
-		return *this;
-	}
 
 	/// Shift arbitrary data to the log. Spaces will be added between items as required.
 	template <class T>

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -27,18 +27,11 @@ constexpr size_t c_maxSearchResults = 1;
 
 struct CLChannel: public LogChannel
 {
-    static const char* name() { return EthOrange " cl"; }
+    static const char* name() { return EthOrange "cl"; }
     static const int verbosity = 2;
     static const bool debug = false;
 };
-struct CLSwitchChannel: public LogChannel
-{
-    static const char* name() { return EthOrange " cl"; }
-    static const int verbosity = 6;
-    static const bool debug = false;
-};
 #define cllog clog(CLChannel)
-#define clswitchlog clog(CLSwitchChannel)
 #define ETHCL_LOG(_contents) cllog << _contents
 
 /**
@@ -348,9 +341,10 @@ void CLMiner::workLoop()
                 else
                     startNonce = get_start_nonce();
 
-                clswitchlog << "Switch time: "
-                    << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - workSwitchStart).count()
-                    << " ms.";
+                if (g_logVerbosity > 5)
+					cllog << "Switch time: "
+                    	<< std::chrono::duration_cast<std::chrono::milliseconds>
+							(std::chrono::high_resolution_clock::now() - workSwitchStart).count() << " ms.";
             }
 
             // Read results.

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -29,9 +29,8 @@ vector<int> CUDAMiner::s_devices(MAX_MINERS, -1);
 
 struct CUDAChannel: public LogChannel
 {
-    static const char* name() { return EthOrange " cu"; }
+    static const char* name() { return EthOrange "cu"; }
     static const int verbosity = 2;
-    static const bool debug = false;
 };
 #define cudalog clog(CUDAChannel)
 

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -72,7 +72,7 @@ PoolManager::PoolManager(PoolClient * client, Farm &farm, MinerType const & mine
 		while (m_headers.size() > 4)
 			m_headers.pop_front();
 
-		cnote << "New job " EthWhite << wp.header << EthReset " " << m_connections[m_activeConnectionIdx].Host()
+		cnote << "Job: " EthWhite "#"<< wp.header.abridged() << EthReset " " << m_connections[m_activeConnectionIdx].Host()
 			<< p_client->ActiveEndPoint();
 		if (wp.boundary != m_lastBoundary)
 		{
@@ -81,7 +81,7 @@ PoolManager::PoolManager(PoolClient * client, Farm &farm, MinerType const & mine
 			m_lastBoundary = wp.boundary;
 			static const uint512_t dividend("0x10000000000000000000000000000000000000000000000000000000000000000");
 			const uint256_t divisor(string("0x") + m_lastBoundary.hex());
-			cnote << "New pool difficulty: " EthWhite << diffToDisplay(double(dividend / divisor)) << EthReset;
+			cnote << "Pool difficulty: " EthWhite << diffToDisplay(double(dividend / divisor)) << EthReset;
 		}
 
 		m_farm.setWork(wp);
@@ -118,8 +118,8 @@ PoolManager::PoolManager(PoolClient * client, Farm &farm, MinerType const & mine
 		}
 
 		std::stringstream ss;
-		ss << std::setw(4) << std::setfill(' ') << ms.count();
-		ss << "ms." << "   " << m_connections[m_activeConnectionIdx].Host() + p_client->ActiveEndPoint();
+		ss << std::setw(4) << std::setfill(' ') << ms.count()
+			<< "ms." << "   " << m_connections[m_activeConnectionIdx].Host() + p_client->ActiveEndPoint();
 		cwarn << EthRed "**Rejected" EthReset << (stale ? "(stale)" : "") << ss.str();
 		m_farm.rejectedSolution(stale);
 	});
@@ -135,9 +135,9 @@ PoolManager::PoolManager(PoolClient * client, Farm &farm, MinerType const & mine
 			m_submit_times.push(std::chrono::steady_clock::now());
 
 			if (sol.stale)
-				cnote << string(EthYellow "Stale solution 0x") + toHex(sol.nonce);
+				cwarn << "Stale solution: " << EthWhite "0x" << toHex(sol.nonce) << EthReset;
 			else
-				cnote << string("Solution 0x") + toHex(sol.nonce);
+				cnote << "Solution: " << EthWhite "0x" << toHex(sol.nonce) << EthReset;
 
 			p_client->submitSolution(sol);
 		}


### PR DESCRIPTION
- Simplifiy code. There's no point in setting the color to black then
  printing someting on a black background. Might as well just use blanks.
- Since we don't enable and disable log channels, there's no need
  for a channel map or its protective mutex.
- Prefer cmd line parameters to env. variables. Add --nocolor, --syslog options
- Rename log global variables appropriately.
- Shorten log message ids to 2 characters.
- Remove unnecesary color setting when in syslog mode

