### PR TITLE
Stratum: Correct miner version

### DIFF
--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -750,7 +750,7 @@ Json::Value ApiConnection::getMinerStat1()
 
 	Json::Value jRes;
 
-	jRes[0] = std::string("ethminer-") + ethminer_get_buildinfo()->project_version;  //miner version.
+	jRes[0] = ethminer_get_buildinfo()->project_name_with_version;  //miner version.
 	jRes[1] = toString(runningTime.count()); // running time, in minutes.
 	jRes[2] = totalMhEth.str();              // total ETH hashrate in MH/s, number of ETH shares, number of ETH rejected shares.
 	jRes[3] = detailedMhEth.str();           // detailed ETH hashrate for all GPUs.
@@ -782,7 +782,7 @@ Json::Value ApiConnection::getMinerStatHR()
 	Json::Value ispaused;
 	ostringstream poolAddresses;
 
-	version << "ethminer-" << ethminer_get_buildinfo()->project_version;
+	version << ethminer_get_buildinfo()->project_name_with_version;
 	runtime << toString(runningTime.count());
 	poolAddresses << m_farm.get_pool_addresses(); 
 

--- a/libapicore/httpServer.cpp
+++ b/libapicore/httpServer.cpp
@@ -22,7 +22,6 @@ httpServer http_server;
 
 void httpServer::tableHeader(stringstream& ss, unsigned columns)
 {
-    auto version = std::string("ethminer-") + ethminer_get_buildinfo()->project_version;
     char hostName[HOST_NAME_MAX + 1];
     gethostname(hostName, HOST_NAME_MAX + 1);
     string l = m_farm->farmLaunchedFormatted();
@@ -30,7 +29,8 @@ void httpServer::tableHeader(stringstream& ss, unsigned columns)
        "<html><head><title>" << hostName <<
        "</title><style>tr:nth-child(even){background-color:Gainsboro;}</style>"
        "<meta http-equiv=refresh content=30></head><body><table width=\"50%\" border=1 cellpadding=2 cellspacing=0 align=center>"
-       "<tr valign=top align=center style=background-color:Gold><th colspan=" << columns << ">" << version <<
+       "<tr valign=top align=center style=background-color:Gold><th colspan=" << columns << ">" <<
+       ethminer_get_buildinfo()->project_name_with_version <<
        " on " << hostName << " - " << l << "</th></tr>";
 }
 

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -550,8 +550,7 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec)
 			case 999:
 			case 2:
 				m_conn->SetStratumMode(2, false);
-				jReq["params"].append(
-					"ethminer-" + std::string(ethminer_get_buildinfo()->project_version));
+				jReq["params"].append(ethminer_get_buildinfo()->project_name_with_version);
 				jReq["params"].append("EthereumStratum/1.0.0");
 				break;
 
@@ -583,8 +582,7 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec)
 
             case EthStratumClient::ETHEREUMSTRATUM:
 
-                jReq["params"].append(
-                    "ethminer-" + std::string(ethminer_get_buildinfo()->project_version));
+                jReq["params"].append(ethminer_get_buildinfo()->project_name_with_version);
                 jReq["params"].append("EthereumStratum/1.0.0");
 
                 break;
@@ -1190,7 +1188,7 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
 		else if (_method == "client.get_version")
 		{
             jReq["id"] = toString(_id);
-            jReq["result"] = std::string("ethminer-") + ethminer_get_buildinfo()->project_version;
+            jReq["result"] = ethminer_get_buildinfo()->project_name_with_version;
 
             if (_rpcVer == 1)
             {

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -551,7 +551,7 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec)
 			case 2:
 				m_conn->SetStratumMode(2, false);
 				jReq["params"].append(
-					"ethminer " + std::string(ethminer_get_buildinfo()->project_version));
+					"ethminer-" + std::string(ethminer_get_buildinfo()->project_version));
 				jReq["params"].append("EthereumStratum/1.0.0");
 				break;
 
@@ -584,7 +584,7 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec)
             case EthStratumClient::ETHEREUMSTRATUM:
 
                 jReq["params"].append(
-                    "ethminer " + std::string(ethminer_get_buildinfo()->project_version));
+                    "ethminer-" + std::string(ethminer_get_buildinfo()->project_version));
                 jReq["params"].append("EthereumStratum/1.0.0");
 
                 break;
@@ -1190,7 +1190,7 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
 		else if (_method == "client.get_version")
 		{
             jReq["id"] = toString(_id);
-            jReq["result"] = ethminer_get_buildinfo()->project_version;
+            jReq["result"] = std::string("ethminer-") + ethminer_get_buildinfo()->project_version;
 
             if (_rpcVer == 1)
             {


### PR DESCRIPTION
Use "ethminer-" instead "ethminer " as version prefix within stratum communication.

@AndreaLanfranchi : Request a review
@chfast : Could we get a function in the ethminer_get_buildinfo()->xxx to get a full qualified name/version info ? (We're currently using the "version" in stratum, api and html and always have to prefix "ethminer-")