### PR TITLE
Change _WIN32_WINNT to Vista.

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -25,10 +25,10 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 
-	# declare Windows XP requirement
+	# declare Windows Vista requirement
 	# undefine windows.h MAX & MIN macros because they conflict with std::min & std::max functions
 	# disable unsafe CRT Library functions warnings
-	add_definitions(/D_WIN32_WINNT=0x0501 /DNOMINMAX /D_CRT_SECURE_NO_WARNINGS)
+	add_definitions(/D_WIN32_WINNT=0x0600 /DNOMINMAX /D_CRT_SECURE_NO_WARNINGS)
 
 	# enable parallel compilation
 	# specify Exception Handling Model


### PR DESCRIPTION
This is the default for the SDK we use.

Not sure if we should set it at all...

PS. The binaries already don't run on XP anyway; the default Windows Subsystem version is 6.0 (Vista).