### PR TITLE
Fix CUDA driver version check.

### DIFF
--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -652,13 +652,22 @@ public:
 		if (m_minerType == MinerType::CUDA || m_minerType == MinerType::Mixed)
 		{
 #if ETH_ETHASHCUDA
-			if (m_cudaDeviceCount > 0)
+			try
 			{
-				CUDAMiner::setDevices(m_cudaDevices, m_cudaDeviceCount);
-				m_miningThreads = m_cudaDeviceCount;
+				if (m_cudaDeviceCount > 0)
+				{
+					CUDAMiner::setDevices(m_cudaDevices, m_cudaDeviceCount);
+					m_miningThreads = m_cudaDeviceCount;
+				}
+				CUDAMiner::setNumInstances(m_miningThreads);
+			}
+			catch(std::runtime_error const& err)
+			{
+				cwarn << "CUDA error: " << err.what();
+				stop_io_service();
+				exit(1);
 			}
 
-			CUDAMiner::setNumInstances(m_miningThreads);
 			if (!CUDAMiner::configureGPU(
 				m_cudaBlockSize,
 				m_cudaGridSize,

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -173,7 +173,7 @@ unsigned CUDAMiner::getNumDevices()
 
     if (err == cudaErrorInsufficientDriver)
     {
-        int driverVersion;
+        int driverVersion = 0;
         cudaDriverGetVersion(&driverVersion);
         if (driverVersion == 0)
             throw std::runtime_error{"No CUDA driver found"};


### PR DESCRIPTION
When accessing CUDAMiner, CUDAMiner::getNumDevices() is
called which can cause an exception.
Catch the exception, display the error message and exit.

Found this problem while searching solution for ISSUE #1378 - maybe this solves the problem.
