### PR TITLE
Tweak docs

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -9,7 +9,7 @@ Ethminer implements an API (Application Programming Interface) interface which a
 
 Whenever the above depicted conditions are met you can take advantage of the API support by adding the `--api-port` argument to the command line used to launch ethminer. The format of this argument is `--api-port nnnn` where `nnnn` is any valid TCP port number (1-65535). Examples:
 
-```
+```shell
 ./ethminer [...] --api-port 3333
 ```
 
@@ -17,7 +17,7 @@ This example puts the API interface listening on port 3333 of **any** local IP a
 
 The API interface not only offers monitoring queries but also implements some methods which may affect the functioning of the miner. These latter operations are named _write_ actions: if you want to inhibit the invocation of such methods you may want to put the API interface in **read-only** mode which means only query to **get** data will be allowed and no _write_ methods will be allowed. To do this simply add the - (minus) sign in front of the port number thus transforming the port number into a negative number. Example for read-only mode:
 
-```
+```shell
 ./ethminer [...] --api-port -3333
 ```
 
@@ -25,7 +25,7 @@ _Note. The port number in this examples is taken randomly and does not imply a s
 
 To gain further security you may wish to password protect the access to your API interface simply by adding the `--api-password` argument to the command line sequence, followed by the password you wish. Password may be composed by any printable char and **must not** have spaces. Password checking is **case sensitive**. Example for password protected API interface:
 
-```
+```shell
 ./ethminer [...] --api-port -3333 --api-password MySuperSecurePassword!!#123456
 ```
 
@@ -35,17 +35,17 @@ At the time of writing of this document ethminer's API interface does not implem
 
 Access to API interface is performed through a TCP socket connection to the API endpoint (which is the IP address of the computer running ethminer's API instance at the configured port). For instance if your computer address is 192.168.1.1 and have configured ethminer to run with `--api-port 3333` your endpoint will be 192.168.1.1:3333.
 
-Messages exchanged through this channel must conform the [Jsonrpc v.2 specifications](http://www.jsonrpc.org/specification) so basically you will issue **requests** and will get back **responses**. At the time of writing of this document do not expect any **notification**. All messages must be line feed terminated.
+Messages exchanged through this channel must conform to the [JSON-RPC 2.0 specification](http://www.jsonrpc.org/specification) so basically you will issue **requests** and will get back **responses**. At the time of writing this document do not expect any **notification**. All messages must be line feed terminated.
 
-To quick test if your ethminer's API instance is working properly you can issue this simple command
+To quickly test if your ethminer's API instance is working properly you can issue this simple command:
 
-```
+```shell
 echo '{"id":0,"jsonrpc":"2.0","method":"miner_ping"}' | netcat 192.168.1.1 3333
 ```
 
-and will get back a response like this
+and will get back a response like this:
 
-```
+```shell
 {"id":0,"jsonrpc":"2.0","result":"pong"}
 ```
 
@@ -83,7 +83,7 @@ If your API instance is password protected by the usage of `--api-password` any 
 }
 ```
 
-where the member `psw` **must** contain the very same password configured with `--api-password` argument. As expected result you will get a JsonRpc 2.0 response with positive or negative values. For instance if password do match you will get a response like this
+where the member `psw` **must** contain the very same password configured with `--api-password` argument. As expected result you will get a JSON-RPC 2.0 response with positive or negative values. For instance if the password matches you will get a response like this:
 
 ```json
 {
@@ -93,7 +93,7 @@ where the member `psw` **must** contain the very same password configured with `
 }
 ```
 
-or, in case of any error
+or, in case of any error:
 
 ```json
 {
@@ -120,7 +120,7 @@ To invoke the action:
 }
 ```
 
-and expect back a result like this
+and expect back a result like this:
 
 ```json
 {
@@ -132,11 +132,11 @@ and expect back a result like this
 
 which confirms the action has been performed.
 
-If you get no response or the socket goes timeout it likely your ethminer's instance has become unresponsive (or in worst cases all the OS of your mining rig is unresponsive) and need to be re-started/re-booted.
+If you get no response or the socket timeouts it's likely your ethminer's instance has become unresponsive (or in worst cases the OS of your mining rig is unresponsive) and needs to be re-started/re-booted.
 
 ### miner_getstat1
 
-With this method you expect back a collection of statistical data. To issue request:
+With this method you expect back a collection of statistical data. To issue a request:
 
 ```json
 {
@@ -146,7 +146,7 @@ With this method you expect back a collection of statistical data. To issue requ
 }
 ```
 
-and expect back a response like this
+and expect back a response like this:
 
 ```js
 {
@@ -170,7 +170,7 @@ Some of the arguments here expressed have been set for compatibility with other 
 
 ### miner_getstathr
 
-With this method you expect back a collection of statistical data. To issue request:
+With this method you expect back a collection of statistical data. To issue a request:
 
 ```json
 {
@@ -180,7 +180,7 @@ With this method you expect back a collection of statistical data. To issue requ
 }
 ```
 
-and expect back a response like this
+and expect back a response like this:
 
 ```js
 {
@@ -231,7 +231,7 @@ and expect back a response like this
 }
 ```
 
-This format does not honor any compliance with other miner's format and does not express values from dual mining, which, we reiterate, is not supported by ethminer.
+This format does not honor any compliance with other miners' format and does not express values from dual mining, which, we reiterate, is not supported by ethminer.
 
 ### miner_restart
 
@@ -243,7 +243,7 @@ With this method you instruct ethminer to _restart_ mining. Restarting means:
 * Regenerate DAG files
 * Restart mining
 
-The invocation of this method **_may_** be useful if you detect one, or more, GPU are in error but in a recoverable state (eg. no hashrate but the GPU has not fallen off the bus). In other words this method works like stopping ethminer and restarting it **but without loosing connection to the pool**.
+The invocation of this method **_may_** be useful if you detect one or more GPUs are in error, but in a recoverable state (eg. no hashrate but the GPU has not fallen off the bus). In other words, this method works like stopping ethminer and restarting it **but without loosing connection to the pool**.
 
 To invoke the action:
 
@@ -255,7 +255,7 @@ To invoke the action:
 }
 ```
 
-and expect back a result like this
+and expect back a result like this:
 
 ```json
 {
@@ -267,19 +267,19 @@ and expect back a result like this
 
 which confirms the action has been performed.
 
-**Note** This method is not available if API interface is in read-only mode (see above)
+**Note**: This method is not available if the API interface is in read-only mode (see above).
 
 ### miner_shuffle
 
-The mining process is nothing more that finding the right number (nonce) which, applied to an algorithm (ethash) and some data, gives a result which is below or equal to a given target. This in very very (very) short !
+The mining process is nothing more that finding the right number (nonce) which, applied to an algorithm (ethash) and some data, gives a result which is below or equal to a given target. This is very very (very) short!
 The range of nonces to be searched is a huge number: 2^64 = 18446744073709600000~ possible values. Each one has the same probability to be the _right_ one.
 
-Every time ethminer receives a job from a pool you'd expect the miner to begin searching from the first but that would be boring. So the concept of scramble nonce has been introduced to achieve these goals:
+Every time ethminer receives a job from a pool you'd expect the miner to begin searching from the first, but that would be boring. So the concept of scramble nonce has been introduced to achieve these goals:
 
 * Start the searching from a random point within the range
-* Ensure all GPUs do not search the same data, or, in other words, ensure each GPU searches it's own range of numbers without overlapping with the same numbers of other GPUs
+* Ensure all GPUs do not search the same data, or, in other words, ensure each GPU searches its own range of numbers without overlapping with the same numbers of the other GPUs
 
-All miner_shuffle method does is to re-initialize a new random scramble nonce to start from in next jobs.
+All `miner_shuffle` method does is to re-initialize a new random scramble nonce to start from in next jobs.
 
 To invoke the action:
 
@@ -291,7 +291,7 @@ To invoke the action:
 }
 ```
 
-and expect back a result like this
+and expect back a result like this:
 
 ```json
 {
@@ -305,7 +305,7 @@ which confirms the action has been performed.
 
 ### miner_getconnections
 
-When you launch ethminer you provide a list of connections specified by the `-P` argument. If you want to remotely check which is the list of connections ethminer is using you can issue this method:
+When you launch ethminer you provide a list of connections specified by the `-P` argument. If you want to remotely check which is the list of connections ethminer is using, you can issue this method:
 
 ```json
 {
@@ -315,7 +315,7 @@ When you launch ethminer you provide a list of connections specified by the `-P`
 }
 ```
 
-and expect back a result like this
+and expect back a result like this:
 
 ```json
 {
@@ -341,7 +341,7 @@ and expect back a result like this
 }
 ```
 
-The `result` member contains an array of objects each one with the definition of the connection (in the form of the URI entered with the `-P` argument), it's ordinal index and the indication if it's the currently active connetion.
+The `result` member contains an array of objects, each one with the definition of the connection (in the form of the URI entered with the `-P` argument), its ordinal index and the indication if it's the currently active connetion.
 
 ### miner_setactiveconnection
 
@@ -364,7 +364,7 @@ You have to pass the `params` member as an object which has member `index` value
 * If the selected index is not of an active connection then ethminer will disconnect from currently active connection and reconnect immediately to the newly selected connection
 * An error result if the index is out of bounds or the request is not properly formatted
 
-**Please note** This method changes the runtime behavior only. If you restart ethminer from a batch file the active connection will become again the first one of the `-P` arguments list.
+**Please note** that this method changes the runtime behavior only. If you restart ethminer from a batch file the active connection will become again the first one of the `-P` arguments list.
 
 ### miner_addconnection
 
@@ -389,7 +389,7 @@ You have to pass the `params` member as an object which has member `uri` valued 
 
 Eventually you may want to issue [miner_getconnections](#miner_getconnections) method to identify which is the ordinal position assigned to the newly added connection and make use of [miner_setactiveconnection](#miner_setactiveconnection) method to instruct ethminer to use it immediately.
 
-**Please note** This method changes the runtime behavior only. If you restart ethminer from a batch file the added connection won't be available if not present in the `-P` arguments list.
+**Please note** that this method changes the runtime behavior only. If you restart ethminer from a batch file the added connection won't be available if not present in the `-P` arguments list.
 
 ### miner_removeconnection
 
@@ -411,7 +411,7 @@ You have to pass the `params` member as an object which has member `index` value
 * An error if the index is out of bounds **or if the index corresponds to the currently active connection**
 * A success message. In such case you can later reissue [miner_getconnections](#miner_getconnections) method to check the connection has been effectively removed.
 
-**Please note** This method changes the runtime behavior only. If you restart ethminer from a batch file the removed connection will become again again available if provided in the `-P` arguments list.
+**Please note** that this method changes the runtime behavior only. If you restart ethminer from a batch file the removed connection will become again again available if provided in the `-P` arguments list.
 
 ### miner_getscrambleinfo
 
@@ -433,7 +433,7 @@ To accomplish this each segment has a range 2^40 nonces by default. If you want 
 }
 ```
 
-and expect a result like this
+and expect a result like this:
 
 ```json
 {

--- a/POOL_EXAMPLES_ETH.md
+++ b/POOL_EXAMPLES_ETH.md
@@ -38,8 +38,6 @@ The servers are listed in alphabetical order. To get best results reorder them f
 | [nicehash.com](#nicehashcom) | <https://www.nicehash.com/> | <https://www.nicehash.com/help/which-stratum-servers-are-available> |
 | [sparkpool.com](#sparkpoolcom) | <https://sparkpool.com/> | <https://eth.sparkpool.com/> |
 
-
-
 ### 2miners.com
 
 ```
@@ -84,7 +82,6 @@ Without email
 -P stratum1+tcp://ETH_WALLET.WORKERNAME@eth-us2.dwarfpool.com:8008
 ```
 
-
 ### ethermine.org
 
 Non-SSL connection:
@@ -105,7 +102,6 @@ SSL connection:
 -P stratum1+ssl://ETH_WALLET.WORKERNAME@us2.ethermine.org:5555
 ```
 
-
 ### ethpool.org
 
  ```
@@ -114,13 +110,11 @@ SSL connection:
  -P stratum1+tcp://ETH_WALLET.WORKERNAME@us1.ethpool.org:3333
  ```
 
-
 ### f2pool.com
 
 ```
 -P stratum1+tcp://ETH_WALLET.WORKERNAME@eth.f2pool.com:8008
 ```
-
 
 ### miningpoolhub.com
 
@@ -130,8 +124,7 @@ SSL connection:
 -P stratum2+tcp://USERNAME.WORKERNAME:WORKERPWD@us-east.ethash-hub.miningpoolhub.com:20535
 ```
 
-HINT: It seems the password is not being verified by the pool so you can use simple 'x' as WORKERPWD.
-
+HINT: It seems the password is not being verified by the pool so you can use a plain `x` as `WORKERPWD`.
 
 ### nanopool.org
 
@@ -155,7 +148,6 @@ Without email:
 -P stratum1+tcp://ETH_WALLET.WORKERNAME@eth-us-west1.nanopool.org:9999
 ```
 
-
 ### nicehash.com
 
 ```
@@ -166,7 +158,6 @@ Without email:
 -P stratum2+tcp://BTC_WALLET.WORKERNAME@daggerhashimoto.jp.nicehash.com:3353
 -P stratum2+tcp://BTC_WALLET.WORKERNAME@daggerhashimoto.usa.nicehash.com:3353
 ```
-
 
 ### sparkpool.com
 

--- a/README.md
+++ b/README.md
@@ -8,29 +8,29 @@
 
 **Ethminer** is an Ethash GPU mining worker: with ethminer you can mine every coin which relies on an Ethash Proof of Work thus including Ethereum, Ethereum Classic, Metaverse, Musicoin, Ellaism, Pirl, Expanse and others. This is the actively maintained version of ethminer. It originates from [cpp-ethereum] project (where GPU mining has been discontinued) and builds on the improvements made in [Genoil's fork]. See [FAQ](#faq) for more details.
 
-### Features
+## Features
 
-- OpenCL mining
-- Nvidia CUDA mining
-- realistic benchmarking against arbitrary epoch/DAG/blocknumber
-- on-GPU DAG generation (no more DAG files on disk)
-- stratum mining without proxy
-- OpenCL devices picking
-- farm failover (getwork + stratum)
+* OpenCL mining
+* Nvidia CUDA mining
+* realistic benchmarking against arbitrary epoch/DAG/blocknumber
+* on-GPU DAG generation (no more DAG files on disk)
+* stratum mining without proxy
+* OpenCL devices picking
+* farm failover (getwork + stratum)
 
 
 ## Table of Contents
 
-- [Install](#install)
-- [Usage](#usage)
-  - [Examples connecting some pools](#examples-connecting-some-pools)
-- [Build](#build)
-  - [Continuous Integration and development builds](#continuous-integration-and-development-builds)
-  - [Building from source](#building-from-source)
-  - [CMake configuration options](#cmake-configuration-options)
-- [Maintainer](#maintainer)
-- [Contribute](#contribute)
-- [F.A.Q.](#faq)
+* [Install](#install)
+* [Usage](#usage)
+    * [Examples connecting some pools](#examples-connecting-some-pools)
+* [Build](#build)
+    * [Continuous Integration and development builds](#continuous-integration-and-development-builds)
+    * [Building from source](#building-from-source)
+    * [CMake configuration options](#cmake-configuration-options)
+* [Maintainer](#maintainer)
+* [Contribute](#contribute)
+* [F.A.Q.](#faq)
 
 
 ## Install
@@ -44,8 +44,8 @@ accessible from command line. The ethminer is ready to go.
 
 | Builds | Release | Date |
 | ------ | ------- | ---- |
-| Last    | [![GitHub release](https://img.shields.io/github/release/ethereum-mining/ethminer/all.svg)](https://github.com/ethereum-mining/ethminer/releases) | [![GitHub Release Date](https://img.shields.io/github/release-date-pre/ethereum-mining/ethminer.svg)](https://github.com/ethereum-mining/ethminer/releases) |
-| Stable  | [![GitHub release](https://img.shields.io/github/release/ethereum-mining/ethminer.svg)](https://github.com/ethereum-mining/ethminer/releases) | [![GitHub Release Date](https://img.shields.io/github/release-date/ethereum-mining/ethminer.svg)](https://github.com/ethereum-mining/ethminer/releases) |
+| Last   | [![GitHub release](https://img.shields.io/github/release/ethereum-mining/ethminer/all.svg)](https://github.com/ethereum-mining/ethminer/releases) | [![GitHub Release Date](https://img.shields.io/github/release-date-pre/ethereum-mining/ethminer.svg)](https://github.com/ethereum-mining/ethminer/releases) |
+| Stable | [![GitHub release](https://img.shields.io/github/release/ethereum-mining/ethminer.svg)](https://github.com/ethereum-mining/ethminer/releases) | [![GitHub Release Date](https://img.shields.io/github/release-date/ethereum-mining/ethminer.svg)](https://github.com/ethereum-mining/ethminer/releases) |
 
 
 ## Usage
@@ -59,7 +59,7 @@ For a full list of available command, please run:
 ethminer --help
 ```
 
-### Examples connecting some pools
+### Examples connecting to pools
 
 Check our [samples](POOL_EXAMPLES_ETH.md) to see how to connect to different pools.
 
@@ -74,61 +74,92 @@ Check our [samples](POOL_EXAMPLES_ETH.md) to see how to connect to different poo
 
 The AppVeyor system automatically builds a Windows .exe for every commit. The latest version is always available [on the landing page](https://ci.appveyor.com/project/ethereum-mining/ethminer) or you can [browse the history](https://ci.appveyor.com/project/ethereum-mining/ethminer/history) to access previous builds.
 
-To download the .exe on a build under 'JOB NAME' select 'Configuration: Release', choose 'ARTIFACTS' then download the zip file.
+To download the .exe on a build under `JOB NAME` select `Configuration: Release`, choose `ARTIFACTS` then download the zip file.
 
 
 ### Building from source
 
 This project uses [CMake] and [Hunter] package manager.
 
-1. Make sure git submodules are up to date
+1. Make sure git submodules are up to date:
 
-   ```sh
-   git submodule update --init --recursive
-   ```
+    ```sh
+    git submodule update --init --recursive
+    ```
 
-2. Create a build directory.
+2. Create a build directory:
 
-   ```sh
-   mkdir build; cd build
-   ```
+    ```sh
+    mkdir build; cd build
+    ```
 
-3. Configure the project with CMake. Check out additional
-   [configuration options](#cmake-configuration-options).
+3. Configure the project with CMake. Check out the additional [configuration options](#cmake-configuration-options).
 
-   ```sh
-   cmake ..
-   ```
+    ```sh
+    cmake ..
+    ```
 
-   Note: In Windows, it is possible to have issues with VS 2017 compilers, in that case, use VS 2017 installer to get VS 2015 compilers and use:
+    Note: On Windows, it's possible to have issues with VS 2017 default compilers; in that case, use the VS 2017 installer to get the VS 2015 compilers and use:
 
-   ```sh
-   cmake .. -G "Visual Studio 15 2017 Win64" -Tv140,host=x64
-   ```
+    ```sh
+    cmake .. -G "Visual Studio 15 2017 Win64" -T v140
+    ```
 
-4. Build the project using [CMake Build Tool Mode]. This is a portable variant
-   of `make`.
+4. Build the project using [CMake Build Tool Mode]. This is a portable variant of `make`.
 
-   ```sh
-   cmake --build .
-   ```
+    ```sh
+    cmake --build .
+    ```
 
-   Note: In Windows, it is possible to have compiler issues if you don't specify build config. In that case use:
+    Note: On Windows, it is possible to have compiler issues if you don't specify the build config. In that case use:
 
-   ```sh
-   cmake --build . --config Release
-   ```
+    ```sh
+    cmake --build . --config Release
+    ```
+
+    Complete sample Windows batch file - **adapt it to your system**. Assumes that:
+
+    * it's placed one folder up from the ethminer source folder
+    * you have CMake installed
+    * you have VS 2017 with the 140 toolset installed; this is needed because CUDA doesn't compile with the 141 toolset currently
+    * you have Perl installed
+
+    ```bat
+    @echo off
+    setlocal
+
+    rem add MSVC in PATH
+    call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsMSBuildCmd.bat"
+
+    rem add Perl in PATH; it's needed for OpenSSL build
+    set "PERL_PATH=C:\Perl\perl\bin"
+    set "PATH=%PERL_PATH%;%PATH%"
+
+    rem switch to this script's working difrectory
+    cd "%~dp0\ethminer\"
+
+    rem clean up old build
+    rem if exist build\ rd /q /s build\
+    mkdir build\
+    cd build\
+
+    cmake -G "Visual Studio 15 2017 Win64" -H. -Bbuild -T v140 -DETHASHCL=ON -DETHASHCUDA=ON -DAPICORE=ON ..
+    cmake --build . --config Release --target package
+
+    endlocal
+    pause
+    ```
 
 5. _(Optional, Linux only)_ Install the built executable.
 
-   ```sh
-   sudo make install
-   ```
+    ```sh
+    sudo make install
+    ```
 
 #### OpenCL support on Linux
 
 If you're planning to use [OpenCL on Linux](https://github.com/ruslo/hunter/wiki/pkg.opencl#pitfalls)
-you have to install OpenGL libraries. E.g. on Ubuntu run:
+you have to install the OpenGL libraries. E.g. on Ubuntu run:
 
 ```sh
 sudo apt-get install mesa-common-dev
@@ -138,7 +169,7 @@ sudo apt-get install mesa-common-dev
 
 If you want to install dependencies yourself or use system package manager
 you can disable Hunter by adding
-[-DHUNTER_ENABLED=OFF](https://docs.hunter.sh/en/latest/reference/user-variables.html#hunter-enabled)
+[`-DHUNTER_ENABLED=OFF`](https://docs.hunter.sh/en/latest/reference/user-variables.html#hunter-enabled)
 to configuration options.
 
 ### CMake configuration options
@@ -149,17 +180,17 @@ Pass these options to CMake configuration command, e.g.
 cmake .. -DETHASHCUDA=ON -DETHASHCL=OFF
 ```
 
-- `-DETHASHCL=ON` - enable OpenCL mining, `ON` by default,
-- `-DETHASHCUDA=ON` - enable CUDA mining, `ON` by default.
-- `-DAPICORE=ON` - enable API Server, `ON` by default.
-- `-DETHDBUS=ON` - enable D-Bus support, `OFF` by default.
+* `-DETHASHCL=ON` - enable OpenCL mining, `ON` by default,
+* `-DETHASHCUDA=ON` - enable CUDA mining, `ON` by default.
+* `-DAPICORE=ON` - enable API Server, `ON` by default.
+* `-DETHDBUS=ON` - enable D-Bus support, `OFF` by default.
 
 
 ## Maintainer
 
 [![Gitter](https://img.shields.io/gitter/room/ethereum-mining/ethminer.svg)][Gitter]
 
-- Paweł Bylica [@chfast](https://github.com/chfast)
+* Paweł Bylica [@chfast](https://github.com/chfast)
 
 
 ## Contribute
@@ -180,59 +211,58 @@ Licensed under the [GNU General Public License, Version 3](LICENSE).
 
 1. Why is my hashrate with Nvidia cards on Windows 10 so low?
 
-   The new WDDM 2.x driver on Windows 10 uses a different way of addressing the GPU. This is good for a lot of things, but not for ETH mining.
-   For Kepler GPUs: I actually don't know. Please let me know what works best for good old Kepler.
-   For Maxwell 1 GPUs: Unfortunately the issue is a bit more serious on the GTX750Ti, already causing suboptimal performance on Win7 and Linux. Apparently about 4MH/s can still be reached on Linux, which, depending on ETH price, could still be profitable, considering the relatively low power draw.
-   For Maxwell 2 GPUs: There is a way of mining ETH at Win7/8/Linux speeds on Win10, by downgrading the GPU driver to a Win7 one (350.12 recommended) and using a build that was created using CUDA 6.5.
-   For Pascal GPUs: You have to use the latest WDDM 2.1 compatible drivers in combination with Windows 10 Anniversary edition in order to get the full potential of your Pascal GPU.
+    The new WDDM 2.x driver on Windows 10 uses a different way of addressing the GPU. This is good for a lot of things, but not for ETH mining.
+    For Kepler GPUs: I actually don't know. Please let me know what works best for good old Kepler.
+    For Maxwell 1 GPUs: Unfortunately the issue is a bit more serious on the GTX750Ti, already causing suboptimal performance on Win7 and Linux. Apparently about 4MH/s can still be reached on Linux, which, depending on ETH price, could still be profitable, considering the relatively low power draw.
+    For Maxwell 2 GPUs: There is a way of mining ETH at Win7/8/Linux speeds on Win10, by downgrading the GPU driver to a Win7 one (350.12 recommended) and using a build that was created using CUDA 6.5.
+    For Pascal GPUs: You have to use the latest WDDM 2.1 compatible drivers in combination with Windows 10 Anniversary edition in order to get the full potential of your Pascal GPU.
 
 2. Why is a GTX 1080 slower than a GTX 1070?
 
-   Because of the GDDR5X memory, which can't be fully utilized for ETH mining (yet).
+    Because of the GDDR5X memory, which can't be fully utilized for ETH mining (yet).
 
 3. Are AMD cards also affected by slowdowns with increasing DAG size?
 
-   Only GCN 1.0 GPUs (78x0, 79x0, 270, 280), but in a different way. You'll see that on each new epoch (30K blocks), the hashrate will go down a little bit.
+    Only GCN 1.0 GPUs (78x0, 79x0, 270, 280), but in a different way. You'll see that on each new epoch (30K blocks), the hashrate will go down a little bit.
 
 4. Can I still mine ETH with my 2GB GPU?
 
-   Not really, your VRAM must be above the DAG size (Currently about 2.15 GB.) to get best performance. Without it severe hash loss will occur.
+    Not really, your VRAM must be above the DAG size (Currently about 2.15 GB.) to get best performance. Without it severe hash loss will occur.
 
 5. What are the optimal launch parameters?
 
-   The default parameters are fine in most scenario's (CUDA). For OpenCL it varies a bit more. Just play around with the numbers and use powers of 2. GPU's like powers of 2.
+    The default parameters are fine in most scenario's (CUDA). For OpenCL it varies a bit more. Just play around with the numbers and use powers of 2. GPU's like powers of 2.
 
 6. What does the `--cuda-parallel-hash` flag do?
 
-   [@davilizh](https://github.com/davilizh) made improvements to the CUDA kernel hashing process and added this flag to allow changing the number of tasks it runs in parallel. These improvements were optimised for GTX 1060 GPUs which saw a large increase in hashrate, GTX 1070 and GTX 1080/Ti GPUs saw some, but less, improvement. The default value is 4 (which does not need to be set with the flag) and in most cases this will provide the best performance.
+    [@davilizh](https://github.com/davilizh) made improvements to the CUDA kernel hashing process and added this flag to allow changing the number of tasks it runs in parallel. These improvements were optimised for GTX 1060 GPUs which saw a large increase in hashrate, GTX 1070 and GTX 1080/Ti GPUs saw some, but less, improvement. The default value is 4 (which does not need to be set with the flag) and in most cases this will provide the best performance.
 
 7. What is ethminer's relationship with [Genoil's fork]?
 
-   [Genoil's fork] was the original source of this version, but as Genoil is no longer consistently maintaining that fork it became almost impossible for developers to get new code merged there. In the interests of progressing development without waiting for reviews this fork should be considered the active one and Genoil's as legacy code.
+    [Genoil's fork] was the original source of this version, but as Genoil is no longer consistently maintaining that fork it became almost impossible for developers to get new code merged there. In the interests of progressing development without waiting for reviews this fork should be considered the active one and Genoil's as legacy code.
 
 8. Can I CPU Mine?
 
-   No, use geth, the go program made for ethereum by ethereum.
+    No, use geth, the go program made for ethereum by ethereum.
 
 9. CUDA GPU order changes sometimes. What can I do?
 
-   There is an environment var `CUDA_DEVICE_ORDER` which tells the Nvidia CUDA driver how to enumerates the graphic cards.
-   Following values are valid:
+    There is an environment var `CUDA_DEVICE_ORDER` which tells the Nvidia CUDA driver how to enumerates the graphic cards.
+    The following values are valid:
 
-   * FASTEST_FIRST (Default) - causes CUDA to guess which device is fastest using a simple heuristic.
-   * PCI_BUS_ID - orders devices by PCI bus ID in ascending order.
+    * `FASTEST_FIRST` (Default) - causes CUDA to guess which device is fastest using a simple heuristic.
+    * `PCI_BUS_ID` - orders devices by PCI bus ID in ascending order.
 
-   To prevent some unwanted changes in the order of your CUDA devices you **might set the environment to `PCI_BUS_ID`**.
-   This can be done:
+    To prevent some unwanted changes in the order of your CUDA devices you **might set the environment variable to `PCI_BUS_ID`**.
+    This can be done with one of the 2 ways:
 
-   * Linux:
-     * Adapt /etc/environment file and add a line `CUDA_DEVICE_ORDER=PCI_BUS_ID`
-     * Adapt your start script launching ethminer and add a line `export CUDA_DEVICE_ORDER=PCI_BUS_ID`
+    * Linux:
+        * Adapt the `/etc/environment` file and add a line `CUDA_DEVICE_ORDER=PCI_BUS_ID`
+        * Adapt your start script launching ethminer and add a line `export CUDA_DEVICE_ORDER=PCI_BUS_ID`
 
-   * Windows:
-     * Adapt your environment using the control panel (just search `setting environment windows control panel` using your favorite search engine)
-     * Adapt your start (.bat) file launching ethminer and add a line `setx CUDA_DEVICE_ORDER=PCI_BUS_ID` or `set CUDA_DEVICE_ORDER=PCI_BUS_ID`
-     * For more details about `setx` and `set` see <https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/setx>
+    * Windows:
+        * Adapt your environment using the control panel (just search `setting environment windows control panel` using your favorite search engine)
+        * Adapt your start (.bat) file launching ethminer and add a line `set CUDA_DEVICE_ORDER=PCI_BUS_ID` or `setx CUDA_DEVICE_ORDER PCI_BUS_ID`. For more info about `set` see [here](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/set_1), for more info about `setx` see [here](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/setx)
 
 
 [Amazon S3 is needed]: https://docs.travis-ci.com/user/uploading-artifacts/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ install: |
   nvcc -V
 
 build_script:
-  - cmake -G "Visual Studio 15 2017 Win64" -H. -Bbuild -T v140,host=x64 -DETHASHCUDA=ON -DAPICORE=ON -DHUNTER_JOBS_NUMBER=%NUMBER_OF_PROCESSORS%
+  - cmake -G "Visual Studio 15 2017 Win64" -H. -Bbuild -T v140 -DETHASHCUDA=ON -DAPICORE=ON -DHUNTER_JOBS_NUMBER=%NUMBER_OF_PROCESSORS%
   - cmake --build build --config %CONFIGURATION% --target package
 
 after_build:


### PR DESCRIPTION
* fix some typos
* remove `host=x64` from the cmake command; we already specify `Win64` in the generator command.
* add an example Windows script to build ethminer
* assorted Markdown tweaks
