### PR TITLE
Various small fixes and improvements

### DIFF
--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -115,8 +115,9 @@ PoolManager::PoolManager(boost::asio::io_service& io_service, PoolClient* client
 		std::stringstream ss;
 		ss << std::setw(4) << std::setfill(' ') << ms.count()
 			<< " ms." << " " << m_connections[m_activeConnectionIdx].Host() + p_client->ActiveEndPoint();
-		cnote << EthLime "**Accepted" EthReset << (stale ? "(stale)" : "") << ss.str();
-		m_farm.acceptedSolution(stale);
+        cnote << EthLime "**Accepted" EthReset << (stale ? EthYellow "(stale)" EthReset : "")
+              << ss.str();
+        m_farm.acceptedSolution(stale);
 	});
 
 	p_client->onSolutionRejected([&](bool const& stale)
@@ -133,8 +134,9 @@ PoolManager::PoolManager(boost::asio::io_service& io_service, PoolClient* client
 		std::stringstream ss;
 		ss << std::setw(4) << std::setfill(' ') << ms.count()
 			<< "ms." << "   " << m_connections[m_activeConnectionIdx].Host() + p_client->ActiveEndPoint();
-		cwarn << EthRed "**Rejected" EthReset << (stale ? "(stale)" : "") << ss.str();
-		m_farm.rejectedSolution();
+        cwarn << EthRed "**Rejected" EthReset << (stale ? EthYellow "(stale)" EthReset : "")
+              << ss.str();
+        m_farm.rejectedSolution();
 	});
 
 	m_farm.onSolutionFound([&](const Solution& sol)


### PR DESCRIPTION
- No need to retrieve abort flag, just read solution and hash counts.
- Move switch time log to best location.
- Remove some comented out debug statements
- Kernel aborts on finding solution, chance of detecting a stale here
  is near zero. Don't bother trying.
- Accentuate stale log message
- Fix Windows version of path name.