### PR TITLE
Stratum mode autodetection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Basic API authentication to protect exposure of API port to the internet [#1228](https://github.com/ethereum-mining/ethminer/pull/1228).
 - Add `ispaused` information into response of `miner_getstathr` API query [#1232](https://github.com/ethereum-mining/ethminer/pull/1232).
 - API responses return "ethminer-" as version prefix. [#1300](https://github.com/ethereum-mining/ethminer/pull/1300).
+- Stratum mode autodetection. No need to specify stratum+tcp or stratum1+tcp or stratum2+tcp
+- Connection failed due to login errors (wrong address or worker) are marked Unrecoverable and no longer used
 
 ## 0.15.0rc1
 

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -215,6 +215,18 @@ void PoolManager::workLoop()
 
 			if (!p_client->isConnected()) {
 
+				// If this connection is marked Unrecoverable then discard it
+				if (m_connections[m_activeConnectionIdx].IsUnrecoverable())
+				{
+					m_connections.erase(m_connections.begin() + m_activeConnectionIdx);
+					m_connectionAttempt = 0;
+					if (m_activeConnectionIdx > 0)
+					{
+						m_activeConnectionIdx--;
+					}
+				}
+
+
 				// Rotate connections if above max attempts threshold
 				if (m_connectionAttempt >= m_maxConnectionAttempts) {
 
@@ -238,7 +250,7 @@ void PoolManager::workLoop()
 
 				}
 
-				if (m_connections[m_activeConnectionIdx].Host() != "exit") {
+				if (m_connections[m_activeConnectionIdx].Host() != "exit" && m_connections.size() > 0) {
 
 					// Count connectionAttempts
 					m_connectionAttempt++;
@@ -252,7 +264,7 @@ void PoolManager::workLoop()
 				}
 				else {
 
-					cnote << "No more failover connections.";
+					cnote << "No more connections to try. Exiting ...";
 
 					// Stop mining if applicable
 					if (m_farm.isMining()) {

--- a/libpoolprotocols/PoolURI.h
+++ b/libpoolprotocols/PoolURI.h
@@ -41,7 +41,7 @@ public:
 private:
 	network::uri m_uri;
 	bool m_stratumModeConfirmed = false;
-	unsigned m_stratumMode = 0;
+	unsigned m_stratumMode = 999;			// Initial value 999 means not tested yet
 	bool m_unrecoverable = false;
 };
 

--- a/libpoolprotocols/PoolURI.h
+++ b/libpoolprotocols/PoolURI.h
@@ -31,8 +31,18 @@ public:
 
 	static std::string KnownSchemes(ProtocolFamily family);
 
+	void SetStratumMode(unsigned mode, bool confirmed) { m_stratumMode = mode; m_stratumModeConfirmed = confirmed; }
+	void SetStratumMode(unsigned mode) { m_stratumMode = mode; }
+	unsigned StratumMode() { return m_stratumMode; }
+	bool StratumModeConfirmed() { return m_stratumModeConfirmed; }
+	bool IsUnrecoverable() { return m_unrecoverable; }
+	void MarkUnrecoverable() { m_unrecoverable = true; }
+
 private:
 	network::uri m_uri;
+	bool m_stratumModeConfirmed = false;
+	unsigned m_stratumMode = 0;
+	bool m_unrecoverable = false;
 };
 
 }

--- a/libpoolprotocols/PoolURI.h
+++ b/libpoolprotocols/PoolURI.h
@@ -13,36 +13,39 @@ enum class ProtocolFamily {GETWORK = 0, STRATUM};
 class URI
 {
 public:
-	URI() {};
-	URI(const std::string uri);
+    URI(){};
+    URI(const std::string uri);
 
-	std::string	Scheme() const;
-	std::string	Host() const;
-	std::string	Path() const;
-	unsigned short	Port() const;
-	std::string	User() const;
-	std::string	Pass() const;
-	SecureLevel	SecLevel() const;
-	ProtocolFamily	Family() const;
-	unsigned	Version() const;
-	std::string string() { return m_uri.string(); }
+    std::string Scheme() const;
+    std::string Host() const;
+    std::string Path() const;
+    unsigned short Port() const;
+    std::string User() const;
+    std::string Pass() const;
+    SecureLevel SecLevel() const;
+    ProtocolFamily Family() const;
+    unsigned Version() const;
+    std::string string() { return m_uri.string(); }
 
-	bool		KnownScheme();
+    bool KnownScheme();
 
-	static std::string KnownSchemes(ProtocolFamily family);
+    static std::string KnownSchemes(ProtocolFamily family);
 
-	void SetStratumMode(unsigned mode, bool confirmed) { m_stratumMode = mode; m_stratumModeConfirmed = confirmed; }
-	void SetStratumMode(unsigned mode) { m_stratumMode = mode; }
-	unsigned StratumMode() { return m_stratumMode; }
-	bool StratumModeConfirmed() { return m_stratumModeConfirmed; }
-	bool IsUnrecoverable() { return m_unrecoverable; }
-	void MarkUnrecoverable() { m_unrecoverable = true; }
+    void SetStratumMode(unsigned mode, bool confirmed)
+    {
+        m_stratumMode = mode;
+        m_stratumModeConfirmed = confirmed;
+    }
+    void SetStratumMode(unsigned mode) { m_stratumMode = mode; }
+    unsigned StratumMode() { return m_stratumMode; }
+    bool StratumModeConfirmed() { return m_stratumModeConfirmed; }
+    bool IsUnrecoverable() { return m_unrecoverable; }
+    void MarkUnrecoverable() { m_unrecoverable = true; }
 
 private:
-	network::uri m_uri;
-	bool m_stratumModeConfirmed = false;
-	unsigned m_stratumMode = 999;			// Initial value 999 means not tested yet
-	bool m_unrecoverable = false;
+    network::uri m_uri;
+    bool m_stratumModeConfirmed = false;
+    unsigned m_stratumMode = 999;  // Initial value 999 means not tested yet
+    bool m_unrecoverable = false;
 };
-
 }

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -1292,14 +1292,14 @@ void EthStratumClient::onRecvSocketDataCompleted(const boost::system::error_code
 				(ERR_GET_REASON(ec.value()) == SSL_RECEIVED_SHUTDOWN)
 				)
 			{
-				cnote << "SSL Stream remotely closed by" << m_conn->Host();
+				cnote << "SSL Stream remotely closed by " << m_conn->Host();
 			} 
 			else if (ec == boost::asio::error::eof)
 			{
-				cnote << "Connection remotely closed by" << m_conn->Host();
+				cnote << "Connection remotely closed by " << m_conn->Host();
 			}
 			else {
-				cwarn << "Socket read failed:" << ec.message();
+				cwarn << "Socket read failed: " << ec.message();
 			}
 			disconnect();
 		}

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -255,28 +255,27 @@ void EthStratumClient::disconnect_finalize() {
 	m_disconnecting.store(false, std::memory_order::memory_order_relaxed);
 
 
-	// If we got disconnected during autodetection phase 
-	// reissue a connect lowering stratum mode checks
-	if (!m_conn->StratumModeConfirmed())
-	{
-		unsigned l = m_conn->StratumMode();
-		if (l > 0)
-		{
-			l--;
-			m_conn->SetStratumMode(l);
+    // If we got disconnected during autodetection phase
+    // reissue a connect lowering stratum mode checks
+    if (!m_conn->StratumModeConfirmed())
+    {
+        unsigned l = m_conn->StratumMode();
+        if (l > 0)
+        {
+            l--;
+            m_conn->SetStratumMode(l);
 
-			// Repost a new connection attempt
-			m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::connect, this)));
-			cnote << l;
-			return;
+            // Repost a new connection attempt
+            m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::connect, this)));
+            return;
+        }
+    }
 
-		}
-	} 
-
-	// Trigger handlers
-	if (m_onDisconnected) { m_onDisconnected(); }
-
-
+    // Trigger handlers
+    if (m_onDisconnected)
+    {
+        m_onDisconnected();
+    }
 }
 
 void EthStratumClient::resolve_handler(const boost::system::error_code& ec, tcp::resolver::iterator i)

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -661,8 +661,8 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
                     // member is exactly "EthereumStratum/1.0.0". Otherwise try with another mode
                     if (_isSuccess)
                     {
-                        if (!jResult.isArray() || jResult.size() != 3 ||
-                            jResult.get((Json::Value::ArrayIndex)2, "").asString() !=
+                        if (!jResult.isArray() || !jResult[0].isArray() || jResult[0].size() != 3 ||
+                            jResult[0].get((Json::Value::ArrayIndex)2, "").asString() !=
                                 "EthereumStratum/1.0.0")
                         {
                             // This is not a proper ETHEREUMSTRATUM response.

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -66,10 +66,10 @@ private:
 	void onSendSocketDataCompleted(const boost::system::error_code& ec);
 	void onSSLShutdownCompleted(const boost::system::error_code& ec);
 
-	string m_user;      // Only user part
-	string m_worker;    // eth-proxy only; No ! It's for all !!!
+    string m_user;    // Only user part
+    string m_worker;  // eth-proxy only; No ! It's for all !!!
 
-	std::atomic<bool> m_disconnecting = { false };
+    std::atomic<bool> m_disconnecting = { false };
 	std::atomic<bool> m_connecting = { false };
 
 	// seconds to trigger a work_timeout (overwritten in constructor)
@@ -82,9 +82,9 @@ private:
 
 	bool m_stale = false;
 
-	boost::asio::io_service & m_io_service;						// The IO service reference passed in the constructor
-	boost::asio::io_service::strand m_io_strand;
-	boost::asio::ip::tcp::socket *m_socket;
+    boost::asio::io_service& m_io_service;  // The IO service reference passed in the constructor
+    boost::asio::io_service::strand m_io_strand;
+    boost::asio::ip::tcp::socket *m_socket;
 
 	// Use shared ptrs to avoid crashes due to async_writes
 	// see https://stackoverflow.com/questions/41526553/can-async-write-cause-segmentation-fault-when-this-is-deleted

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -66,7 +66,8 @@ private:
 	void onSendSocketDataCompleted(const boost::system::error_code& ec);
 	void onSSLShutdownCompleted(const boost::system::error_code& ec);
 
-	string m_worker; // eth-proxy only; No ! It's for all !!!
+	string m_user;      // Only user part
+	string m_worker;    // eth-proxy only; No ! It's for all !!!
 
 	std::atomic<bool> m_disconnecting = { false };
 	std::atomic<bool> m_connecting = { false };


### PR DESCRIPTION
Eliminates the hassle of knowing in advance which is the stratum mode implemented by the pool. No more stratum/1/2+tcp:// but only stratum+tcp://

Added support for invalid connections. Whenever a connection cannot be established due to login errors (invalid worker or bad address) it's marked as Unrecoverable and won't be used again.