### PR TITLE
Fix broken opencl miner

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -770,11 +770,13 @@ bool CLMiner::init(int epoch)
 
         m_searchKernel.setArg(1, m_header);
         m_searchKernel.setArg(2, m_dag);
-        m_searchKernel.setArg(5, ~0UL);  // Pass this to stop the compiler unrolling the loops.
 
         if(s_clKernelName == CLKernelName::Binary && loadedBinary) {
+            m_searchKernel.setArg(5, ~0UL);  // Pass this to stop the compiler unrolling the loops.
             m_searchKernel.setArg(6, uint32_t(dagNumItems));
             m_searchKernel.setArg(7, uint32_t(s_kernelIterations));  // Number of iterations
+        }else {
+            m_searchKernel.setArg(5, ~0u);  // Pass this to stop the compiler unrolling the loops.
         }
 
         // create mining buffers


### PR DESCRIPTION
Not sure why:

m_searchKernel.setArg(5, ~0UL);  // Pass this to stop the compiler unrolling the loops.

if(s_clKernelName == CLKernelName::Binary && loadedBinary) {
    m_searchKernel.setArg(6, uint32_t(dagNumItems));
    m_searchKernel.setArg(7, uint32_t(s_kernelIterations));  // Number of iterations
}

would be any different from:

if(s_clKernelName == CLKernelName::Binary && loadedBinary) {
    m_searchKernel.setArg(5, ~0UL);  // Pass this to stop the compiler unrolling the loops.
    m_searchKernel.setArg(6, uint32_t(dagNumItems));
    m_searchKernel.setArg(7, uint32_t(s_kernelIterations));  // Number of iterations
}else {
    m_searchKernel.setArg(5, ~0u);  // Pass this to stop the compiler unrolling the loops.
}

But for some reason the former completely breaks CLMiner!!!

Wait... I see... one is uint32 the other uint64