### PR TITLE
Make sure old opencl context is deleted before allocating new.

### DIFF
--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -77,7 +77,7 @@ private:
 
 	bool init(int epoch);
 
-	cl::Context m_context;
+    vector<cl::Context> m_context;
     vector<cl::CommandQueue> m_queue;
     vector<cl::CommandQueue> m_abortqueue;
     cl::Kernel m_searchKernel;


### PR DESCRIPTION
- ethminer leaks context with each new epoch