### PR TITLE
Clean up and optimize CUDA DAG gen

### DIFF
--- a/libethash-cuda/ethash_cuda_miner_kernel.h
+++ b/libethash-cuda/ethash_cuda_miner_kernel.h
@@ -23,7 +23,6 @@ typedef struct {
 } search_results;
 
 #define ACCESSES 64
-#define THREADS_PER_HASH (128 / 16)
 
 typedef struct
 {
@@ -32,19 +31,21 @@ typedef struct
 
 typedef struct
 {
-	uint4	 uint4s[128 / sizeof(uint4)];
+	uint4 uint4s[128 / sizeof(uint4)];
 } hash128_t;
+
+#define THREADS_PER_HASH (sizeof(hash128_t) / sizeof(uint4))
 
 typedef union {
 	uint32_t words[64 / sizeof(uint32_t)];
-	uint2	 uint2s[64 / sizeof(uint2)];
-	uint4	 uint4s[64 / sizeof(uint4)];
+	uint2    uint2s[64 / sizeof(uint2)];
+	uint4    uint4s[64 / sizeof(uint4)];
 } hash64_t;
 
 typedef union {
 	uint32_t words[200 / sizeof(uint32_t)];
-	uint2	 uint2s[200 / sizeof(uint2)];
-	uint4	 uint4s[200 / sizeof(uint4)];
+	uint2    uint2s[200 / sizeof(uint2)];
+	uint4    uint4s[200 / sizeof(uint4)];
 } hash200_t;
 
 void set_constants(
@@ -83,18 +84,18 @@ struct cuda_runtime_error : public virtual std::runtime_error
 	cuda_runtime_error( const std::string &msg ) : std::runtime_error(msg) {}
 };
 
-#define CUDA_SAFE_CALL(call)				\
-do {							\
-	cudaError_t err = call;				\
-	if (cudaSuccess != err) {			\
-		std::stringstream ss;			\
-		ss << "CUDA error in func " 		\
-			<< __FUNCTION__ 		\
-			<< " at line "			\
-			<< __LINE__			\
-			<< ' '				\
-			<< cudaGetErrorString(err);	\
-		throw cuda_runtime_error(ss.str());	\
-	}						\
+#define CUDA_SAFE_CALL(call) \
+do { \
+	cudaError_t err = call; \
+	if (cudaSuccess != err) { \
+		std::stringstream ss; \
+		ss << "CUDA error in func " \
+			<< __FUNCTION__ \
+			<< " at line " \
+			<< __LINE__ \
+			<< ' ' \
+			<< cudaGetErrorString(err); \
+		throw cuda_runtime_error(ss.str()); \
+	} \
 } while (0)
 


### PR DESCRIPTION
We can't use the multi-thread algorithm unless a full group of 4 DAG entries needs to be calculated. That will be the case in 1 out of 2 epochs for the last DAG entries. For those we need to use a single threaded algorithm to avoid clobbering DAG entry 0.

DAG entries are 128 bytes each, but at gen time we view the DAG as consecutive 64 byte entries. Every odd epoch will have two last entries that cannot be grouped.