### PR TITLE
Correct disconnect message.

### DIFF
--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -16,6 +16,7 @@ PoolManager::PoolManager(boost::asio::io_service& io_service, PoolClient* client
 	p_client->onConnected([&]()
 	{
 		m_connectionAttempt = 0;
+		m_activeConnectionHost = m_connections[m_activeConnectionIdx].Host();
 		cnote << "Connected to " << m_connections[m_activeConnectionIdx].Host() << p_client->ActiveEndPoint();
 
 		// Rough implementation to return to primary pool
@@ -50,7 +51,7 @@ PoolManager::PoolManager(boost::asio::io_service& io_service, PoolClient* client
 	p_client->onDisconnected([&]()
 	{
 		dev::setThreadName("main");
-		cnote << "Disconnected from " + m_connections[m_activeConnectionIdx].Host() << p_client->ActiveEndPoint();
+		cnote << "Disconnected from " + m_activeConnectionHost << p_client->ActiveEndPoint();
 
 		// Clear queue of submission times as we won't get any further response for them (if any left)
 		// We need to consume all elements as no clear mehod is provided.

--- a/libpoolprotocols/PoolManager.h
+++ b/libpoolprotocols/PoolManager.h
@@ -42,6 +42,7 @@ namespace dev
 			unsigned m_connectionAttempt = 0;
 			unsigned m_maxConnectionAttempts = 0;
 			unsigned m_activeConnectionIdx = 0;
+			std::string m_activeConnectionHost = "";
 
 			std::vector <URI> m_connections;
 			std::thread m_workThread;


### PR DESCRIPTION
If a connection is changed via API call 'miner_setactiveconnection'
ethminer displays info that it disconnects from the "new" host.
Fixing this - display the correct host in the disconnect message.