### PR TITLE
Job duplicate check breaks stratum2...

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -317,7 +317,6 @@ void CLMiner::workLoop()
                         ++s_dagLoadIndex;
                     }
 
-                    cllog << "New epoch: " << w.epoch;
                     init(w.epoch);
                 }
 

--- a/libpoolprotocols/PoolClient.h
+++ b/libpoolprotocols/PoolClient.h
@@ -38,7 +38,7 @@ namespace dev
 			using SolutionRejected = std::function<void(bool const&)>;
 			using Disconnected = std::function<void()>;
 			using Connected = std::function<void()>;
-			using WorkReceived = std::function<void(WorkPackage const&)>;
+			using WorkReceived = std::function<void(WorkPackage const&, bool checkForDuplicates)>;
 
 			void onSolutionAccepted(SolutionAccepted const& _handler) { m_onSolutionAccepted = _handler; }
 			void onSolutionRejected(SolutionRejected const& _handler) { m_onSolutionRejected = _handler; }

--- a/libpoolprotocols/PoolManager.h
+++ b/libpoolprotocols/PoolManager.h
@@ -51,6 +51,8 @@ namespace dev
 			MinerType m_minerType;
 			boost::lockfree::queue<std::chrono::steady_clock::time_point> m_submit_times;
 
+			int m_lastEpoch = 0;
+
 		};
 	}
 }

--- a/libpoolprotocols/getwork/EthGetworkClient.cpp
+++ b/libpoolprotocols/getwork/EthGetworkClient.cpp
@@ -118,7 +118,7 @@ void EthGetworkClient::workLoop()
 					m_prevWorkPackage.boundary = h256(fromHex(v[2].asString()), h256::AlignRight);
 
 					if (m_onWorkReceived) {
-						m_onWorkReceived(m_prevWorkPackage);
+						m_onWorkReceived(m_prevWorkPackage, true);
 					}
 				}
 			}

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -116,4 +116,6 @@ private:
 	bool m_submit_hashrate;
 	std::string m_submit_hashrate_id;
 
+	bool m_checkForDups = true;
+
 };

--- a/libpoolprotocols/testing/SimulateClient.cpp
+++ b/libpoolprotocols/testing/SimulateClient.cpp
@@ -96,7 +96,7 @@ void SimulateClient::workLoop()
 					current.header = h256::random();
 					current.boundary = genesis.boundary();
 
-					m_onWorkReceived(current);
+					m_onWorkReceived(current, false);
 				}
 			}
 			else {


### PR DESCRIPTION
Nicehash resends current job whenever it changes the extranonce
or the difficulty. Makes sense since any solution found with the
old parameters would be invalid under the new.

Discarding this duplicate job prevents a reset to the new diff and
extranonce and can lead us to send invalid solutions.

Don't check for duplicate jobs if stratum2 and we just received a diff or extranonce notification.