### PR TITLE
api listen address parameter

### DIFF
--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -35,7 +35,12 @@ Whenever the above depicted conditions are met you can take advantage of the API
 ./ethminer [...] --api-port 3333
 ```
 
-This example puts the API interface listening on port 3333 of **any** local IP address which means the loop-back interface (127.0.0.1/127.0.1.1) and any configured IP address of the network card.
+This example puts the API interface listening on port 3333 of, by default, **any** local IP address which means the loop-back interface (127.0.0.1/127.0.1.1) and any configured IP address of the network card, but you can dictate what address to listen on with the `--api-address` parameter, for example, to only accept localhost connections:
+
+```shell
+./ethminer [...] --api-port 3333 --api-address "127.0.0.1"
+```
+and likewise, if you want to only accept connections from a VPN or a specific network, replace 127.0.0.1 accordingly.
 
 The API interface not only offers monitoring queries but also implements some methods which may affect the functioning of the miner. These latter operations are named _write_ actions: if you want to inhibit the invocation of such methods you may want to put the API interface in **read-only** mode which means only query to **get** data will be allowed and no _write_ methods will be allowed. To do this simply add the - (minus) sign in front of the port number thus transforming the port number into a negative number. Example for read-only mode:
 

--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -211,6 +211,10 @@ public:
 
 #if API_CORE
 
+		app.add_option("--api-address", m_api_address,
+			"Set the network address the api should listen on. (by default, it listens on every ip address)", true)
+			->group(APIGroup);
+
 		app.add_option("--api-port", m_api_port,
 			"Set the api port, the miner should listen to. Use 0 to disable. Use negative numbers for readonly mode", true)
 			->group(APIGroup)
@@ -220,6 +224,13 @@ public:
 			"Set the password to protect interaction with Api server. If not set any connection is granted access. "
 		    "Be advised passwords are sent unencrypted over plain tcp !!")
 			->group(APIGroup);
+
+// warning, before enabling this code, consider the security implications,
+// if the user is not careful, and only specify "--api-address 127.0.0.1 --api-port 3333 --http-port 3334"
+// or vise-versa, the user may inadvertently listen in on an insecure network without realizing it =/
+//      app.add_option("--http-address", m_http_address,
+//			"Set the network address the http api should listen on. (by default, it listens on every ip address)", true)
+//			->group(APIGroup);*/
 
 		app.add_option("--http-port", m_http_port,
 			"Set the web api port, the miner should listen to. Use 0 to disable. Data shown depends on hwmon setting", true)
@@ -735,10 +746,10 @@ private:
 
 #if API_CORE
 
-		ApiServer api(m_io_service, abs(m_api_port), (m_api_port < 0) ? true : false, m_api_password, f, mgr);
+		ApiServer api(m_io_service, m_api_address, abs(m_api_port), (m_api_port < 0) ? true : false, m_api_password, f, mgr);
 		api.start();
 
-        http_server.run(m_http_port, &f, m_show_hwmonitors, m_show_power);
+        http_server.run(m_api_address, m_http_port, &f, m_show_hwmonitors, m_show_power);
 
 #endif
 
@@ -843,8 +854,10 @@ private:
 	unsigned m_tstart = 40;
 
 #if API_CORE
+	string m_api_address;
 	int m_api_port = 0;
 	string m_api_password;
+	// m_http_address;
 	unsigned m_http_port = 0;
 #endif
 

--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -3,9 +3,10 @@
 #include <ethminer-buildinfo.h>
 
 ApiServer::ApiServer(
-    boost::asio::io_service& io_service, int portnum, bool readonly, string password, Farm& f, PoolManager& mgr)
+    boost::asio::io_service& io_service, string address, int portnum, bool readonly, string password, Farm& f, PoolManager& mgr)
   : m_readonly(readonly),
     m_password(std::move(password)),
+    m_address(address),
     m_portnumber(portnum),
     m_acceptor(io_service),
     m_io_strand(io_service),
@@ -19,9 +20,12 @@ void ApiServer::start()
     if (m_portnumber == 0)
         return;
 
+    if(m_address.empty())
+        m_address = "0.0.0.0";
+
     m_running.store(true, std::memory_order_relaxed);
 
-    tcp::endpoint endpoint(tcp::v4(), m_portnumber);
+    tcp::endpoint endpoint(boost::asio::ip::address::from_string(m_address), m_portnumber);
 
     // Try to bind to port number
     // if exception occurs it may be due to the fact that

--- a/libapicore/ApiServer.h
+++ b/libapicore/ApiServer.h
@@ -79,7 +79,7 @@ class ApiServer
 {
 public:
 
-	ApiServer(boost::asio::io_service& io_service, int portnum, bool readonly, string password, Farm& f, PoolManager& mgr);
+	ApiServer(boost::asio::io_service& io_service, string address, int portnum, bool readonly, string password, Farm& f, PoolManager& mgr);
 	bool isRunning() { return m_running.load(std::memory_order_relaxed); };
 	void start();
 	void stop();
@@ -95,6 +95,7 @@ private:
 	std::atomic<bool> m_readonly = { false };
 	std::string m_password = "";
 	std::atomic<bool> m_running = { false };
+	string m_address;
 	int m_portnumber;
 	tcp::acceptor m_acceptor;
 	boost::asio::io_service::strand m_io_strand;

--- a/libapicore/httpServer.cpp
+++ b/libapicore/httpServer.cpp
@@ -88,12 +88,17 @@ static void ev_handler(struct mg_connection* c, int ev, void* p)
     }
 }
 
-void httpServer::run(unsigned short port, dev::eth::Farm* farm, bool show_hwmonitors, bool show_power)
+void httpServer::run(string address, uint16_t port, dev::eth::Farm* farm, bool show_hwmonitors, bool show_power)
 {
 	if (port == 0)
 		return;
     m_farm = farm;
-    m_port = to_string(port);
+    // admittedly, at this point, it's a bit hacky to call it "m_port" =/
+    if(address.empty()){
+        m_port = to_string(port);
+    } else {
+        m_port = address + string(":") + to_string(port);
+    }
     m_show_hwmonitors = show_hwmonitors;
 	m_show_power = show_power;
     new thread(bind(&httpServer::run_thread, this));

--- a/libapicore/httpServer.h
+++ b/libapicore/httpServer.h
@@ -7,7 +7,7 @@ class httpServer
 {
 public:
 	httpServer() {};
-    void run(unsigned short port, dev::eth::Farm* farm, bool show_hwmonitors, bool show_power);
+    void run(string address, uint16_t port, dev::eth::Farm* farm, bool show_hwmonitors, bool show_power);
     void run_thread();
     void getstat1(stringstream& ss);
 


### PR DESCRIPTION
this allows listening to only a specific network address, for example, this allows ethminer to only listen for connections from localhost, or only listen to a VPN/secure network, instead listening in on all available networks.