### PR TITLE
Consistent behavior of -P exit

### DIFF
--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -215,7 +215,7 @@ public:
 		app.add_option("--farm-retries", m_maxFarmRetries,
 			"Set number of reconnection retries", true)
 			->group(CommonGroup)
-			->check(CLI::Range(1, 99999));
+			->check(CLI::Range(0, 99999));
 
 		app.add_option("--stratum-email", m_email,
 			"Set email address for eth-proxy")

--- a/libpoolprotocols/PoolClient.h
+++ b/libpoolprotocols/PoolClient.h
@@ -19,11 +19,16 @@ namespace dev
 			virtual ~PoolClient() noexcept = default;
 
 
-			void setConnection(URI &conn)
+			void setConnection(URI *conn)
 			{
-				m_conn = &conn;
+				m_conn = conn;
 				m_canconnect.store(false, std::memory_order_relaxed);
 			}
+
+            void unsetConnection()
+            { 
+                m_conn = nullptr;
+            }
 
 			virtual void connect() = 0;
 			virtual void disconnect() = 0;

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -932,7 +932,8 @@ void EthStratumClient::processReponse(Json::Value& responseObject)
 
 			if (!m_authorized)
 			{
-				cnote << "Worker not authorized" << m_conn->User() << _errReason;
+				cnote << "Worker not authorized " << m_conn->User() << _errReason;
+                m_conn->MarkUnrecoverable();
                 m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
 				return;
 			


### PR DESCRIPTION
* --farm-retries allows 0
* PoolClient receives a pointer to URI instead of a reference
* PoolClient method unsetConnection releases the pointer
* PoolManager gets rid of Unrecoverable connections with a copy of vector (could not make vector.erase to function)
* EthStratumClient now marks as unrecoverable connections where mining.authorize is not succesful

Amends #1405