### PR TITLE
Shorten mining progress logs.

### DIFF
--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -755,7 +755,7 @@ private:
 
 			if (mgr.isConnected()) {
 				auto mp = f.miningProgress(m_show_hwmonitors, m_show_power);
-				minelog << mp << f.getSolutionStats() << ' ' << f.farmLaunchedFormatted();
+				minelog << mp << ' ' << f.getSolutionStats() << ' ' << f.farmLaunchedFormatted();
 
 #if ETH_DBUS
 				dbusint.send(toString(mp).data());

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -384,15 +384,8 @@ public:
 		}
 	}
 
-	void rejectedSolution(bool _stale) {
-		if (!_stale)
-		{
+	void rejectedSolution() {
 			m_solutionStats.rejected();
-		}
-		else
-		{
-			m_solutionStats.rejectedStale();
-		}
 	}
 
 	using SolutionFound = std::function<void(const Solution&)>;

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -120,7 +120,7 @@ inline std::ostream& operator<<(std::ostream& _out, WorkingProgress _p)
 			}
 		}
 
-		_out << " gpu/" << i << " " << EthTeal << std::fixed << std::setprecision(2) << mh << EthReset;
+		_out << " gpu" << i << " " << EthTeal << std::fixed << std::setprecision(2) << mh << EthReset;
 		if (_p.minerMonitors.size() == _p.minersHashes.size())
 			_out << " " << EthTeal << _p.minerMonitors[i] << EthReset;
 	}

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -83,13 +83,10 @@ struct HwMonitor
 
 inline std::ostream& operator<<(std::ostream& os, HwMonitor _hw)
 {
-	string power = "";
-	if(_hw.powerW != 0){
-		ostringstream stream;
-		stream << fixed << setprecision(0) << _hw.powerW << "W";
-		power = stream.str();
-	}
-	return os << _hw.tempC << "C " << _hw.fanP << "% " << power;
+	os << _hw.tempC << "C " << _hw.fanP << "%";
+	if(_hw.powerW)
+		os << ' ' << fixed << setprecision(0) << _hw.powerW << "W";
+	return os;
 }
 
 /// Describes the progress of a mining operation.
@@ -109,8 +106,8 @@ inline std::ostream& operator<<(std::ostream& _out, WorkingProgress _p)
 {
 	float mh = _p.rate() / 1000000.0f;
 	_out << "Speed "
-		 << EthTealBold << std::fixed << std::setw(6) << std::setprecision(2) << mh << EthReset
-		 << " Mh/s    ";
+		 << EthTealBold << std::fixed << std::setprecision(2) << mh << EthReset
+		 << " Mh/s";
 
 	for (size_t i = 0; i < _p.minersHashes.size(); ++i)
 	{
@@ -123,10 +120,9 @@ inline std::ostream& operator<<(std::ostream& _out, WorkingProgress _p)
 			}
 		}
 
-		_out << "gpu/" << i << " " << EthTeal << std::fixed << std::setw(5) << std::setprecision(2) << mh << EthReset;
+		_out << " gpu/" << i << " " << EthTeal << std::fixed << std::setprecision(2) << mh << EthReset;
 		if (_p.minerMonitors.size() == _p.minersHashes.size())
 			_out << " " << EthTeal << _p.minerMonitors[i] << EthReset;
-		_out << "  ";
 	}
 
 	return _out;
@@ -139,27 +135,31 @@ public:
 	void failed()   { failures++; }
 
 	void acceptedStale() { acceptedStales++; }
-	void rejectedStale() { rejectedStales++; }
 
-	void reset() { accepts = rejects = failures = acceptedStales = rejectedStales = 0; }
+	void reset() { accepts = rejects = failures = acceptedStales = 0; }
 
 	unsigned getAccepts()			{ return accepts; }
 	unsigned getRejects()			{ return rejects; }
 	unsigned getFailures()			{ return failures; }
 	unsigned getAcceptedStales()	{ return acceptedStales; }
-	unsigned getRejectedStales()	{ return rejectedStales; }
 private:
 	unsigned accepts  = 0;
 	unsigned rejects  = 0;
 	unsigned failures = 0; 
 
 	unsigned acceptedStales = 0;
-	unsigned rejectedStales = 0;
 };
 
 inline std::ostream& operator<<(std::ostream& os, SolutionStats s)
 {
-	return os << "[A" << s.getAccepts() << "+" << s.getAcceptedStales() << ":R" << s.getRejects() << "+" << s.getRejectedStales() << ":F" << s.getFailures() << "]";
+	os << "[A" << s.getAccepts();
+	if (s.getAcceptedStales())
+		os << "+" << s.getAcceptedStales();
+	if (s.getRejects())
+		os << ":R" << s.getRejects();
+	if (s.getFailures())
+		os << ":F" << s.getFailures();
+	return os << "]";
 }
 
 class Miner;

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -133,7 +133,7 @@ PoolManager::PoolManager(boost::asio::io_service& io_service, PoolClient* client
 		ss << std::setw(4) << std::setfill(' ') << ms.count()
 			<< "ms." << "   " << m_connections[m_activeConnectionIdx].Host() + p_client->ActiveEndPoint();
 		cwarn << EthRed "**Rejected" EthReset << (stale ? "(stale)" : "") << ss.str();
-		m_farm.rejectedSolution(stale);
+		m_farm.rejectedSolution();
 	});
 
 	m_farm.onSolutionFound([&](const Solution& sol)


### PR DESCRIPTION
- No need to count stale rejects separately.
- Use minimal spacing... line gets very long for multi GPU
- Other than accepted, only display non zero solution stats.