### PR TITLE
Make log values more readable using locale specific formatting

### DIFF
--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -41,8 +41,10 @@ const char* NoteChannel::name() { return EthBlue " i"; }
 LogOutputStreamBase::LogOutputStreamBase(char const* _id, unsigned _v):
 	m_verbosity(_v)
 {
+	static std::locale logLocl = std::locale("");
 	if ((int)_v <= g_logVerbosity)
 	{
+		m_sstr.imbue(logLocl);
 		if (g_logSyslog)
 			m_sstr << std::left << std::setw(8) << getThreadName() << " " EthReset;
 		else {

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -71,7 +71,7 @@ public:
 
 	template <class T> void append(T const& _t)
 	{
-		m_sstr << toString(_t);
+		m_sstr << _t;
 	}
 
 protected:


### PR DESCRIPTION
- Specifically, large numbers are hard to parse.