### PR TITLE
Prevent never-ending loop due to stratum mode autodetection

### DIFF
--- a/libpoolprotocols/PoolClient.h
+++ b/libpoolprotocols/PoolClient.h
@@ -22,6 +22,7 @@ namespace dev
 			void setConnection(URI &conn)
 			{
 				m_conn = &conn;
+				m_canconnect.store(false, std::memory_order_relaxed);
 			}
 
 			virtual void connect() = 0;
@@ -49,6 +50,7 @@ namespace dev
 			std::atomic<bool> m_subscribed = { false };
 			std::atomic<bool> m_authorized = { false };
 			std::atomic<bool> m_connected = { false };
+			std::atomic<bool> m_canconnect = { false };
 
 			boost::asio::ip::basic_endpoint<boost::asio::ip::tcp> m_endpoint;
 

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -257,8 +257,8 @@ void EthStratumClient::disconnect_finalize() {
 
     // If we got disconnected during autodetection phase
     // reissue a connect lowering stratum mode checks
-	// m_canconnect flag is used to prevent never-ending loop when
-	// remote endpoint rejects connections attempts persistently since the first
+    // m_canconnect flag is used to prevent never-ending loop when
+    // remote endpoint rejects connections attempts persistently since the first
     if (!m_conn->StratumModeConfirmed() && m_canconnect.load(std::memory_order_relaxed))
     {
         unsigned l = m_conn->StratumMode();


### PR DESCRIPTION
As for stratum autodetection a new issue  emerged in case pool's endpoint refuses connection since the very first. This PR amends it.