### PR TITLE
std::atomic_uint64_t not defined

### DIFF
--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -102,7 +102,7 @@ typedef enum
 
 struct MiningPause
 {
-	std::atomic_uint64_t m_mining_paused_flag = {MinigPauseReason::MINING_NOT_PAUSED};
+	std::atomic<uint64_t> m_mining_paused_flag = {MinigPauseReason::MINING_NOT_PAUSED};
 
 	void set_mining_paused(MinigPauseReason pause_reason)
 	{


### PR DESCRIPTION
- std::atomic_uint64_t is not defined in older versions of gcc