### PR TITLE
add --api-bind and --http-bind parameters

### DIFF
--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -29,18 +29,25 @@ Ethminer implements an API (Application Programming Interface) interface which a
 
 ## Activation and Security
 
-Whenever the above depicted conditions are met you can take advantage of the API support by adding the `--api-port` argument to the command line used to launch ethminer. The format of this argument is `--api-port nnnn` where `nnnn` is any valid TCP port number (1-65535). Examples:
+Whenever the above depicted conditions are met you can take advantage of the API support by adding the `--api-bind` argument to the command line used to launch ethminer. The format of this argument is `--api-bind address:port` where `nnnn` is any valid TCP port number (1-65535) and is required, and the `address` dictates what ip the api will listen on, and is optional, and defaults to "all ipv4 addresses". Examples:
 
 ```shell
-./ethminer [...] --api-port 3333
+./ethminer [...] --api-bind 3333
 ```
 
-This example puts the API interface listening on port 3333 of **any** local IP address which means the loop-back interface (127.0.0.1/127.0.1.1) and any configured IP address of the network card.
+This example puts the API interface listening on port 3333 of **any** local IPv4 address which means the loop-back interface (127.0.0.1/127.0.1.1) and any configured IPv4 address of the network card(s). To only listen to localhost connections (which may be a more secure setting),
+
+```shell
+./ethminer [...] --api-bind 127.0.0.1:3333
+```
+and likewise, to only listen on a specific address, replace `127.0.0.1` accordingly.
+
+
 
 The API interface not only offers monitoring queries but also implements some methods which may affect the functioning of the miner. These latter operations are named _write_ actions: if you want to inhibit the invocation of such methods you may want to put the API interface in **read-only** mode which means only query to **get** data will be allowed and no _write_ methods will be allowed. To do this simply add the - (minus) sign in front of the port number thus transforming the port number into a negative number. Example for read-only mode:
 
 ```shell
-./ethminer [...] --api-port -3333
+./ethminer [...] --api-bind -3333
 ```
 
 _Note. The port number in this examples is taken randomly and does not imply a suggested value. You can use any port number you wish while it's not in use by other applications._
@@ -48,14 +55,14 @@ _Note. The port number in this examples is taken randomly and does not imply a s
 To gain further security you may wish to password protect the access to your API interface simply by adding the `--api-password` argument to the command line sequence, followed by the password you wish. Password may be composed by any printable char and **must not** have spaces. Password checking is **case sensitive**. Example for password protected API interface:
 
 ```shell
-./ethminer [...] --api-port -3333 --api-password MySuperSecurePassword!!#123456
+./ethminer [...] --api-bind -3333 --api-password MySuperSecurePassword!!#123456
 ```
 
 At the time of writing of this document ethminer's API interface does not implement any sort of data encryption over SSL secure channel so **be advised your passwords will be sent as plain text over plain TCP sockets**.
 
 ## Usage
 
-Access to API interface is performed through a TCP socket connection to the API endpoint (which is the IP address of the computer running ethminer's API instance at the configured port). For instance if your computer address is 192.168.1.1 and have configured ethminer to run with `--api-port 3333` your endpoint will be 192.168.1.1:3333.
+Access to API interface is performed through a TCP socket connection to the API endpoint (which is the IP address of the computer running ethminer's API instance at the configured port). For instance if your computer address is 192.168.1.1 and have configured ethminer to run with `--api-bind 3333` your endpoint will be 192.168.1.1:3333.
 
 Messages exchanged through this channel must conform to the [JSON-RPC 2.0 specification](http://www.jsonrpc.org/specification) so basically you will issue **requests** and will get back **responses**. At the time of writing this document do not expect any **notification**. All messages must be line feed terminated.
 

--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -3,9 +3,10 @@
 #include <ethminer-buildinfo.h>
 
 ApiServer::ApiServer(
-    boost::asio::io_service& io_service, int portnum, bool readonly, string password, Farm& f, PoolManager& mgr)
+    boost::asio::io_service& io_service, string address, int portnum, bool readonly, string password, Farm& f, PoolManager& mgr)
   : m_readonly(readonly),
     m_password(std::move(password)),
+    m_address(address),
     m_portnumber(portnum),
     m_acceptor(io_service),
     m_io_strand(io_service),
@@ -21,7 +22,7 @@ void ApiServer::start()
 
     m_running.store(true, std::memory_order_relaxed);
 
-    tcp::endpoint endpoint(tcp::v4(), m_portnumber);
+    tcp::endpoint endpoint(boost::asio::ip::address::from_string(m_address), m_portnumber);
 
     // Try to bind to port number
     // if exception occurs it may be due to the fact that

--- a/libapicore/ApiServer.h
+++ b/libapicore/ApiServer.h
@@ -79,7 +79,7 @@ class ApiServer
 {
 public:
 
-	ApiServer(boost::asio::io_service& io_service, int portnum, bool readonly, string password, Farm& f, PoolManager& mgr);
+	ApiServer(boost::asio::io_service& io_service, string address, int portnum, bool readonly, string password, Farm& f, PoolManager& mgr);
 	bool isRunning() { return m_running.load(std::memory_order_relaxed); };
 	void start();
 	void stop();
@@ -95,6 +95,7 @@ private:
 	std::atomic<bool> m_readonly = { false };
 	std::string m_password = "";
 	std::atomic<bool> m_running = { false };
+	string m_address;
 	int m_portnumber;
 	tcp::acceptor m_acceptor;
 	boost::asio::io_service::strand m_io_strand;

--- a/libapicore/httpServer.cpp
+++ b/libapicore/httpServer.cpp
@@ -88,12 +88,17 @@ static void ev_handler(struct mg_connection* c, int ev, void* p)
     }
 }
 
-void httpServer::run(unsigned short port, dev::eth::Farm* farm, bool show_hwmonitors, bool show_power)
+void httpServer::run(string address, uint16_t port, dev::eth::Farm* farm, bool show_hwmonitors, bool show_power)
 {
 	if (port == 0)
 		return;
     m_farm = farm;
-    m_port = to_string(port);
+    // admittedly, at this point, it's a bit hacky to call it "m_port" =/
+    if(address.empty()){
+        m_port = to_string(port);
+    } else {
+        m_port = address + string(":") + to_string(port);
+    }
     m_show_hwmonitors = show_hwmonitors;
 	m_show_power = show_power;
     new thread(bind(&httpServer::run_thread, this));

--- a/libapicore/httpServer.h
+++ b/libapicore/httpServer.h
@@ -7,7 +7,7 @@ class httpServer
 {
 public:
 	httpServer() {};
-    void run(unsigned short port, dev::eth::Farm* farm, bool show_hwmonitors, bool show_power);
+    void run(string address, uint16_t port, dev::eth::Farm* farm, bool show_hwmonitors, bool show_power);
     void run_thread();
     void getstat1(stringstream& ss);
 


### PR DESCRIPTION
this allows listening to only a specific network address, for example, this allows ethminer to only listen for connections from localhost, or only listen to a VPN/secure network, instead listening in on all available networks. i also replaced `--api-port`  in the documentation  with `--api-bind`,  as this kindof supersedes it.