### PR TITLE
Binary loader for Zawawawa's kernels

### DIFF
--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -348,6 +348,11 @@ public:
 			->group(OpenCLGroup)
 			->check(CLI::Range(2));
 
+		app.add_option("--cl-iterations", m_openclIterations,
+			"Number of outer iterations to perform before enqeueing on a new nonce", true)
+			->group(OpenCLGroup)
+			->check(CLI::Range(1,99999));
+
 		app.add_option("--cl-global-work", m_globalWorkSizeMultiplier,
 			"Set the global work size multipler. Specify negative value for automatic scaling based on # of compute units", true)
 			->group(OpenCLGroup);
@@ -617,6 +622,7 @@ public:
 			}
 
 			CLMiner::setCLKernel(m_openclSelectedKernel);
+			CLMiner::setNumberIterations(m_openclIterations);
 			CLMiner::setThreadsPerHash(m_openclThreadsPerHash);
 
 			if (!CLMiner::configureGPU(
@@ -891,6 +897,7 @@ private:
 	bool m_shouldListDevices = false;
 #if ETH_ETHASHCL
 	unsigned m_openclSelectedKernel = 0;  ///< A numeric value for the selected OpenCL kernel
+	unsigned m_openclIterations = 1;  ///< A numeric value for the number of iterations
 	unsigned m_openclDeviceCount = 0;
 	vector<unsigned> m_openclDevices;
 	unsigned m_openclThreadsPerHash = 8;

--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -70,8 +70,8 @@ public:
 		Stratum
 	};
 
-	MinerCLI() : 
-		m_io_work(m_io_service), 
+	MinerCLI() :
+		m_io_work(m_io_service),
 		m_io_work_timer(m_io_service),
 		m_io_strand(m_io_service)
 	{
@@ -344,9 +344,9 @@ public:
 			->group(OpenCLGroup);
 
 		app.add_option("--cl-kernel", m_openclSelectedKernel,
-			"Select kernel. 0 stable kernel, 1 experimental kernel", true)
+			"Select kernel. 0 stable kernel, 1 experimental kernel, 2 binary kernel", true)
 			->group(OpenCLGroup)
-			->check(CLI::Range(1));
+			->check(CLI::Range(2));
 
 		app.add_option("--cl-global-work", m_globalWorkSizeMultiplier,
 			"Set the global work size multipler. Specify negative value for automatic scaling based on # of compute units", true)
@@ -533,7 +533,7 @@ public:
 				exit(-1);
 			}
 			m_endpoints.push_back(uri);
-			
+
 			OperationMode mode = OperationMode::None;
 			switch (uri.Family())
 			{
@@ -729,7 +729,7 @@ private:
 			f.start("cuda", false);
 
 		WorkPackage current = WorkPackage(genesis);
-		
+
 
 		vector<uint64_t> results;
 		results.reserve(_trials);
@@ -739,7 +739,7 @@ private:
 		{
 			current.header = h256::random();
 			current.boundary = genesis.boundary();
-			f.setWork(current);	
+			f.setWork(current);
 			if (!i)
 				cout << "Warming up..." << endl;
 			else
@@ -768,7 +768,7 @@ private:
 		stop_io_service();
 		exit(0);
 	}
-	
+
 	void doMiner()
 	{
 		map<string, Farm::SealerDescriptor> sealers;
@@ -857,11 +857,11 @@ private:
 			else {
 				minelog << "not-connected";
 			}
-			
+
 		}
 
 #if API_CORE
-		
+
 		// Stop Api server
 		api.stop();
 
@@ -921,7 +921,7 @@ private:
 	unsigned m_maxFarmRetries = 3;
 	unsigned m_farmRecheckPeriod = 500;
 	unsigned m_displayInterval = 5;
-	
+
 	// Number of seconds to wait before triggering a no work timeout from pool
 	unsigned m_worktimeout = 180;
 	// Number of seconds to wait before triggering a response timeout from pool

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -639,14 +639,14 @@ bool CLMiner::init(int epoch)
             cllog << "OpenCL kernel: Experimental kernel";
             code = string(CLMiner_kernel_experimental, CLMiner_kernel_experimental + sizeof(CLMiner_kernel_experimental));
         }
-        else { //if(s_clKernelName == CLKernelName::Stable || s_clKernelName == CLKernelName::Binary_Sgminer)
-            cllog << (s_clKernelName == CLKernelName::Binary_Sgminer ?
+        else { //if(s_clKernelName == CLKernelName::Stable || s_clKernelName == CLKernelName::Binary)
+            cllog << (s_clKernelName == CLKernelName::Binary ?
                         "OpenCL kernel: Binary kernel" :
                         "OpenCL kernel: Stable kernel");
 
             //CLMiner_kernel_stable.cl will do a #undef THREADS_PER_HASH
             if(s_threadsPerHash != 8) {
-                cwarn << "The current stable OpenCL kernel only supports exactly 8 threads. Thread parameter will be ignored.";
+                cwarn << "The current kernel only supports exactly 8 threads. Thread parameter will be ignored.";
             }
 
             // Even if we're using the binary kernel, we still need the generate dag
@@ -682,7 +682,7 @@ bool CLMiner::init(int epoch)
            the default kernel if loading fails for whatever reason */
 		bool loadedBinary = false;
 
-        if(s_clKernelName == CLKernelName::Binary_Sgminer) {
+        if(s_clKernelName == CLKernelName::Binary) {
             std::ifstream kernel_file;
             vector<unsigned char> bin_data;
             std::stringstream fname_strm;
@@ -744,7 +744,7 @@ bool CLMiner::init(int epoch)
             cllog << "Loading kernels";
 
             // If we have a binary kernel to use, let's try it
-            if(s_clKernelName == CLKernelName::Binary_Sgminer && loadedBinary) {
+            if(s_clKernelName == CLKernelName::Binary && loadedBinary) {
                 m_searchKernel = cl::Kernel(binaryProgram, "ethash_search");
                 // TODO: Load the binary dag builder
                 m_dagKernel = cl::Kernel(program, "ethash_calculate_dag_item");
@@ -770,7 +770,7 @@ bool CLMiner::init(int epoch)
         m_searchKernel.setArg(2, m_dag);
         m_searchKernel.setArg(5, ~0u);  // Pass this to stop the compiler unrolling the loops.
 
-        if(s_clKernelName == CLKernelName::Binary_Sgminer && loadedBinary) {
+        if(s_clKernelName == CLKernelName::Binary && loadedBinary) {
             m_searchKernel.setArg(6, dagNumItems);
             m_searchKernel.setArg(7, 1);  // Number of iterations, set to 1 for now
         }

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -20,6 +20,8 @@ namespace eth
 unsigned CLMiner::s_workgroupSize = CLMiner::c_defaultLocalWorkSize;
 unsigned CLMiner::s_initialGlobalWorkSize = CLMiner::c_defaultGlobalWorkSizeMultiplier * CLMiner::c_defaultLocalWorkSize;
 unsigned CLMiner::s_threadsPerHash = 8;
+unsigned CLMiner::s_kernelIterations = 1;
+
 CLKernelName CLMiner::s_clKernelName = CLMiner::c_defaultKernelName;
 bool CLMiner::s_adjustWorkSize = false;
 
@@ -772,7 +774,7 @@ bool CLMiner::init(int epoch)
 
         if(s_clKernelName == CLKernelName::Binary && loadedBinary) {
             m_searchKernel.setArg(6, dagNumItems);
-            m_searchKernel.setArg(7, 1);  // Number of iterations, set to 1 for now
+            m_searchKernel.setArg(7, s_kernelIterations);  // Number of iterations
         }
 
         // create mining buffers

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -770,11 +770,13 @@ bool CLMiner::init(int epoch)
 
         m_searchKernel.setArg(1, m_header);
         m_searchKernel.setArg(2, m_dag);
-        m_searchKernel.setArg(5, ~0u);  // Pass this to stop the compiler unrolling the loops.
 
         if(s_clKernelName == CLKernelName::Binary && loadedBinary) {
-            m_searchKernel.setArg(6, dagNumItems);
-            m_searchKernel.setArg(7, s_kernelIterations);  // Number of iterations
+            m_searchKernel.setArg(5, ~0UL);  // Pass this to stop the compiler unrolling the loops.
+            m_searchKernel.setArg(6, uint32_t(dagNumItems));
+            m_searchKernel.setArg(7, uint32_t(s_kernelIterations));  // Number of iterations
+        }else {
+            m_searchKernel.setArg(5, ~0u);  // Pass this to stop the compiler unrolling the loops.
         }
 
         // create mining buffers

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -498,8 +498,8 @@ bool CLMiner::configureGPU(unsigned _localWorkSize, int _globalWorkSizeMultiplie
                 "Found suitable OpenCL device [" << device.getInfo<CL_DEVICE_NAME>()
                                                  << "] with " << result << " bytes of GPU memory";
             foundSuitableDevice = true;
-        } 
-        else 
+        }
+        else
         {
         cnote <<
             "OpenCL device " << device.getInfo<CL_DEVICE_NAME>()
@@ -507,7 +507,7 @@ bool CLMiner::configureGPU(unsigned _localWorkSize, int _globalWorkSizeMultiplie
                              " bytes of memory found < " << dagSize << " bytes of memory required";
         }
     }
-    if (foundSuitableDevice) 
+    if (foundSuitableDevice)
     {
         return true;
     }
@@ -568,7 +568,8 @@ bool CLMiner::init(int epoch)
         m_hwmoninfo.deviceIndex = deviceId % devices.size();
         cl::Device& device = devices[deviceId % devices.size()];
         string device_version = device.getInfo<CL_DEVICE_VERSION>();
-        ETHCL_LOG("Device:   " << device.getInfo<CL_DEVICE_NAME>() << " / " << device_version);
+        string device_name = device.getInfo<CL_DEVICE_NAME>();
+        ETHCL_LOG("Device:   " << device_name << " / " << device_version);
 
         string clVer = device_version.substr(7, 3);
         if (clVer == "1.0" || clVer == "1.1")
@@ -638,14 +639,18 @@ bool CLMiner::init(int epoch)
             cllog << "OpenCL kernel: Experimental kernel";
             code = string(CLMiner_kernel_experimental, CLMiner_kernel_experimental + sizeof(CLMiner_kernel_experimental));
         }
-        else { //if(s_clKernelName == CLKernelName::Stable)
-            cllog << "OpenCL kernel: Stable kernel";
+        else { //if(s_clKernelName == CLKernelName::Stable || s_clKernelName == CLKernelName::Binary_Sgminer)
+            cllog << (s_clKernelName == CLKernelName::Binary_Sgminer ?
+                        "OpenCL kernel: Binary kernel" :
+                        "OpenCL kernel: Stable kernel");
 
             //CLMiner_kernel_stable.cl will do a #undef THREADS_PER_HASH
             if(s_threadsPerHash != 8) {
                 cwarn << "The current stable OpenCL kernel only supports exactly 8 threads. Thread parameter will be ignored.";
             }
 
+            // Even if we're using the binary kernel, we still need the generate dag
+            // from the CL kernel. For now.
             code = string(CLMiner_kernel_stable, CLMiner_kernel_stable + sizeof(CLMiner_kernel_stable));
         }
         addDefinition(code, "GROUP_SIZE", m_workgroupSize);
@@ -659,7 +664,7 @@ bool CLMiner::init(int epoch)
 
         // create miner OpenCL program
         cl::Program::Sources sources{{code.data(), code.size()}};
-        cl::Program program(m_context, sources);
+        cl::Program program(m_context, sources), binaryProgram;
         try
         {
             program.build({device}, options);
@@ -672,15 +677,60 @@ bool CLMiner::init(int epoch)
             return false;
         }
 
+        /* If we have a binary kernel, we load it in tandem with the opencl,
+		   that way, we can use the dag generate opencl code and fall back on
+           the default kernel if loading fails for whatever reason */
+		bool loadedBinary = false;
+
+        if(s_clKernelName == CLKernelName::Binary_Sgminer) {
+            std::ifstream kernel_file;
+            vector<unsigned char> bin_data;
+            std::stringstream fname_strm;
+
+            /* Open kernels/ethash_{devicename}_lws{local_work_size}.bin */
+            std::transform(device_name.begin(), device_name.end(), device_name.begin(), ::tolower);
+            fname_strm << "kernels/ethash_" << device_name << "_lws" << m_workgroupSize << ".bin";
+            kernel_file.open(fname_strm.str(), ios::in | ios::binary);
+
+            if(kernel_file.good()) {
+                /* Load the data vector with file data */
+                kernel_file.unsetf(std::ios::skipws);
+                bin_data.insert(bin_data.begin(),
+                std::istream_iterator<unsigned char>(kernel_file),
+                std::istream_iterator<unsigned char>());
+
+                /* Setup the program */
+                cl::Program::Binaries blobs({bin_data});
+                cl::Program program(m_context, { device }, blobs);
+                try
+                {
+                    program.build({ device }, options);
+                    cllog << "Build info success:" << program.getBuildInfo<CL_PROGRAM_BUILD_LOG>(device);
+                    binaryProgram = program;
+                    loadedBinary = true;
+                }
+                catch (cl::Error const&)
+                {
+                    cwarn << "Build failed! Info:" << program.getBuildInfo<CL_PROGRAM_BUILD_LOG>(device);
+                    cwarn << fname_strm.str();
+                    cwarn << "Falling back to OpenCL kernel...";
+                }
+            } else {
+                cwarn << "Instructed to load binary kernel, but failed to load kernel:";
+                cwarn << fname_strm.str();
+                cwarn << "Falling back to OpenCL kernel...";
+            }
+        }
+
         //check whether the current dag fits in memory everytime we recreate the DAG
         cl_ulong result = 0;
         device.getInfo(CL_DEVICE_GLOBAL_MEM_SIZE, &result);
         if (result < dagSize)
         {
             cnote <<
-            "OpenCL device " << device.getInfo<CL_DEVICE_NAME>()
+            "OpenCL device " << device_name
                              << " has insufficient GPU memory." << result <<
-                             " bytes of memory found < " << dagSize << " bytes of memory required";    
+                             " bytes of memory found < " << dagSize << " bytes of memory required";
             return false;
         }
 
@@ -692,8 +742,18 @@ bool CLMiner::init(int epoch)
             cllog << "Creating DAG buffer, size: " << dagSize;
             m_dag = cl::Buffer(m_context, CL_MEM_READ_ONLY, dagSize);
             cllog << "Loading kernels";
-            m_searchKernel = cl::Kernel(program, "ethash_search");
-            m_dagKernel = cl::Kernel(program, "ethash_calculate_dag_item");
+
+            // If we have a binary kernel to use, let's try it
+            if(s_clKernelName == CLKernelName::Binary_Sgminer && loadedBinary) {
+                m_searchKernel = cl::Kernel(binaryProgram, "ethash_search");
+                // TODO: Load the binary dag builder
+                m_dagKernel = cl::Kernel(program, "ethash_calculate_dag_item");
+            } else {
+                // otherwise just do a normal load
+                m_searchKernel = cl::Kernel(program, "ethash_search");
+                m_dagKernel = cl::Kernel(program, "ethash_calculate_dag_item");
+            }
+
             cllog << "Writing light cache buffer";
             m_queue.enqueueWriteBuffer(m_light, CL_TRUE, 0, lightSize, context.light_cache);
         }
@@ -709,6 +769,11 @@ bool CLMiner::init(int epoch)
         m_searchKernel.setArg(1, m_header);
         m_searchKernel.setArg(2, m_dag);
         m_searchKernel.setArg(5, ~0u);  // Pass this to stop the compiler unrolling the loops.
+
+        if(s_clKernelName == CLKernelName::Binary_Sgminer && loadedBinary) {
+            m_searchKernel.setArg(6, dagNumItems);
+            m_searchKernel.setArg(7, 1);  // Number of iterations, set to 1 for now
+        }
 
         // create mining buffers
         ETHCL_LOG("Creating mining buffer");

--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -87,6 +87,7 @@ public:
 			case 2: s_clKernelName = CLKernelName::Binary; break;
 		}
 	}
+    static void setNumberIterations(unsigned _iterations) {s_kernelIterations = _iterations <= 1 ? 1 : _iterations;}
 protected:
 	void kick_miner() override;
 
@@ -100,7 +101,6 @@ private:
 	cl::Kernel m_searchKernel;
 	cl::Kernel m_dagKernel;
 
-
 	cl::Buffer m_dag;
 	cl::Buffer m_light;
 	cl::Buffer m_header;
@@ -112,6 +112,7 @@ private:
 	static unsigned s_numInstances;
 	static unsigned s_threadsPerHash;
 	static CLKernelName s_clKernelName;
+    static unsigned s_kernelIterations;
 	static vector<int> s_devices;
 
 	/// The local work size for the search

--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -46,7 +46,7 @@ namespace eth
 enum CLKernelName {
 	Stable,
 	Experimental,
-    Binary_Sgminer
+    Binary
 };
 
 class CLMiner: public Miner
@@ -84,7 +84,7 @@ public:
 			default: ;
 			case 0: s_clKernelName = CLKernelName::Stable; break;
 			case 1: s_clKernelName = CLKernelName::Experimental; break;
-			case 2: s_clKernelName = CLKernelName::Binary_Sgminer; break;
+			case 2: s_clKernelName = CLKernelName::Binary; break;
 		}
 	}
 protected:

--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -8,7 +8,7 @@
 #include <libdevcore/Worker.h>
 #include <libethcore/EthashAux.h>
 #include <libethcore/Miner.h>
-
+#include <fstream>
 
 #pragma GCC diagnostic push
 #if __GNUC__ >= 6
@@ -99,6 +99,8 @@ private:
 	cl::CommandQueue m_queue;
 	cl::Kernel m_searchKernel;
 	cl::Kernel m_dagKernel;
+
+
 	cl::Buffer m_dag;
 	cl::Buffer m_light;
 	cl::Buffer m_header;

--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -46,6 +46,7 @@ namespace eth
 enum CLKernelName {
 	Stable,
 	Experimental,
+    Binary_Sgminer
 };
 
 class CLMiner: public Miner
@@ -78,7 +79,14 @@ public:
 			s_devices[i] = _devices[i];
 		}
 	}
-	static void setCLKernel(unsigned _clKernel) { s_clKernelName = _clKernel == 1 ? CLKernelName::Experimental : CLKernelName::Stable; }
+	static void setCLKernel(unsigned _clKernel) {
+		switch (_clKernel) {
+			default: ;
+			case 0: s_clKernelName = CLKernelName::Stable; break;
+			case 1: s_clKernelName = CLKernelName::Experimental; break;
+			case 2: s_clKernelName = CLKernelName::Binary_Sgminer; break;
+		}
+	}
 protected:
 	void kick_miner() override;
 


### PR DESCRIPTION
Since zawawawa open sourced his kernels, I added a binary loader to load them for AMD cards based on architecture and local work size. This patch adds another value for the option kernel option i.e. ```--cl-kernel 2``` which loads the binary kernels from ```./kernels/```. There's also ```--cl-iterations``` which controls a parameter with the kernel. Kernels can be found [here](https://github.com/goobur/ethash-kernels) although they're still experimental.