### PR TITLE
Stratum auto-detection extensive logic review

### DIFF
--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -54,7 +54,7 @@ PoolManager::PoolManager(boost::asio::io_service& io_service, PoolClient* client
 	p_client->onDisconnected([&]()
 	{
 		dev::setThreadName("main");
-        cnote << "Disconnected from " << m_connections.at(m_activeConnectionIdx).Host();
+        cnote << "Disconnected from " + m_activeConnectionHost << p_client->ActiveEndPoint();
 
 		// Clear queue of submission times as we won't get any further response for them (if any left)
 		// We need to consume all elements as no clear mehod is provided.

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -19,264 +19,280 @@ static uint64_t bswap(uint64_t val)
 }
 
 
-static void diffToTarget(uint32_t *target, double diff)
+static void diffToTarget(uint32_t* target, double diff)
 {
-	uint32_t target2[8];
-	uint64_t m;
-	int k;
+    uint32_t target2[8];
+    uint64_t m;
+    int k;
 
-	for (k = 6; k > 0 && diff > 1.0; k--)
-		diff /= 4294967296.0;
-	m = (uint64_t)(4294901760.0 / diff);
-	if (m == 0 && k == 6)
-		memset(target2, 0xff, 32);
-	else {
-		memset(target2, 0, 32);
-		target2[k] = (uint32_t)m;
-		target2[k + 1] = (uint32_t)(m >> 32);
-	}
+    for (k = 6; k > 0 && diff > 1.0; k--)
+        diff /= 4294967296.0;
+    m = (uint64_t)(4294901760.0 / diff);
+    if (m == 0 && k == 6)
+        memset(target2, 0xff, 32);
+    else
+    {
+        memset(target2, 0, 32);
+        target2[k] = (uint32_t)m;
+        target2[k + 1] = (uint32_t)(m >> 32);
+    }
 
-	for (int i = 0; i < 32; i++)
-		((uint8_t*)target)[31 - i] = ((uint8_t*)target2)[i];
+    for (int i = 0; i < 32; i++)
+        ((uint8_t*)target)[31 - i] = ((uint8_t*)target2)[i];
 }
 
 
-EthStratumClient::EthStratumClient(boost::asio::io_service & io_service, int worktimeout, int responsetimeout, const string& email, bool submitHashrate) : PoolClient(),
-	m_worktimeout(worktimeout),
-	m_responsetimeout(responsetimeout),
-	m_io_service(io_service),
-	m_io_strand(io_service),
-	m_socket(nullptr),
-	m_conntimer(io_service),
-	m_worktimer(io_service),
-	m_responsetimer(io_service),
-	m_resolver(io_service),
-	m_endpoints(),
-	m_email(email),
-	m_submit_hashrate(submitHashrate)
+EthStratumClient::EthStratumClient(boost::asio::io_service& io_service, int worktimeout,
+    int responsetimeout, const string& email, bool submitHashrate)
+  : PoolClient(),
+    m_worktimeout(worktimeout),
+    m_responsetimeout(responsetimeout),
+    m_io_service(io_service),
+    m_io_strand(io_service),
+    m_socket(nullptr),
+    m_conntimer(io_service),
+    m_worktimer(io_service),
+    m_responsetimer(io_service),
+    m_resolver(io_service),
+    m_endpoints(),
+    m_email(email),
+    m_submit_hashrate(submitHashrate)
 {
-
-	if (m_submit_hashrate)
-		m_submit_hashrate_id = h256::random().hex();
-
+    if (m_submit_hashrate)
+        m_submit_hashrate_id = h256::random().hex();
 }
 
 EthStratumClient::~EthStratumClient()
 {
-	// Do not stop io service.
-	// It's global
+    // Do not stop io service.
+    // It's global
+}
+
+void EthStratumClient::init_socket() 
+{
+
+    // Prepare Socket
+    if (m_conn->SecLevel() != SecureLevel::NONE)
+    {
+        boost::asio::ssl::context::method method = boost::asio::ssl::context::tls_client;
+        if (m_conn->SecLevel() == SecureLevel::TLS12)
+            method = boost::asio::ssl::context::tlsv12;
+
+        boost::asio::ssl::context ctx(method);
+        m_securesocket = std::make_shared<boost::asio::ssl::stream<boost::asio::ip::tcp::socket>>(
+            m_io_service, ctx);
+        m_socket = &m_securesocket->next_layer();
+
+
+        m_securesocket->set_verify_mode(boost::asio::ssl::verify_peer);
+
+#ifdef _WIN32
+        HCERTSTORE hStore = CertOpenSystemStore(0, "ROOT");
+        if (hStore == nullptr)
+        {
+            return;
+        }
+
+        X509_STORE* store = X509_STORE_new();
+        PCCERT_CONTEXT pContext = nullptr;
+        while ((pContext = CertEnumCertificatesInStore(hStore, pContext)) != nullptr)
+        {
+            X509* x509 = d2i_X509(
+                nullptr, (const unsigned char**)&pContext->pbCertEncoded, pContext->cbCertEncoded);
+            if (x509 != nullptr)
+            {
+                X509_STORE_add_cert(store, x509);
+                X509_free(x509);
+            }
+        }
+
+        CertFreeCertificateContext(pContext);
+        CertCloseStore(hStore, 0);
+
+        SSL_CTX_set_cert_store(ctx.native_handle(), store);
+#else
+        char* certPath = getenv("SSL_CERT_FILE");
+        try
+        {
+            ctx.load_verify_file(certPath ? certPath : "/etc/ssl/certs/ca-certificates.crt");
+        }
+        catch (...)
+        {
+            cwarn << "Failed to load ca certificates. Either the file "
+                     "'/etc/ssl/certs/ca-certificates.crt' does not exist";
+            cwarn << "or the environment variable SSL_CERT_FILE is set to an invalid or "
+                     "inaccessible file.";
+            cwarn << "It is possible that certificate verification can fail.";
+        }
+#endif
+    }
+    else
+    {
+        m_nonsecuresocket = std::make_shared<boost::asio::ip::tcp::socket>(m_io_service);
+        m_socket = m_nonsecuresocket.get();
+    }
+
+    // Activate keep alive to detect disconnects
+    unsigned int keepAlive = 10000;
+
+#if defined(_WIN32)
+    int32_t timeout = keepAlive;
+    setsockopt(
+        m_socket->native_handle(), SOL_SOCKET, SO_RCVTIMEO, (const char*)&timeout, sizeof(timeout));
+    setsockopt(
+        m_socket->native_handle(), SOL_SOCKET, SO_SNDTIMEO, (const char*)&timeout, sizeof(timeout));
+#else
+    struct timeval tv;
+    tv.tv_sec = keepAlive / 1000;
+    tv.tv_usec = keepAlive % 1000;
+    setsockopt(m_socket->native_handle(), SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    setsockopt(m_socket->native_handle(), SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+#endif
+
 }
 
 void EthStratumClient::connect()
 {
-
-	// Prevent unnecessary and potentially dangerous recursion
-	if (m_connecting.load(std::memory_order::memory_order_relaxed)) {
-		return;
-	}
-	else {
-		m_connecting.store(true, std::memory_order::memory_order_relaxed);
-	}
-
-	m_connected.store(false, std::memory_order_relaxed);
-	m_subscribed.store(false, std::memory_order_relaxed);
-	m_authorized.store(false, std::memory_order_relaxed);
+    // Prevent unnecessary and potentially dangerous recursion
+    if (m_connecting.load(std::memory_order::memory_order_relaxed))
+        return;
     
-	// Prepare Socket
-	if (m_conn->SecLevel() != SecureLevel::NONE) {
+    m_canconnect.store(false, std::memory_order_relaxed);
+    m_connected.store(false, std::memory_order_relaxed);
+    m_subscribed.store(false, std::memory_order_relaxed);
+    m_authorized.store(false, std::memory_order_relaxed);
+    m_authpending.store(false, std::memory_order_relaxed);
 
-		boost::asio::ssl::context::method method = boost::asio::ssl::context::tls_client;
-		if (m_conn->SecLevel() == SecureLevel::TLS12)
-			method = boost::asio::ssl::context::tlsv12;
+    // Initializes socket and eventually secure stream
+    if(!m_socket)
+        init_socket();
 
-		boost::asio::ssl::context ctx(method);
-		m_securesocket = std::make_shared<boost::asio::ssl::stream<boost::asio::ip::tcp::socket> >(m_io_service, ctx);
-		m_socket = &m_securesocket->next_layer();
-		
+    // Begin resolve all ips associated to hostname
+    // empty queue from any previous listed ip
+    // calling the resolver each time is useful as most
+    // load balancer will give Ips in different order
+    m_endpoints = std::queue<boost::asio::ip::basic_endpoint<boost::asio::ip::tcp>>();
+    m_endpoint = boost::asio::ip::basic_endpoint<boost::asio::ip::tcp>();
+    m_resolver = tcp::resolver(m_io_service);
+    tcp::resolver::query q(m_conn->Host(), toString(m_conn->Port()));
 
-		m_securesocket->set_verify_mode(boost::asio::ssl::verify_peer);
-
-#ifdef _WIN32
-		HCERTSTORE hStore = CertOpenSystemStore(0, "ROOT");
-		if (hStore == nullptr) {
-			return;
-		}
-
-		X509_STORE *store = X509_STORE_new();
-		PCCERT_CONTEXT pContext = nullptr;
-		while ((pContext = CertEnumCertificatesInStore(hStore, pContext)) != nullptr) {
-			X509 *x509 = d2i_X509(nullptr,
-				(const unsigned char **)&pContext->pbCertEncoded,
-				pContext->cbCertEncoded);
-			if (x509 != nullptr) {
-				X509_STORE_add_cert(store, x509);
-				X509_free(x509);
-			}
-		}
-
-		CertFreeCertificateContext(pContext);
-		CertCloseStore(hStore, 0);
-
-		SSL_CTX_set_cert_store(ctx.native_handle(), store);
-#else
-		char *certPath = getenv("SSL_CERT_FILE");
-		try {
-			ctx.load_verify_file(certPath ? certPath : "/etc/ssl/certs/ca-certificates.crt");
-		}
-		catch (...) {
-			cwarn << "Failed to load ca certificates. Either the file '/etc/ssl/certs/ca-certificates.crt' does not exist";
-			cwarn << "or the environment variable SSL_CERT_FILE is set to an invalid or inaccessible file.";
-			cwarn << "It is possible that certificate verification can fail.";
-		}
-#endif
-	}
-	else {
-	  m_nonsecuresocket = std::make_shared<boost::asio::ip::tcp::socket>(m_io_service);
-	  m_socket = m_nonsecuresocket.get();
-	}
-
-	// Activate keep alive to detect disconnects
-	unsigned int keepAlive = 10000;
-
-#if defined(_WIN32)
-	int32_t timeout = keepAlive;
-	setsockopt(m_socket->native_handle(), SOL_SOCKET, SO_RCVTIMEO, (const char*)&timeout, sizeof(timeout));
-	setsockopt(m_socket->native_handle(), SOL_SOCKET, SO_SNDTIMEO, (const char*)&timeout, sizeof(timeout));
-#else
-	struct timeval tv;
-	tv.tv_sec = keepAlive / 1000;
-	tv.tv_usec = keepAlive % 1000;
-	setsockopt(m_socket->native_handle(), SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-	setsockopt(m_socket->native_handle(), SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
-#endif
-
-	// Begin resolve all ips associated to hostname
-	// empty queue from any previous listed ip
-	// calling the resolver each time is useful as most
-	// load balancer will give Ips in different order
-	m_endpoints = std::queue<boost::asio::ip::basic_endpoint<boost::asio::ip::tcp>>();
-	m_endpoint = boost::asio::ip::basic_endpoint<boost::asio::ip::tcp>();
-	m_resolver = tcp::resolver(m_io_service);
-	tcp::resolver::query q(m_conn->Host(), toString(m_conn->Port()));
-	m_resolver.async_resolve(q,
-		m_io_strand.wrap(boost::bind(&EthStratumClient::resolve_handler, this, boost::asio::placeholders::error, boost::asio::placeholders::iterator)));
-	
+    // Start resolving async
+    m_resolver.async_resolve(
+        q, m_io_strand.wrap(boost::bind(&EthStratumClient::resolve_handler, this,
+               boost::asio::placeholders::error, boost::asio::placeholders::iterator)));
 }
 
 void EthStratumClient::disconnect()
 {
-	// Prevent unnecessary recursion
-	if (m_disconnecting.load(std::memory_order::memory_order_relaxed)) {
-		return;
-	}
-	else {
-		m_disconnecting.store(true, std::memory_order::memory_order_relaxed);
-	}
+    // Prevent unnecessary recursion
+    if (!m_connected.load(std::memory_order_relaxed) || m_disconnecting.load(std::memory_order_relaxed))
+        return;
+    m_disconnecting.store(true, std::memory_order_relaxed);
+        
+    // Cancel any outstanding async operation
+    if (m_socket)
+        m_socket->cancel();
 
-	// Cancel any outstanding async operation
-	if (m_socket)
-		m_socket->cancel();
+    m_io_service.post([&] {
+        m_conntimer.cancel();
+        m_worktimer.cancel();
+        m_responsetimer.cancel();
+    });
 
-	m_io_service.post([&] {
-		m_conntimer.cancel();
-		m_worktimer.cancel();
-		m_responsetimer.cancel();
-	});
+    m_response_pending = false;
 
-	m_response_pending = false;
+    if (m_socket && m_socket->is_open())
+    {
+        try
+        {
+            boost::system::error_code sec;
 
-	if (m_socket && m_socket->is_open()) { 
+            if (m_conn->SecLevel() != SecureLevel::NONE)
+            {
+                // This will initiate the exchange of "close_notify" message among parties.
+                // If both client and server are connected then we expect the handler with success
+                // As there may be a connection issue we also endorse a timeout
+                m_securesocket->async_shutdown(
+                    m_io_strand.wrap(boost::bind(&EthStratumClient::onSSLShutdownCompleted, this,
+                        boost::asio::placeholders::error)));
 
-		try {
-		
-			boost::system::error_code sec;
-
-			if (m_conn->SecLevel() != SecureLevel::NONE) {
-
-				// This will initiate the exchange of "close_notify" message among parties.
-				// If both client and server are connected then we expect the handler with success
-				// As there may be a connection issue we also endorse a timeout
-				m_securesocket->async_shutdown(m_io_strand.wrap(boost::bind(&EthStratumClient::onSSLShutdownCompleted, this, boost::asio::placeholders::error)));
-
-				m_conntimer.expires_from_now(boost::posix_time::seconds(m_responsetimeout));
-				m_conntimer.async_wait(boost::bind(&EthStratumClient::check_connect_timeout, this, boost::asio::placeholders::error));
-
-
-				// Rest of disconnection is performed asynchronously
-				return;
-			}
-			else {
-
-				m_nonsecuresocket->shutdown(boost::asio::ip::tcp::socket::shutdown_both, sec);
-				m_socket->close();
-			}
+                m_conntimer.cancel();
+                m_conntimer.expires_from_now(boost::posix_time::seconds(m_responsetimeout));
+                m_conntimer.async_wait(boost::bind(&EthStratumClient::check_connect_timeout, this,
+                    boost::asio::placeholders::error));
 
 
-		}
-		catch (std::exception const& _e) {
-			cwarn << "Error while disconnecting:" << _e.what();
-		}
+                // Rest of disconnection is performed asynchronously
+                return;
+            }
+            else
+            {
+                m_nonsecuresocket->shutdown(boost::asio::ip::tcp::socket::shutdown_both, sec);
+                m_socket->close();
+            }
+        }
+        catch (std::exception const& _e)
+        {
+            cwarn << "Error while disconnecting:" << _e.what();
+        }
+        
+    }
 
-		disconnect_finalize();
-
-	}
-
-
-
+    disconnect_finalize();
 }
 
-void EthStratumClient::disconnect_finalize() {
-
-	if (m_conn->SecLevel() != SecureLevel::NONE) {
-
-		if (m_securesocket->lowest_layer().is_open()) {
-
-			// Manage error code if layer is already shut down
-			boost::system::error_code ec;
-			m_securesocket->lowest_layer().shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
-			m_securesocket->lowest_layer().close();
-
-		}
-		m_securesocket = nullptr;
-		m_socket = nullptr;
-		
-	}
-	else {
-
-		m_socket = nullptr;
-		m_nonsecuresocket = nullptr;
-
-	}
-
-	m_subscribed.store(false, std::memory_order_relaxed);
-	m_authorized.store(false, std::memory_order_relaxed);
-
-	// Release locking flag and set connection status
-	m_connected.store(false, std::memory_order_relaxed);
-	m_disconnecting.store(false, std::memory_order::memory_order_relaxed);
-
-
-    // If we got disconnected during autodetection phase
-    // reissue a connect lowering stratum mode checks
-    // m_canconnect flag is used to prevent never-ending loop when
-    // remote endpoint rejects connections attempts persistently since the first
-    if (!m_conn->StratumModeConfirmed() && m_canconnect.load(std::memory_order_relaxed))
+void EthStratumClient::disconnect_finalize()
+{
+    if (m_conn->SecLevel() != SecureLevel::NONE)
     {
-
-        // Repost a new connection attempt and advance to next stratum test
-        if (m_conn->StratumMode() > 0)
+        if (m_securesocket->lowest_layer().is_open())
         {
-            m_conn->SetStratumMode(m_conn->StratumMode() - 1);
-            m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::connect, this)));
-            return;
+            // Manage error code if layer is already shut down
+            boost::system::error_code ec;
+            m_securesocket->lowest_layer().shutdown(
+                boost::asio::ip::tcp::socket::shutdown_both, ec);
+            m_securesocket->lowest_layer().close();
         }
-        else
-        {
-            // There are no more stratum modes to test
-            // Mark connection as unrecoverable and trash it
-            m_conn->MarkUnrecoverable();
-        }
+        m_securesocket = nullptr;
+        m_socket = nullptr;
+    }
+    else
+    {
+        m_socket = nullptr;
+        m_nonsecuresocket = nullptr;
+    }
 
+    // Release locking flag and set connection status
+    if (g_logVerbosity >= 6)
+        cnote << "Socket disconnected from " << ActiveEndPoint();
+    m_connected.store(false, std::memory_order_relaxed);
+    m_subscribed.store(false, std::memory_order_relaxed);
+    m_authorized.store(false, std::memory_order_relaxed);
+    m_authpending.store(false, std::memory_order_relaxed);
+    m_disconnecting.store(false, std::memory_order_relaxed);
+
+    if (!m_conn->IsUnrecoverable())
+    {
+        // If we got disconnected during autodetection phase
+        // reissue a connect lowering stratum mode checks
+        // m_canconnect flag is used to prevent never-ending loop when
+        // remote endpoint rejects connections attempts persistently since the first
+        if (!m_conn->StratumModeConfirmed() && m_canconnect.load(std::memory_order_relaxed))
+        {
+            // Repost a new connection attempt and advance to next stratum test
+            if (m_conn->StratumMode() > 0)
+            {
+                m_conn->SetStratumMode(m_conn->StratumMode() - 1);
+                m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::start_connect, this)));
+                return;
+            }
+            else
+            {
+                // There are no more stratum modes to test
+                // Mark connection as unrecoverable and trash it
+                m_conn->MarkUnrecoverable();
+            }
+        }
     }
 
     // Trigger handlers
@@ -286,764 +302,755 @@ void EthStratumClient::disconnect_finalize() {
     }
 }
 
-void EthStratumClient::resolve_handler(const boost::system::error_code& ec, tcp::resolver::iterator i)
-{	
-	if (!ec)
-	{
-		dev::setThreadName("stratum");
+void EthStratumClient::resolve_handler(
+    const boost::system::error_code& ec, tcp::resolver::iterator i)
+{
+    if (!ec)
+    {
+        dev::setThreadName("stratum");
 
-		while (i != tcp::resolver::iterator())
-		{
-			m_endpoints.push(i->endpoint());
-			i++;
-		}
-		m_resolver.cancel();
+        while (i != tcp::resolver::iterator())
+        {
+            m_endpoints.push(i->endpoint());
+            i++;
+        }
+        m_resolver.cancel();
 
-		// Resolver has finished so invoke connection asynchronously
-		m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::start_connect, this)));
-		
+        // Resolver has finished so invoke connection asynchronously
+        m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::start_connect, this)));
+    }
+    else
+    {
+        dev::setThreadName("stratum");
+        cwarn << "Could not resolve host " << m_conn->Host() << ", " << ec.message();
 
-	}
-	else
-	{
-		dev::setThreadName("stratum");
-		cwarn << "Could not resolve host " << m_conn->Host() << ", " << ec.message();
+        // Release locking flag and set connection status
+        m_connected.store(false, std::memory_order_relaxed);
+        m_connecting.store(false, std::memory_order::memory_order_relaxed);
 
-		// Release locking flag and set connection status
-		m_connected.store(false, std::memory_order_relaxed);
-		m_connecting.store(false, std::memory_order::memory_order_relaxed);
-
-		// Trigger handlers
-		if (m_onDisconnected) { m_onDisconnected(); }
-
-	}
+        // Trigger handlers
+        if (m_onDisconnected)
+        {
+            m_onDisconnected();
+        }
+    }
 }
 
 void EthStratumClient::reset_work_timeout()
 {
-	m_worktimer.cancel();
-	m_worktimer.expires_from_now(boost::posix_time::seconds(m_worktimeout));
-	m_worktimer.async_wait(m_io_strand.wrap(boost::bind(&EthStratumClient::work_timeout_handler, this, boost::asio::placeholders::error)));
-
+    m_worktimer.cancel();
+    m_worktimer.expires_from_now(boost::posix_time::seconds(m_worktimeout));
+    m_worktimer.async_wait(m_io_strand.wrap(boost::bind(
+        &EthStratumClient::work_timeout_handler, this, boost::asio::placeholders::error)));
 }
 
 void EthStratumClient::start_connect()
 {
-	if (!m_endpoints.empty()) {
-		
+    if (m_connecting.load(std::memory_order_relaxed))
+        return;
+    m_connecting.store(true, std::memory_order::memory_order_relaxed);
+
+    if (!m_endpoints.empty())
+    {
         // Pick the first endpoint in list.
         // Eventually endpoints get discarded on connection errors
         m_endpoint = m_endpoints.front();
 
-        // Reset status stratum mode autodetection if canconnect is set to false
-        if (!m_canconnect.load(std::memory_order_relaxed))
-        {
-            m_conn->SetStratumMode(999, false);
-        }
+        // Re-init socket if we need to
+        if (m_socket == nullptr)
+            init_socket();
 
         dev::setThreadName("stratum");
-        cnote << ("Trying " + toString(m_endpoint) + " ...");
 
-		m_conntimer.expires_from_now(boost::posix_time::seconds(m_responsetimeout));
-		m_conntimer.async_wait(m_io_strand.wrap(boost::bind(&EthStratumClient::check_connect_timeout, this, boost::asio::placeholders::error)));
-		
-		// Start connecting async
-		if (m_conn->SecLevel() != SecureLevel::NONE) {
-			m_securesocket->lowest_layer().async_connect(m_endpoint, m_io_strand.wrap(boost::bind(&EthStratumClient::connect_handler, this, _1)));
-		}
-		else {
-			m_socket->async_connect(m_endpoint,
-				m_io_strand.wrap(boost::bind(&EthStratumClient::connect_handler, this, _1)));
-		}
+        if (g_logVerbosity >=6)
+            cnote << ("Trying " + toString(m_endpoint) + " ...");
 
+        m_connecting.store(true, std::memory_order::memory_order_relaxed);
+        m_conntimer.cancel();
+        m_conntimer.expires_from_now(boost::posix_time::seconds(m_responsetimeout));
+        m_conntimer.async_wait(m_io_strand.wrap(boost::bind(
+            &EthStratumClient::check_connect_timeout, this, boost::asio::placeholders::error)));
 
-	}
-	else {
-		
+        // Start connecting async
+        if (m_conn->SecLevel() != SecureLevel::NONE)
+        {
+            m_securesocket->lowest_layer().async_connect(m_endpoint,
+                m_io_strand.wrap(boost::bind(&EthStratumClient::connect_handler, this, _1)));
+        }
+        else
+        {
+            m_socket->async_connect(m_endpoint,
+                m_io_strand.wrap(boost::bind(&EthStratumClient::connect_handler, this, _1)));
+        }
+    }
+    else
+    {
+        dev::setThreadName("stratum");
+        m_connecting.store(false, std::memory_order_relaxed);
+        cwarn << "No more IP addresses to try for host: " << m_conn->Host();
 
-		dev::setThreadName("stratum");
-		m_connecting.store(false, std::memory_order_relaxed);
-		cwarn << "No more IP addresses to try for host: " << m_conn->Host();
-
-		// Trigger handlers
-		if (m_onDisconnected) { m_onDisconnected(); }
-
-	}
-
-
+        // Trigger handlers
+        if (m_onDisconnected)
+        {
+            m_onDisconnected();
+        }
+    }
 }
 
 void EthStratumClient::check_connect_timeout(const boost::system::error_code& ec)
 {
-	(void)ec;
+    // Timer cancelled
+    if (ec == boost::asio::error::operation_aborted)
+        return;
 
-	// Check whether the deadline has passed. We compare the deadline against
-	// the current time since a new asynchronous operation may have moved the
-	// deadline before this actor had a chance to run.
+    // Check whether the deadline has passed. We compare the deadline against
+    // the current time since a new asynchronous operation may have moved the
+    // deadline before this actor had a chance to run.
 
-	if (isPendingState()) {
+    if (isPendingState())
+    {
+        if (m_conntimer.expires_at() <= boost::asio::deadline_timer::traits_type::now())
+        {
+            // The deadline has passed.
 
-		if (m_conntimer.expires_at() <= boost::asio::deadline_timer::traits_type::now())
-		{
-			// The deadline has passed. 
+            if (m_connecting.load(std::memory_order_relaxed))
+            {
+                // The socket is closed so that any outstanding
+                // asynchronous connection operations are cancelled.
+                m_socket->close();
+            }
 
-			if (m_connecting.load(std::memory_order_relaxed)) {
+            // This is set for SSL disconnection
+            if (m_disconnecting.load(std::memory_order_relaxed) &&
+                (m_conn->SecLevel() != SecureLevel::NONE))
+            {
+                if (m_securesocket->lowest_layer().is_open())
+                {
+                    m_securesocket->lowest_layer().close();
+                }
+            }
 
-				// The socket is closed so that any outstanding
-				// asynchronous connection operations are cancelled.
-				m_socket->close();
-
-			}
-
-			// This is set for SSL disconnection
-			if (m_disconnecting.load(std::memory_order_relaxed) && (m_conn->SecLevel() != SecureLevel::NONE)) {
-				if (m_securesocket->lowest_layer().is_open()) {
-					m_securesocket->lowest_layer().close();
-				}
-			}
-
-			// There is no longer an active deadline. The expiry is set to positive
-			// infinity so that the actor takes no action until a new deadline is set.
-			m_conntimer.expires_at(boost::posix_time::pos_infin);
-		}
-		// Put the actor back to sleep.
-		m_conntimer.async_wait(m_io_strand.wrap(boost::bind(&EthStratumClient::check_connect_timeout, this, boost::asio::placeholders::error)));
-	}
-
+            // There is no longer an active deadline. The expiry is set to positive
+            // infinity so that the actor takes no action until a new deadline is set.
+            m_conntimer.expires_at(boost::posix_time::pos_infin);
+        }
+        // Put the actor back to sleep.
+        m_conntimer.async_wait(m_io_strand.wrap(boost::bind(
+            &EthStratumClient::check_connect_timeout, this, boost::asio::placeholders::error)));
+    }
 }
 
 
 void EthStratumClient::connect_handler(const boost::system::error_code& ec)
 {
-	
-	dev::setThreadName("stratum");
+    dev::setThreadName("stratum");
 
-	// Timeout has run before
-	if (!m_socket->is_open()) {
+    // Set status completion
+    m_conntimer.cancel();
+    m_connecting.store(false, std::memory_order_relaxed);
 
-		cwarn << ("Error  " + toString(m_endpoint) + " [Timeout]");
+    // Timeout has run before or we got error
+    if (ec || !m_socket->is_open())
+    {
+        cwarn << ("Error  " + toString(m_endpoint) + " [ " + ( ec ? ec.message() : "Timeout") + " ]");
 
-		// Try the next available endpoint.
-        m_canconnect.store(false, std::memory_order_relaxed);
+        // We need to close the socket used in the previous connection attempt
+        // before starting a new one.
+        // In case of error, in fact, boost does not close the socket
+        // If socket is not opened it means we got timed out
+        if (m_socket->is_open())
+            m_socket->close();
+
+        // Discard this endpoint and try the next available.
+        // Eventually is start_connect which will check for an
+        // empty list.
         m_endpoints.pop();
-		m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::start_connect, this)));
-
-	} else if (ec) {
-
-		cwarn << ("Error  " + toString(m_endpoint) + " [" + ec.message() + "]");
-		
-		// We need to close the socket used in the previous connection attempt
-		// before starting a new one.
-		// In case of error, in fact, boost does not close the socket
-		m_socket->close();
-
-		// Try the next available endpoint.
         m_canconnect.store(false, std::memory_order_relaxed);
-        m_endpoints.pop();
-		m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::start_connect, this)));
+        m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::start_connect, this)));
 
-	}
-	else {
+        return;
+    }
 
-		// Immediately set connecting flag to prevent 
-		// occurrence of subsequents timeouts (if any)
-		m_canconnect.store(true, std::memory_order_relaxed);
-		m_connecting.store(false, std::memory_order_relaxed);
-		m_conntimer.cancel();
+    // We got a socket connection established
+    m_canconnect.store(true, std::memory_order_relaxed);
+    if (g_logVerbosity >=6 )
+        cnote << "Socket connected to " << ActiveEndPoint();
 
-		if (m_conn->SecLevel() != SecureLevel::NONE) {
+    if (m_conn->SecLevel() != SecureLevel::NONE)
+    {
+        boost::system::error_code hec;
+        m_securesocket->lowest_layer().set_option(boost::asio::socket_base::keep_alive(true));
+        m_securesocket->lowest_layer().set_option(tcp::no_delay(true));
 
-			boost::system::error_code hec;
-			m_securesocket->lowest_layer().set_option(boost::asio::socket_base::keep_alive(true));
-			m_securesocket->lowest_layer().set_option(tcp::no_delay(true));
+        m_securesocket->handshake(boost::asio::ssl::stream_base::client, hec);
 
-			m_securesocket->handshake(boost::asio::ssl::stream_base::client, hec);
-
-			if (hec) {
-				cwarn << "SSL/TLS Handshake failed: " << hec.message();
-				if (hec.value() == 337047686) { // certificate verification failed
-					cwarn << "This can have multiple reasons:";
-					cwarn << "* Root certs are either not installed or not found";
-					cwarn << "* Pool uses a self-signed certificate";
-					cwarn << "Possible fixes:";
-					cwarn << "* Make sure the file '/etc/ssl/certs/ca-certificates.crt' exists and is accessible";
-					cwarn << "* Export the correct path via 'export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt' to the correct file";
-					cwarn << "  On most systems you can install the 'ca-certificates' package";
-					cwarn << "  You can also get the latest file here: https://curl.haxx.se/docs/caextract.html";
-					cwarn << "* Disable certificate verification all-together via command-line option.";
-				}
-
-				// Do not trigger a full disconnection but, instead, let the loop
-				// continue with another IP (if any). 
-				// Disconnection is triggered on no more IP available
-				m_connected.store(false, std::memory_order_relaxed);
-				m_socket->close();
-				m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::start_connect, this)));
-				return;
-			}
-		}
-		else {
-			m_nonsecuresocket->set_option(boost::asio::socket_base::keep_alive(true));
-			m_nonsecuresocket->set_option(tcp::no_delay(true));
-		}
-
-		// Here is where we're properly connected
-		m_connected.store(true, std::memory_order_relaxed);
-
-		// Clean buffer from any previous stale data
-		m_sendBuffer.consume(4096);
-
-		// Trigger event handlers and begin counting for the next job
-		if (m_onConnected) { m_onConnected(); }
-		reset_work_timeout();
-
-        // Extract user and worker
-        size_t p;
-        m_worker.clear();
-        p = m_conn->User().find_first_of(".");
-        if (p != string::npos)
+        if (hec)
         {
-            m_user = m_conn->User().substr(0, p);
-
-            // There should be at least one char after dot
-            // returned p is zero based
-            if (p < (m_conn->User().length() - 1))
-                m_worker = m_conn->User().substr(++p);
-        }
-        else
-        {
-            m_user = m_conn->User();
-        }
-
-        /*
-        If this connection has not gone through an autodetection of stratum mode
-        begin it now.
-        Autodetection process passes all known stratum modes.
-        - 1st pass EthStratumClient::ETHEREUMSTRATUM  (2)
-        - 2nd pass EthStratumClient::ETHPROXY         (1)
-        - 3rd pass EthStratumClient::STRATUM          (0)
-        */
-
-        Json::Value jReq;
-        jReq["id"] = unsigned(1);
-        jReq["method"] = "mining.subscribe";
-        jReq["params"] = Json::Value(Json::arrayValue);
-
-        if (!m_conn->StratumModeConfirmed())
-        {
-			switch (m_conn->StratumMode())
-			{
-
-			case 0:
-
-				m_conn->SetStratumMode(0, false);
-				jReq["id"] = unsigned(1);
-				jReq["jsonrpc"] = "2.0";
-				jReq["method"] = "mining.subscribe";
-				jReq["params"] = Json::Value(Json::arrayValue);
-				break;
-
-			case 1:
-
-				m_conn->SetStratumMode(1, false);
-				jReq["id"] = unsigned(1);
-				jReq["method"] = "eth_submitLogin";
-				jReq["params"] = Json::Value(Json::arrayValue);
-				if (m_worker.length())
-					jReq["worker"] = m_worker;
-				jReq["params"].append(m_user + m_conn->Path());
-				if (!m_email.empty())
-					jReq["params"].append(m_email);
-
-				break;
-
-			case 999:
-			case 2:
-				m_conn->SetStratumMode(2, false);
-				jReq["params"].append(ethminer_get_buildinfo()->project_name_with_version);
-				jReq["params"].append("EthereumStratum/1.0.0");
-				break;
-
-			default:
-				break;
-			}
-
-        }
-        else
-        {
-            switch (m_conn->StratumMode())
-            {
-            case EthStratumClient::STRATUM:
-
-                jReq["jsonrpc"] = "2.0";
-
-                break;
-
-            case EthStratumClient::ETHPROXY:
-
-                jReq["method"] = "eth_submitLogin";
-                if (m_worker.length())
-                    jReq["worker"] = m_worker;
-                jReq["params"].append(m_user + m_conn->Path());
-                if (!m_email.empty())
-                    jReq["params"].append(m_email);
-
-                break;
-
-            case EthStratumClient::ETHEREUMSTRATUM:
-
-                jReq["params"].append(ethminer_get_buildinfo()->project_name_with_version);
-                jReq["params"].append("EthereumStratum/1.0.0");
-
-                break;
+            cwarn << "SSL/TLS Handshake failed: " << hec.message();
+            if (hec.value() == 337047686)
+            {  // certificate verification failed
+                cwarn << "This can have multiple reasons:";
+                cwarn << "* Root certs are either not installed or not found";
+                cwarn << "* Pool uses a self-signed certificate";
+                cwarn << "Possible fixes:";
+                cwarn << "* Make sure the file '/etc/ssl/certs/ca-certificates.crt' exists and "
+                         "is accessible";
+                cwarn << "* Export the correct path via 'export "
+                         "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt' to the correct "
+                         "file";
+                cwarn << "  On most systems you can install the 'ca-certificates' package";
+                cwarn << "  You can also get the latest file here: "
+                         "https://curl.haxx.se/docs/caextract.html";
+                cwarn << "* Disable certificate verification all-together via command-line "
+                         "option.";
             }
+
+            // This is a fatal error
+            // No need to try other IPs as the certificate is based on host-name
+            // not ip address. Trying other IPs would end up with the very same error.
+            m_canconnect.store(false, std::memory_order_relaxed);
+            m_conn->MarkUnrecoverable();
+            m_io_service.post(
+                m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
+            return;
+
         }
+    }
+    else
+    {
+        m_nonsecuresocket->set_option(boost::asio::socket_base::keep_alive(true));
+        m_nonsecuresocket->set_option(tcp::no_delay(true));
+    }
 
-        // Begin receive data
-        recvSocketData();
+    // Here is where we're properly connected
+    m_connected.store(true, std::memory_order_relaxed);
 
-        /*
-        Send first message
-        NOTE !!
-        It's been tested that f2pool.com does not respond with json error to wrong
-        access message (which is needed to autodetect stratum mode).
-        IT DOES NOT RESPOND AT ALL !!
-        Due to this we need to set a timeout (arbitrary set to 1 second) and
-        if no response within that time consider the tentative login failed
-        and switch to next stratum mode test
-        */
-        m_responsetimer.cancel();
-        m_responsetimer.expires_from_now(boost::posix_time::milliseconds(1000));
-        m_responsetimer.async_wait(m_io_strand.wrap(boost::bind(&EthStratumClient::response_timeout_handler, this, boost::asio::placeholders::error)));
-		sendSocketData(jReq);
+    // Clean buffer from any previous stale data
+    m_sendBuffer.consume(4096);
 
-	}
+    // Extract user and worker
+    size_t p;
+    m_worker.clear();
+    p = m_conn->User().find_first_of(".");
+    if (p != string::npos)
+    {
+        m_user = m_conn->User().substr(0, p);
+
+        // There should be at least one char after dot
+        // returned p is zero based
+        if (p < (m_conn->User().length() - 1))
+            m_worker = m_conn->User().substr(++p);
+    }
+    else
+    {
+        m_user = m_conn->User();
+    }
+
+    /*
+    If this connection has not gone through an autodetection of stratum mode
+    begin it now.
+    Autodetection process passes all known stratum modes.
+    - 1st pass EthStratumClient::ETHEREUMSTRATUM  (2)
+    - 2nd pass EthStratumClient::ETHPROXY         (1)
+    - 3rd pass EthStratumClient::STRATUM          (0)
+    */
+
+    Json::Value jReq;
+    jReq["id"] = unsigned(1);
+    jReq["method"] = "mining.subscribe";
+    jReq["params"] = Json::Value(Json::arrayValue);
+
+    if (!m_conn->StratumModeConfirmed() && m_conn->StratumMode() == 999)
+        m_conn->SetStratumMode(2, false);
+
+    switch (m_conn->StratumMode())
+    {
+    case EthStratumClient::STRATUM:
+
+        jReq["jsonrpc"] = "2.0";
+
+        break;
+
+    case EthStratumClient::ETHPROXY:
+
+        jReq["method"] = "eth_submitLogin";
+        if (m_worker.length())
+            jReq["worker"] = m_worker;
+        jReq["params"].append(m_user + m_conn->Path());
+        if (!m_email.empty())
+            jReq["params"].append(m_email);
+
+        break;
+
+    case EthStratumClient::ETHEREUMSTRATUM:
+
+        jReq["params"].append(ethminer_get_buildinfo()->project_name_with_version);
+        jReq["params"].append("EthereumStratum/1.0.0");
+
+        break;
+    }
+
+    // Begin receive data
+    recvSocketData();
+
+    /*
+    Send first message
+    NOTE !!
+    It's been tested that f2pool.com does not respond with json error to wrong
+    access message (which is needed to autodetect stratum mode).
+    IT DOES NOT RESPOND AT ALL !!
+    Due to this we need to set a timeout (arbitrary set to 1 second) and
+    if no response within that time consider the tentative login failed
+    and switch to next stratum mode test
+    */
+    m_responsetimer.cancel();
+    m_responsetimer.expires_from_now(boost::posix_time::milliseconds(1000));
+    m_responsetimer.async_wait(m_io_strand.wrap(boost::bind(
+        &EthStratumClient::response_timeout_handler, this, boost::asio::placeholders::error)));
+    sendSocketData(jReq);
+
 
 }
 
 std::string EthStratumClient::processError(Json::Value& responseObject)
 {
-	std::string retVar;
+    std::string retVar;
 
-	if (responseObject.isMember("error") && !responseObject.get("error", Json::Value::null).isNull()) {
+    if (responseObject.isMember("error") &&
+        !responseObject.get("error", Json::Value::null).isNull())
+    {
+        if (responseObject["error"].isConvertibleTo(Json::ValueType::stringValue))
+        {
+            retVar = responseObject.get("error", "Unknown error").asString();
+        }
+        else if (responseObject["error"].isConvertibleTo(Json::ValueType::arrayValue))
+        {
+            for (auto i : responseObject["error"])
+            {
+                retVar += i.asString() + " ";
+            }
+        }
+        else if (responseObject["error"].isConvertibleTo(Json::ValueType::objectValue))
+        {
+            for (Json::Value::iterator i = responseObject["error"].begin();
+                 i != responseObject["error"].end(); ++i)
+            {
+                Json::Value k = i.key();
+                Json::Value v = (*i);
+                retVar += (std::string)i.name() + ":" + v.asString() + " ";
+            }
+        }
+    }
+    else
+    {
+        retVar = "Unknown error";
+    }
 
-		if (responseObject["error"].isConvertibleTo(Json::ValueType::stringValue)) {
-			retVar = responseObject.get("error", "Unknown error").asString();
-		}
-		else if (responseObject["error"].isConvertibleTo(Json::ValueType::arrayValue))
-		{
-			for (auto i : responseObject["error"]) {
-				retVar += i.asString() + " ";
-			}
-		}
-		else if (responseObject["error"].isConvertibleTo(Json::ValueType::objectValue))
-		{
-			for (Json::Value::iterator i = responseObject["error"].begin(); i != responseObject["error"].end(); ++i)
-			{
-				Json::Value k = i.key();
-				Json::Value v = (*i);
-				retVar += (std::string)i.name() + ":" + v.asString() + " ";
-			}
-		}
-
-	}
-	else {
-		retVar = "Unknown error";
-	}
-
-	return retVar;
-
+    return retVar;
 }
 
 void EthStratumClient::processExtranonce(std::string& enonce)
 {
-	m_extraNonceHexSize = enonce.length();
+    m_extraNonceHexSize = enonce.length();
 
-	cnote << "Extranonce set to " EthWhite << enonce << EthReset " (nicehash)";
-	enonce.append(16 - m_extraNonceHexSize, '0');
-	m_extraNonce = h64(enonce);
+    cnote << "Extranonce set to " EthWhite << enonce << EthReset " (nicehash)";
+    enonce.append(16 - m_extraNonceHexSize, '0');
+    m_extraNonce = h64(enonce);
 }
 
-void EthStratumClient::processResponse(Json::Value &responseObject)
+void EthStratumClient::processResponse(Json::Value& responseObject)
 {
+    dev::setThreadName("stratum");
 
-	dev::setThreadName("stratum");
+    // Out received message only for debug purpouses
+    if (g_logVerbosity >= 9)
+    {
+        cnote << responseObject;
+    }
 
-	// Out received message only for debug purpouses
-	if (g_logVerbosity >= 9) {
-		cnote << responseObject;
-	}
+    // Store jsonrpc version to test against
+    int _rpcVer = responseObject.isMember("jsonrpc") ? 2 : 1;
 
-	// Store jsonrpc version to test against
-	int _rpcVer = responseObject.isMember("jsonrpc") ? 2 : 1;					
-
-	bool _isNotification = false;		// Whether or not this message is a reply to previous request or is a broadcast notification
-	bool _isSuccess = false;			// Whether or not this is a succesful or failed response (implies _isNotification = false)
-	string _errReason = "";				// Content of the error reason
-	string _method = "";				// The method of the notification (or request from pool)
-	int _id = 0;						// This SHOULD be the same id as the request it is responding to (known exception is ethermine.org using 999)
+    bool _isNotification = false;  // Whether or not this message is a reply to previous request or
+                                   // is a broadcast notification
+    bool _isSuccess = false;       // Whether or not this is a succesful or failed response (implies
+                                   // _isNotification = false)
+    string _errReason = "";        // Content of the error reason
+    string _method = "";           // The method of the notification (or request from pool)
+    int _id = 0;                   // This SHOULD be the same id as the request it is responding to (known exception
+                                   // is ethermine.org using 999)
 
 
-	// Retrieve essential values
-	_id = responseObject.get("id", unsigned(0)).asUInt();
-	_isSuccess = responseObject.get("error", Json::Value::null).empty();
-	_errReason = (_isSuccess ? "" : processError(responseObject));
-	_method = responseObject.get("method", "").asString();
-	_isNotification = ( _method != "" || _id == unsigned(0) );
+    // Retrieve essential values
+    _id = responseObject.get("id", unsigned(0)).asUInt();
+    _isSuccess = responseObject.get("error", Json::Value::null).empty();
+    _errReason = (_isSuccess ? "" : processError(responseObject));
+    _method = responseObject.get("method", "").asString();
+    _isNotification = (_method != "" || _id == unsigned(0));
 
-	// Notifications of new jobs are like responses to get_work requests
-	if (_isNotification && _method == "" && m_conn->StratumMode() == EthStratumClient::ETHPROXY && responseObject["result"].isArray()) {
-		_method = "mining.notify";
-	}
+    // Notifications of new jobs are like responses to get_work requests
+    if (_isNotification && _method == "" && m_conn->StratumMode() == EthStratumClient::ETHPROXY &&
+        responseObject["result"].isArray())
+    {
+        _method = "mining.notify";
+    }
 
-	// Very minimal sanity checks 
-	// - For rpc2 member "jsonrpc" MUST be valued to "2.0"
-	// - For responses ... well ... whatever
-	// - For notifications I must receive "method" member and a not empty "params" or "result" member
-	if (
-		(_rpcVer == 2 && (!responseObject["jsonrpc"].isString() || responseObject.get("jsonrpc", "") != "2.0")) ||
-		(_isNotification && (responseObject["params"].empty() && responseObject["result"].empty()))
-		)
-	{ 
-
-		cwarn << "Pool sent an invalid jsonrpc message ...";
-		cwarn << "Do not blame ethminer for this. Ask pool devs to honor http://www.jsonrpc.org/ specifications ";
-		cwarn << "Disconnecting ...";
+    // Very minimal sanity checks
+    // - For rpc2 member "jsonrpc" MUST be valued to "2.0"
+    // - For responses ... well ... whatever
+    // - For notifications I must receive "method" member and a not empty "params" or "result"
+    // member
+    if ((_rpcVer == 2 && (!responseObject["jsonrpc"].isString() ||
+                             responseObject.get("jsonrpc", "") != "2.0")) ||
+        (_isNotification && (responseObject["params"].empty() && responseObject["result"].empty())))
+    {
+        cwarn << "Pool sent an invalid jsonrpc message ...";
+        cwarn << "Do not blame ethminer for this. Ask pool devs to honor http://www.jsonrpc.org/ "
+                 "specifications ";
+        cwarn << "Disconnecting ...";
         m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
-		return;
+        return;
+    }
 
-	}
 
+    // Handle awaited responses to OUR requests
+    if (!_isNotification)
+    {
+        Json::Value jReq;
+        Json::Value jResult = responseObject.get("result", Json::Value::null);
 
-	// Handle awaited responses to OUR requests
-	if (!_isNotification) {
-
-		Json::Value jReq;
-		Json::Value jResult = responseObject.get("result", Json::Value::null);
-
-		switch (_id)
-		{
-
-		case 1:
+        switch (_id)
+        {
+        case 1:
 
             /*
             This is the response to very first message after connection.
             I wish I could manage to have different Ids but apparently ethermine.org always replies
             to first message with id=1 regardless the id originally sent.
             */
+
+            // If still in detection phase every failure to
+            // to our issued method must lead to a disconnection and
+            // reconnection with next available method.
             if (!m_conn->StratumModeConfirmed())
             {
+
+                if (!_isSuccess)
+                {
+                    // Disconnect and Proceed with next step of autodetection
+                    m_io_service.post(
+                        m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
+                    return;
+                
+                }
+
                 switch (m_conn->StratumMode())
                 {
                 case EthStratumClient::ETHEREUMSTRATUM:
 
                     // In case of success we also need to verify third parameter of "result" array
                     // member is exactly "EthereumStratum/1.0.0". Otherwise try with another mode
-                    if (_isSuccess &&
-                    	jResult.isArray() && jResult[0].isArray() && jResult[0].size() == 3 &&
-                    	jResult[0].get((Json::Value::ArrayIndex)2, "").asString() == "EthereumStratum/1.0.0")
-					{
-						// ETHEREUMSTRATUM is confirmed
-						cnote << "Stratum mode detected : ETHEREUMSTRATUM (NiceHash)";
-						m_conn->SetStratumMode(2, true);
-					}
-					else
-					{
-						// This is not a proper ETHEREUMSTRATUM response.
-						// Proceed with next step of autodetection ETHPROXY compatible
-						m_conn->SetStratumMode(1);
-						jReq["id"] = unsigned(1);
-						jReq["method"] = "eth_submitLogin";
-						jReq["params"] = Json::Value(Json::arrayValue);
-						if (m_worker.length())
-							jReq["worker"] = m_worker;
-						jReq["params"].append(m_user + m_conn->Path());
-						if (!m_email.empty())
-							jReq["params"].append(m_email);
-
-						// Set a timeout in case pool does not respond
-						m_responsetimer.cancel();
-						m_responsetimer.expires_from_now(boost::posix_time::milliseconds(1000));
-						m_responsetimer.async_wait(m_io_strand.wrap(boost::bind(&EthStratumClient::response_timeout_handler, this, boost::asio::placeholders::error)));
-						sendSocketData(jReq);
-						return;
-					}
+                    if (jResult.isArray() && jResult[0].isArray() &&
+                        jResult[0].size() == 3 &&
+                        jResult[0].get((Json::Value::ArrayIndex)2, "").asString() ==
+                            "EthereumStratum/1.0.0")
+                    {
+                        // ETHEREUMSTRATUM is confirmed
+                        m_conn->SetStratumMode(2, true);
+                    }
+                    else
+                    {
+                        // Disconnect and Proceed with next step of autodetection ETHPROXY compatible
+                        m_io_service.post(
+                            m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
+                        return;
+                    }
 
                     break;
 
                 case EthStratumClient::ETHPROXY:
 
-                    if (!_isSuccess)
-                    {
-                        // In case of failure try next step which is STRATUM
-                        m_conn->SetStratumMode(0);
-                        jReq["id"] = unsigned(1);
-                        jReq["jsonrpc"] = "2.0";
-                        jReq["method"] = "mining.subscribe";
-                        jReq["params"] = Json::Value(Json::arrayValue);
-
-                        // Set a timeout in case pool does not respond
-                        m_responsetimer.cancel();
-                        m_responsetimer.expires_from_now(boost::posix_time::milliseconds(1000));
-                        m_responsetimer.async_wait(m_io_strand.wrap(boost::bind(&EthStratumClient::response_timeout_handler, this, boost::asio::placeholders::error)));
-
-                        sendSocketData(jReq);
-                        return;
-                    }
-                    else
-                    {
-                        // ETHPROXY is confirmed
-                        cnote << "Stratum mode detected : ETHPROXY compatible";
-                        m_conn->SetStratumMode(1, true);
-                    }
+                    // ETHPROXY is confirmed
+                    m_conn->SetStratumMode(1, true);
 
                     break;
 
                 case EthStratumClient::STRATUM:
 
-                    if (!_isSuccess)
-                    {
-                        // In case of failure we can't manage this connection
-                        cwarn << "Unable to find suitable Stratum Mode";
-                        m_conn->MarkUnrecoverable();
-                        m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
-                        return;
-                    }
-                    else
-                    {
-                        // STRATUM is confirmed
-                        cnote << "Stratum mode detected : STRATUM";
-                        m_conn->SetStratumMode(0, true);
-                    }
+                    // STRATUM is confirmed
+                    m_conn->SetStratumMode(0, true);
 
                     break;
                 }
+
             }
 
 
-            // Response to "mining.subscribe" (https://en.bitcoin.it/wiki/Stratum_mining_protocol#mining.subscribe)
-			// Result should be an array with multiple dimensions, we only care about the data if EthStratumClient::ETHEREUMSTRATUM
-			switch (m_conn->StratumMode()) {
+            // Response to "mining.subscribe"
+            // (https://en.bitcoin.it/wiki/Stratum_mining_protocol#mining.subscribe) Result should
+            // be an array with multiple dimensions, we only care about the data if
+            // EthStratumClient::ETHEREUMSTRATUM
+            switch (m_conn->StratumMode())
+            {
+            case EthStratumClient::STRATUM:
 
-			case EthStratumClient::STRATUM:
+                cnote << "Stratum mode detected : STRATUM";
+                m_subscribed.store(_isSuccess, std::memory_order_relaxed);
+                if (!m_subscribed)
+                {
+                    cnote << "Could not subscribe : " << _errReason;
+                    m_conn->MarkUnrecoverable();
+                    m_io_service.post(
+                        m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
+                    return;
+                }
+                else
+                {
+                    cnote << "Subscribed !";
+                    m_authpending.store(true, std::memory_order_relaxed);
+                    jReq["id"] = unsigned(3);
+                    jReq["jsonrpc"] = "2.0";
+                    jReq["method"] = "mining.authorize";
+                    jReq["params"] = Json::Value(Json::arrayValue);
+                    jReq["params"].append(m_conn->User() + m_conn->Path());
+                    jReq["params"].append(m_conn->Pass());
+                }
 
-				m_subscribed.store(_isSuccess, std::memory_order_relaxed);
-				if (!m_subscribed)
-				{
-					cnote << "Could not subscribe to stratum server";
-					m_conn->MarkUnrecoverable();
-                    m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
-					return;
-				}
-				else {
+                break;
 
-					cnote << "Subscribed to stratum server";
+            case EthStratumClient::ETHPROXY:
 
-					jReq["id"] = unsigned(3);
-					jReq["jsonrpc"] = "2.0";
-					jReq["method"] = "mining.authorize";
-					jReq["params"] = Json::Value(Json::arrayValue);
-					jReq["params"].append(m_conn->User() + m_conn->Path());
-					jReq["params"].append(m_conn->Pass());
-				}
+                cnote << "Stratum mode detected : ETHPROXY Compatible";
+                m_subscribed.store(_isSuccess, std::memory_order_relaxed);
+                if (!m_subscribed)
+                {
+                    cnote << "Could not login :" << _errReason;
+                    m_conn->MarkUnrecoverable();
+                    m_io_service.post(
+                        m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
+                    return;
+                }
+                else
+                {
+                    cnote << "Logged in !";
+                    m_authorized.store(true, std::memory_order_relaxed);
 
-				break;
+                    // If we get here we have a valid application connection
+                    // not only a socket connection
+                    if (m_onConnected && m_conn->StratumModeConfirmed())
+                    {
+                        m_onConnected();
+                        reset_work_timeout();
+                    }
 
-			case EthStratumClient::ETHPROXY:
+                    jReq["id"] = unsigned(5);
+                    jReq["method"] = "eth_getWork";
+                    jReq["params"] = Json::Value(Json::arrayValue);
+                }
 
-				m_subscribed.store(_isSuccess, std::memory_order_relaxed);
-				if (!m_subscribed)
-				{
-					cnote << "Could not login to ethproxy server:" << _errReason;
-					m_conn->MarkUnrecoverable();
-                    m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
-					return;
-				}
-				else {
+                break;
 
-					cnote << "Logged in to eth-proxy server";
-					m_authorized.store(true, std::memory_order_relaxed);
+            case EthStratumClient::ETHEREUMSTRATUM:
 
-					jReq["id"] = unsigned(5);
-					jReq["method"] = "eth_getWork";
-					jReq["params"] = Json::Value(Json::arrayValue);
+                cnote << "Stratum mode detected : ETHEREUMSTRATUM (NiceHash)";
+                m_subscribed.store(_isSuccess, std::memory_order_relaxed);
+                if (!m_subscribed)
+                {
+                    cnote << "Could not subscribe : " << _errReason;
+                    m_conn->MarkUnrecoverable();
+                    m_io_service.post(
+                        m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
+                    return;
+                }
+                else
+                {
+                    cnote << "Subscribed to stratum server";
 
-				}
+                    m_nextWorkBoundary =
+                        h256("0xffff000000000000000000000000000000000000000000000000000000000000");
 
-				break;
+                    if (!jResult.empty() && jResult.isArray())
+                    {
+                        std::string enonce = jResult.get((Json::Value::ArrayIndex)1, "").asString();
+                        processExtranonce(enonce);
+                    }
 
-			case EthStratumClient::ETHEREUMSTRATUM:
+                    // Notify we're ready for extra nonce subscribtion on the fly
+                    // reply to this message should not perform any logic
+                    jReq["id"] = unsigned(2);
+                    jReq["method"] = "mining.extranonce.subscribe";
+                    jReq["params"] = Json::Value(Json::arrayValue);
+                    sendSocketData(jReq);
 
-				m_subscribed.store(_isSuccess, std::memory_order_relaxed);
-				if (!m_subscribed)
-				{
-					cnote << "Could not subscribe to stratum server:" << _errReason;
-					m_conn->MarkUnrecoverable();
-                    m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
-					return;
-				}
-				else {
-
-					cnote << "Subscribed to stratum server";
-
-					m_nextWorkBoundary = h256("0xffff000000000000000000000000000000000000000000000000000000000000");
-
-					if (!jResult.empty() && jResult.isArray()) {
-						std::string enonce = jResult.get((Json::Value::ArrayIndex)1, "").asString();
-						processExtranonce(enonce);
-					}
-
-					// Notify we're ready for extra nonce subscribtion on the fly
-					// reply to this message should not perform any logic
-					jReq["id"] = unsigned(2);
-					jReq["method"] = "mining.extranonce.subscribe";
-					jReq["params"] = Json::Value(Json::arrayValue);
-					sendSocketData(jReq);
-
-					// Eventually request authorization
-					jReq["id"] = unsigned(3);
-					jReq["method"] = "mining.authorize";
-					jReq["params"].append(m_conn->User() + m_conn->Path());
-					jReq["params"].append(m_conn->Pass());
-
-				}
+                    // Eventually request authorization
+                    m_authpending.store(true, std::memory_order_relaxed);
+                    jReq["id"] = unsigned(3);
+                    jReq["method"] = "mining.authorize";
+                    jReq["params"].append(m_conn->User() + m_conn->Path());
+                    jReq["params"].append(m_conn->Pass());
+                }
 
 
-				break;
-			}
+                break;
+            }
 
-			sendSocketData(jReq);
-			break;
+            sendSocketData(jReq);
+            break;
 
-		case 2:
+        case 2:
 
-			// This is the response to mining.extranonce.subscribe
-			// according to this 
-			// https://github.com/nicehash/Specifications/blob/master/NiceHash_extranonce_subscribe_extension.txt
-			// In all cases, client does not perform any logic when receiving back these replies.
-			// With mining.extranonce.subscribe subscription, client should handle extranonce1
-			// changes correctly
+            // This is the response to mining.extranonce.subscribe
+            // according to this
+            // https://github.com/nicehash/Specifications/blob/master/NiceHash_extranonce_subscribe_extension.txt
+            // In all cases, client does not perform any logic when receiving back these replies.
+            // With mining.extranonce.subscribe subscription, client should handle extranonce1
+            // changes correctly
 
-			// Nothing to do here.
+            // Nothing to do here.
 
-			break;
+            break;
 
-		case 3:
+        case 3:
 
-			// Response to "mining.authorize" (https://en.bitcoin.it/wiki/Stratum_mining_protocol#mining.authorize)
-			// Result should be boolean, some pools also throw an error, so _isSuccess can be false
-			// Due to this reevaluate _isSuccess
+            // Response to "mining.authorize"
+            // (https://en.bitcoin.it/wiki/Stratum_mining_protocol#mining.authorize) Result should
+            // be boolean, some pools also throw an error, so _isSuccess can be false Due to this
+            // reevaluate _isSuccess
 
-			if (_isSuccess && jResult.isBool()) {
-				_isSuccess = jResult.asBool();
-			}
+            if (_isSuccess && jResult.isBool())
+            {
+                _isSuccess = jResult.asBool();
+            }
 
-			m_authorized.store(_isSuccess, std::memory_order_relaxed);
+            m_authpending.store(false, std::memory_order_relaxed);
+            m_authorized.store(_isSuccess, std::memory_order_relaxed);
 
-			if (!m_authorized)
-			{
-				cnote << "Worker not authorized " << m_conn->User() << _errReason;
+            if (!m_authorized)
+            {
+                cnote << "Worker not authorized " << m_conn->User() << _errReason;
                 m_conn->MarkUnrecoverable();
-                m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
-				return;
-			
-			}
-			else {
-				cnote << "Authorized worker " + m_conn->User();
-			}
-			
-			break;
+                m_io_service.post(
+                    m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
+                return;
+            }
+            else
+            {
+                cnote << "Authorized worker " + m_conn->User();
 
-		case 4:
+                // If we get here we have a valid application connection
+                // not only a socket connection
+                if (m_onConnected && m_conn->StratumModeConfirmed())
+                {
+                    m_onConnected();
+                    reset_work_timeout();
+                }
 
-			// Response to solution submission mining.submit  (https://en.bitcoin.it/wiki/Stratum_mining_protocol#mining.submit)
-			// Result should be boolean, some pools also throw an error, so _isSuccess can be false
-			// Due to this reevaluate _isSucess
+            }
 
-			if (_isSuccess && jResult.isBool()) {
-				_isSuccess = jResult.asBool();
-			}
+            break;
 
-			{
-				m_responsetimer.cancel();
-				m_response_pending = false;
-				if (_isSuccess) {
-					if (m_onSolutionAccepted) {
-						m_onSolutionAccepted(m_stale);
-					}
-				}
-				else {
-					if (m_onSolutionRejected) {
-						cwarn << "Reject reason :" << (_errReason.empty() ? "Unspecified" : _errReason);
-						m_onSolutionRejected(m_stale);
-					}
-				}
-			}
-			break;
+        case 4:
 
+            // Response to solution submission mining.submit
+            // (https://en.bitcoin.it/wiki/Stratum_mining_protocol#mining.submit) Result should be
+            // boolean, some pools also throw an error, so _isSuccess can be false Due to this
+            // reevaluate _isSucess
 
-		case 5:
+            if (_isSuccess && jResult.isBool())
+            {
+                _isSuccess = jResult.asBool();
+            }
 
-			// This is the response we get on first get_work request issued 
-			// in mode EthStratumClient::ETHPROXY
-			// thus we change it to a mining.notify notification
-			if (m_conn->StratumMode() == EthStratumClient::ETHPROXY && responseObject["result"].isArray()) {
-				_method = "mining.notify";
-				_isNotification = true;
-			}
-			break;
-
-		case 9:
-
-			// Response to hashrate submit
-			// Shall we do anything ?
-			// Hashrate submit is actually out of stratum spec
-			if (!_isSuccess) {
-				cwarn << "Submit hashRate failed:" << (_errReason.empty() ? "Unspecified error" : _errReason);
-			}
-			break;
-
-		case 999:
-
-			// This unfortunate case should not happen as none of the outgoing requests is marked with id 999
-			// However it has been tested that ethermine.org responds with this id when error replying to 
-			// either mining.subscribe (1) or mining.authorize requests (3)
-			// To properly handle this situation we need to rely on Subscribed/Authorized states
-
-			if (!_isSuccess) {
-
-				if (!m_subscribed) {
-
-					// Subscription pending
-					cnote << "Subscription failed:" << (_errReason.empty() ? "Unspecified error" : _errReason);
-                    m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
-					return;
-
-				}
-				else if (m_subscribed && !m_authorized) {
-
-					// Authorization pending
-					cnote << "Worker not authorized:" << (_errReason.empty() ? "Unspecified error" : _errReason);
-                    m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
-					return;
-
-				}
-			};
-
-			break;
+            {
+                m_responsetimer.cancel();
+                m_response_pending = false;
+                if (_isSuccess)
+                {
+                    if (m_onSolutionAccepted)
+                    {
+                        m_onSolutionAccepted(m_stale);
+                    }
+                }
+                else
+                {
+                    if (m_onSolutionRejected)
+                    {
+                        cwarn << "Reject reason :"
+                              << (_errReason.empty() ? "Unspecified" : _errReason);
+                        m_onSolutionRejected(m_stale);
+                    }
+                }
+            }
+            break;
 
 
-		default:
+        case 5:
 
-			cnote << "Got response for unknown message id [" << _id << "] Discarding ...";
-			break;
+            // This is the response we get on first get_work request issued
+            // in mode EthStratumClient::ETHPROXY
+            // thus we change it to a mining.notify notification
+            if (m_conn->StratumMode() == EthStratumClient::ETHPROXY &&
+                responseObject["result"].isArray())
+            {
+                _method = "mining.notify";
+                _isNotification = true;
+            }
+            break;
 
-		}
+        case 9:
 
-	}
+            // Response to hashrate submit
+            // Shall we do anything ?
+            // Hashrate submit is actually out of stratum spec
+            if (!_isSuccess)
+            {
+                cwarn << "Submit hashRate failed:"
+                      << (_errReason.empty() ? "Unspecified error" : _errReason);
+            }
+            break;
+
+        case 999:
+
+            // This unfortunate case should not happen as none of the outgoing requests is marked
+            // with id 999 However it has been tested that ethermine.org responds with this id when
+            // error replying to either mining.subscribe (1) or mining.authorize requests (3) To
+            // properly handle this situation we need to rely on Subscribed/Authorized states
+
+            if (!_isSuccess)
+            {
+                if (!m_subscribed)
+                {
+                    // Subscription pending
+                    cnote << "Subscription failed:"
+                          << (_errReason.empty() ? "Unspecified error" : _errReason);
+                    m_io_service.post(
+                        m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
+                    return;
+                }
+                else if (m_subscribed && !m_authorized)
+                {
+                    // Authorization pending
+                    cnote << "Worker not authorized:"
+                          << (_errReason.empty() ? "Unspecified error" : _errReason);
+                    m_io_service.post(
+                        m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
+                    return;
+                }
+            };
+
+            break;
+
+
+        default:
+
+            cnote << "Got response for unknown message id [" << _id << "] Discarding ...";
+            return;
+            break;
+        }
+    }
 
     /*
-    
+    
     Handle unsolicited messages FROM pool AKA notifications
 
     NOTE !
@@ -1051,129 +1058,137 @@ void EthStratumClient::processResponse(Json::Value &responseObject)
     which means we have detected proper stratum mode.
 
     */
-	
-	if (_isNotification && m_conn->StratumModeConfirmed()) {
 
-		Json::Value jReq;
-		Json::Value jPrm;
+    if (_isNotification && m_conn->StratumModeConfirmed())
+    {
+        Json::Value jReq;
+        Json::Value jPrm;
 
-		unsigned prmIdx;
+        unsigned prmIdx;
 
         if (_method == "mining.notify")
         {
-
             /*
             Workaround for Nanopool wrong implementation
             see issue # 1348
             */
 
-		    if (m_conn->StratumMode() == EthStratumClient::ETHPROXY && responseObject.isMember("result")) {
+            if (m_conn->StratumMode() == EthStratumClient::ETHPROXY &&
+                responseObject.isMember("result"))
+            {
+                jPrm = responseObject.get("result", Json::Value::null);
+                prmIdx = 0;
+            }
+            else
+            {
+                jPrm = responseObject.get("params", Json::Value::null);
+                prmIdx = 1;
+            }
 
-			    jPrm = responseObject.get("result", Json::Value::null);
-			    prmIdx = 0;
-		    }
-		    else
-		    {
 
-			    jPrm = responseObject.get("params", Json::Value::null);
-			    prmIdx = 1;
+            if (jPrm.isArray() && !jPrm.empty())
+            {
+                string job = jPrm.get((Json::Value::ArrayIndex)0, "").asString();
 
-		    }
+                if (m_response_pending)
+                    m_stale = true;
 
+                if (m_conn->StratumMode() == EthStratumClient::ETHEREUMSTRATUM)
+                {
+                    string sSeedHash = jPrm.get(1, "").asString();
+                    string sHeaderHash = jPrm.get(2, "").asString();
 
-			if (jPrm.isArray() && !jPrm.empty())
-			{
-				string job = jPrm.get((Json::Value::ArrayIndex)0, "").asString();
+                    if (sHeaderHash != "" && sSeedHash != "")
+                    {
+                        reset_work_timeout();
 
-				if (m_response_pending)
-					m_stale = true;
-
-				if (m_conn->StratumMode() == EthStratumClient::ETHEREUMSTRATUM)
-				{
-					string sSeedHash = jPrm.get(1, "").asString();
-					string sHeaderHash = jPrm.get(2, "").asString();
-
-					if (sHeaderHash != "" && sSeedHash != "")
-					{
-						reset_work_timeout();
-
-                        m_current.epoch = ethash::find_epoch_number(ethash::hash256_from_bytes(h256{sSeedHash}.data()));
+                        m_current.epoch = ethash::find_epoch_number(
+                            ethash::hash256_from_bytes(h256{sSeedHash}.data()));
                         m_current.header = h256(sHeaderHash);
-						m_current.boundary = m_nextWorkBoundary;
-						m_current.startNonce = bswap(*((uint64_t*)m_extraNonce.data()));
-						m_current.exSizeBits = m_extraNonceHexSize * 4;
-						m_current.job_len = job.size();
-						if (m_conn->StratumMode() == EthStratumClient::ETHEREUMSTRATUM)
-							job.resize(64, '0');
-						m_current.job = h256(job);
+                        m_current.boundary = m_nextWorkBoundary;
+                        m_current.startNonce = bswap(*((uint64_t*)m_extraNonce.data()));
+                        m_current.exSizeBits = m_extraNonceHexSize * 4;
+                        m_current.job_len = job.size();
+                        if (m_conn->StratumMode() == EthStratumClient::ETHEREUMSTRATUM)
+                            job.resize(64, '0');
+                        m_current.job = h256(job);
 
-						if (m_onWorkReceived) {
-							m_onWorkReceived(m_current, true);
-						}
-					}
-				}
-				else
-				{
-					string sHeaderHash = jPrm.get((Json::Value::ArrayIndex)prmIdx++, "").asString();
-					string sSeedHash = jPrm.get((Json::Value::ArrayIndex)prmIdx++, "").asString();
-					string sShareTarget = jPrm.get((Json::Value::ArrayIndex)prmIdx++, "").asString();
+                        if (m_onWorkReceived)
+                        {
+                            m_onWorkReceived(m_current, true);
+                        }
+                    }
+                }
+                else
+                {
+                    string sHeaderHash = jPrm.get((Json::Value::ArrayIndex)prmIdx++, "").asString();
+                    string sSeedHash = jPrm.get((Json::Value::ArrayIndex)prmIdx++, "").asString();
+                    string sShareTarget =
+                        jPrm.get((Json::Value::ArrayIndex)prmIdx++, "").asString();
 
-					// coinmine.pl fix
-					int l = sShareTarget.length();
-					if (l < 66)
-						sShareTarget = "0x" + string(66 - l, '0') + sShareTarget.substr(2);
+                    // coinmine.pl fix
+                    int l = sShareTarget.length();
+                    if (l < 66)
+                        sShareTarget = "0x" + string(66 - l, '0') + sShareTarget.substr(2);
 
 
-					if (sHeaderHash != "" && sSeedHash != "" && sShareTarget != "")
-					{
-						h256 headerHash = h256(sHeaderHash);
+                    if (sHeaderHash != "" && sSeedHash != "" && sShareTarget != "")
+                    {
+                        h256 headerHash = h256(sHeaderHash);
 
-						if (headerHash != m_current.header)
-						{
-							reset_work_timeout();
+                        if (headerHash != m_current.header)
+                        {
+                            reset_work_timeout();
 
-							m_current.header = h256(sHeaderHash);
+                            m_current.header = h256(sHeaderHash);
                             m_current.epoch = ethash::find_epoch_number(
                                 ethash::hash256_from_bytes(h256{sSeedHash}.data()));
                             m_current.boundary = h256(sShareTarget);
-							m_current.job = h256(job);
+                            m_current.job = h256(job);
 
-							if (m_onWorkReceived) {
-								m_onWorkReceived(m_current, true);
-							}
-						}
-					}
-				}
-			}
-		}
-		else if (_method == "mining.set_difficulty" && m_conn->StratumMode() == EthStratumClient::ETHEREUMSTRATUM)
-		{
-			jPrm = responseObject.get("params", Json::Value::null);
-			if (jPrm.isArray())
-			{
-				double nextWorkDifficulty = jPrm.get((Json::Value::ArrayIndex)0, 1).asDouble();
-				if (nextWorkDifficulty <= 0.0001) nextWorkDifficulty = 0.0001;
-				diffToTarget((uint32_t*)m_nextWorkBoundary.data(), nextWorkDifficulty);
-				cnote << "Difficulty set to " EthWhite << nextWorkDifficulty << EthReset " (nicehash)";
-				if (m_onWorkReceived && (m_current.epoch != -1)) {
-					m_onWorkReceived(m_current, false);
-				}
-			}
-		}
-		else if (_method == "mining.set_extranonce" && m_conn->StratumMode() == EthStratumClient::ETHEREUMSTRATUM)
-		{
-			jPrm = responseObject.get("params", Json::Value::null);
-			if (jPrm.isArray())
-			{
-				std::string enonce = jPrm.get((Json::Value::ArrayIndex)0, "").asString();
-				processExtranonce(enonce);
-				if (m_onWorkReceived  && (m_current.epoch != -1)) {
-					m_onWorkReceived(m_current, false);
-				}
-			}
-		}
-		else if (_method == "client.get_version")
-		{
+                            if (m_onWorkReceived)
+                            {
+                                m_onWorkReceived(m_current, true);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        else if (_method == "mining.set_difficulty" &&
+                 m_conn->StratumMode() == EthStratumClient::ETHEREUMSTRATUM)
+        {
+            jPrm = responseObject.get("params", Json::Value::null);
+            if (jPrm.isArray())
+            {
+                double nextWorkDifficulty = jPrm.get((Json::Value::ArrayIndex)0, 1).asDouble();
+                if (nextWorkDifficulty <= 0.0001)
+                    nextWorkDifficulty = 0.0001;
+                diffToTarget((uint32_t*)m_nextWorkBoundary.data(), nextWorkDifficulty);
+                cnote << "Difficulty set to " EthWhite << nextWorkDifficulty
+                      << EthReset " (nicehash)";
+                if (m_onWorkReceived && (m_current.epoch != -1))
+                {
+                    m_onWorkReceived(m_current, false);
+                }
+            }
+        }
+        else if (_method == "mining.set_extranonce" &&
+                 m_conn->StratumMode() == EthStratumClient::ETHEREUMSTRATUM)
+        {
+            jPrm = responseObject.get("params", Json::Value::null);
+            if (jPrm.isArray())
+            {
+                std::string enonce = jPrm.get((Json::Value::ArrayIndex)0, "").asString();
+                processExtranonce(enonce);
+                if (m_onWorkReceived && (m_current.epoch != -1))
+                {
+                    m_onWorkReceived(m_current, false);
+                }
+            }
+        }
+        else if (_method == "client.get_version")
+        {
             jReq["id"] = toString(_id);
             jReq["result"] = ethminer_get_buildinfo()->project_name_with_version;
 
@@ -1203,10 +1218,10 @@ void EthStratumClient::processResponse(Json::Value &responseObject)
             sendSocketData(jReq);
         }
     }
-
 }
 
-void EthStratumClient::work_timeout_handler(const boost::system::error_code& ec) {
+void EthStratumClient::work_timeout_handler(const boost::system::error_code& ec)
+{
     if (!ec)
     {
         if (isConnected())
@@ -1219,7 +1234,8 @@ void EthStratumClient::work_timeout_handler(const boost::system::error_code& ec)
     }
 }
 
-void EthStratumClient::response_timeout_handler(const boost::system::error_code& ec) {
+void EthStratumClient::response_timeout_handler(const boost::system::error_code& ec)
+{
     if (!ec)
     {
         if (isConnected())
@@ -1230,7 +1246,8 @@ void EthStratumClient::response_timeout_handler(const boost::system::error_code&
                 dev::setThreadName("stratum");
                 cwarn << "No response received in " << m_responsetimeout << " seconds.";
                 m_endpoints.pop();
-                m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
+                m_io_service.post(
+                    m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
             }
 
             if (m_conn->StratumModeConfirmed() == false && m_conn->IsUnrecoverable() == false)
@@ -1248,36 +1265,37 @@ void EthStratumClient::response_timeout_handler(const boost::system::error_code&
     }
 }
 
-void EthStratumClient::submitHashrate(string const & rate) {
-	
-	m_rate = rate;
-	
-	if (!m_submit_hashrate || !isConnected()) {
-		return;
-	}
+void EthStratumClient::submitHashrate(string const& rate)
+{
+    m_rate = rate;
 
-	// There is no stratum method to submit the hashrate so we use the rpc variant.
-	// Note !!
-	// id = 6 is also the id used by ethermine.org and nanopool to push new jobs
-	// thus we will be in trouble if we want to check the result of hashrate submission
-	// actually change the id from 6 to 9
+    if (!m_submit_hashrate || !isConnected())
+    {
+        return;
+    }
 
-	Json::Value jReq;
-	jReq["id"] = unsigned(9);
-	jReq["jsonrpc"] = "2.0";
-	if (m_worker.length()) jReq["worker"] = m_worker;
-	jReq["method"] = "eth_submitHashrate";
-	jReq["params"] = Json::Value(Json::arrayValue);
-	jReq["params"].append(m_rate);
-	jReq["params"].append("0x" + toString(this->m_submit_hashrate_id));
+    // There is no stratum method to submit the hashrate so we use the rpc variant.
+    // Note !!
+    // id = 6 is also the id used by ethermine.org and nanopool to push new jobs
+    // thus we will be in trouble if we want to check the result of hashrate submission
+    // actually change the id from 6 to 9
 
-	sendSocketData(jReq);
+    Json::Value jReq;
+    jReq["id"] = unsigned(9);
+    jReq["jsonrpc"] = "2.0";
+    if (m_worker.length())
+        jReq["worker"] = m_worker;
+    jReq["method"] = "eth_submitHashrate";
+    jReq["params"] = Json::Value(Json::arrayValue);
+    jReq["params"].append(m_rate);
+    jReq["params"].append("0x" + toString(this->m_submit_hashrate_id));
 
+    sendSocketData(jReq);
 }
 
-void EthStratumClient::submitSolution(const Solution& solution) {
-
-	string nonceHex = toHex(solution.nonce);
+void EthStratumClient::submitSolution(const Solution& solution)
+{
+    string nonceHex = toHex(solution.nonce);
 
     m_responsetimer.cancel();
     m_responsetimer.expires_from_now(boost::posix_time::seconds(m_responsetimeout));
@@ -1286,52 +1304,53 @@ void EthStratumClient::submitSolution(const Solution& solution) {
 
     Json::Value jReq;
 
-	jReq["id"] = unsigned(4);
-	jReq["method"] = "mining.submit";
-	jReq["params"] = Json::Value(Json::arrayValue);
+    jReq["id"] = unsigned(4);
+    jReq["method"] = "mining.submit";
+    jReq["params"] = Json::Value(Json::arrayValue);
 
-	switch (m_conn->StratumMode()) {
+    switch (m_conn->StratumMode())
+    {
+    case EthStratumClient::STRATUM:
 
-		case EthStratumClient::STRATUM:
-			
-			jReq["jsonrpc"] = "2.0";
-			jReq["params"].append(m_conn->User());
-			jReq["params"].append(solution.work.job.hex());
-			jReq["params"].append("0x" + nonceHex);
-			jReq["params"].append("0x" + solution.work.header.hex());
-			jReq["params"].append("0x" + solution.mixHash.hex());
-			if (m_worker.length()) jReq["worker"] = m_worker;
+        jReq["jsonrpc"] = "2.0";
+        jReq["params"].append(m_conn->User());
+        jReq["params"].append(solution.work.job.hex());
+        jReq["params"].append("0x" + nonceHex);
+        jReq["params"].append("0x" + solution.work.header.hex());
+        jReq["params"].append("0x" + solution.mixHash.hex());
+        if (m_worker.length())
+            jReq["worker"] = m_worker;
 
-			break;
+        break;
 
-		case EthStratumClient::ETHPROXY:
+    case EthStratumClient::ETHPROXY:
 
-			jReq["method"] = "eth_submitWork";
-			jReq["params"].append("0x" + nonceHex);
-			jReq["params"].append("0x" + solution.work.header.hex());
-			jReq["params"].append("0x" + solution.mixHash.hex());
-			if (m_worker.length()) jReq["worker"] = m_worker;
+        jReq["method"] = "eth_submitWork";
+        jReq["params"].append("0x" + nonceHex);
+        jReq["params"].append("0x" + solution.work.header.hex());
+        jReq["params"].append("0x" + solution.mixHash.hex());
+        if (m_worker.length())
+            jReq["worker"] = m_worker;
 
-			break;
+        break;
 
-		case EthStratumClient::ETHEREUMSTRATUM:
+    case EthStratumClient::ETHEREUMSTRATUM:
 
-			jReq["params"].append(m_conn->User());
-			jReq["params"].append(solution.work.job.hex().substr(0, solution.work.job_len));
-			jReq["params"].append(nonceHex.substr(m_extraNonceHexSize, 16 - m_extraNonceHexSize));
+        jReq["params"].append(m_conn->User());
+        jReq["params"].append(solution.work.job.hex().substr(0, solution.work.job_len));
+        jReq["params"].append(nonceHex.substr(m_extraNonceHexSize, 16 - m_extraNonceHexSize));
 
-			break;
+        break;
+    }
 
-	}
+    sendSocketData(jReq);
 
-	sendSocketData(jReq);
-
-	m_stale = solution.stale;
-	m_response_pending = true;
-
+    m_stale = solution.stale;
+    m_response_pending = true;
 }
 
-void EthStratumClient::recvSocketData() {
+void EthStratumClient::recvSocketData()
+{
     if (m_conn->SecLevel() != SecureLevel::NONE)
     {
         async_read_until(*m_securesocket, m_recvBuffer, "\n",
@@ -1346,16 +1365,18 @@ void EthStratumClient::recvSocketData() {
     }
 }
 
-void EthStratumClient::onRecvSocketDataCompleted(const boost::system::error_code& ec, std::size_t bytes_transferred) {
-	
-	dev::setThreadName("stratum");
+void EthStratumClient::onRecvSocketDataCompleted(
+    const boost::system::error_code& ec, std::size_t bytes_transferred)
+{
+    dev::setThreadName("stratum");
 
-	// Due to the nature of io_service's queue and
-	// the implementation of the loop this event may trigger
-	// late after clean disconnection. Check status of connection
-	// before triggering all stack of calls
+    // Due to the nature of io_service's queue and
+    // the implementation of the loop this event may trigger
+    // late after clean disconnection. Check status of connection
+    // before triggering all stack of calls
 
-	if (!ec && bytes_transferred > 0) {
+    if (!ec && bytes_transferred > 0)
+    {
         // Extract received message
         std::istream is(&m_recvBuffer);
         std::string message;
@@ -1382,10 +1403,17 @@ void EthStratumClient::onRecvSocketDataCompleted(const boost::system::error_code
             recvSocketData();
         }
     }
-	else
-	{
+    else
+    {
         if (isConnected())
         {
+            if (m_authpending.load(std::memory_order_relaxed))
+            {
+                cwarn << "Error while waiting for authorization from pool";
+                cwarn << "Double check your pool credentials.";
+                m_conn->MarkUnrecoverable();
+            }
+
             if ((ec.category() == boost::asio::error::get_ssl_category()) &&
                 (ERR_GET_REASON(ec.value()) == SSL_RECEIVED_SHUTDOWN))
             {
@@ -1402,10 +1430,11 @@ void EthStratumClient::onRecvSocketDataCompleted(const boost::system::error_code
             m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
         }
     }
-
 }
 
-void EthStratumClient::sendSocketData(Json::Value const & jReq) {
+void EthStratumClient::sendSocketData(Json::Value const& jReq)
+{
+
     if (!isConnected())
         return;
 
@@ -1432,7 +1461,8 @@ void EthStratumClient::sendSocketData(Json::Value const & jReq) {
     }
 }
 
-void EthStratumClient::onSendSocketDataCompleted(const boost::system::error_code& ec) {
+void EthStratumClient::onSendSocketDataCompleted(const boost::system::error_code& ec)
+{
     if (ec)
     {
         if ((ec.category() == boost::asio::error::get_ssl_category()) &&
@@ -1451,9 +1481,9 @@ void EthStratumClient::onSendSocketDataCompleted(const boost::system::error_code
     }
 }
 
-void EthStratumClient::onSSLShutdownCompleted(const boost::system::error_code& ec) {
+void EthStratumClient::onSSLShutdownCompleted(const boost::system::error_code& ec)
+{
     (void)ec;
     // cnote << "onSSLShutdownCompleted Error code is : " << ec.message();
     m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect_finalize, this)));
 }
-

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -1050,7 +1050,8 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
     }
 
     /*
-    
+    
+
     Handle unsolicited messages FROM pool AKA notifications
 
     NOTE !

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -27,8 +27,9 @@ public:
 	EthStratumClient(boost::asio::io_service & io_service, int worktimeout, int responsetimeout, const string& email, bool submitHashrate);
 	~EthStratumClient();
 
-	void connect() override;
-	void disconnect() override;
+    void init_socket();
+    void connect() override;
+    void disconnect() override;
 	
 	// Connected and Connection Statuses
 	bool isConnected() override { return m_connected.load(std::memory_order_relaxed) && !isPendingState(); }
@@ -69,8 +70,9 @@ private:
     string m_user;    // Only user part
     string m_worker;  // eth-proxy only; No ! It's for all !!!
 
-    std::atomic<bool> m_disconnecting = { false };
-	std::atomic<bool> m_connecting = { false };
+    std::atomic<bool> m_disconnecting = {false};
+    std::atomic<bool> m_connecting = {false};
+    std::atomic<bool> m_authpending = {false};
 
 	// seconds to trigger a work_timeout (overwritten in constructor)
 	int m_worktimeout;


### PR DESCRIPTION
Detecting proper stratum mode is a try-and-error process.
Unfortunately there's not a unified standard implemented by pools to handle errors.

This PR enforces a standard on ethminer's side by :
1. Connect socket. If error ... try next available endpoint.
2. Send out the method under test
3. Waiting for any event which imply test failure. If none go to step 6
4. Failing events may be : explicit trasmission of json message with error and / or connection drop on pool's side and or any kind of timeout.
5. Disconnect socket connection and reconnect. Goto point 2.
6. Mark the found stratum mode as confirmed on connection object.

If, during the connection rotation due to failovers, an already used connection is set to current **and** it has stratum protocol marked as confirmed the autodetection phase is skipped and conversation starts immediately with the previously detected protocol.

Under these circumstances had to define a difference among "socket" connection and "application" connection. In previous versions of ethminer the socket connected event was enough to start farm. 
In this PR farm is NOT started (thus PoolManager does not trigger the OnConnected handler) until the authentication stack of the protocol is complete.

Tested succesfully on theese pools:

tw.sparkpool.com:3333
daggerhashimoto.eu.nicehash.com:3353
eth.anorak.tech:8004
eth.f2pool.com
eu1.nanopool.org:9999
etp.dodopool.com:8008 (metaverse)
europe.ethash-hub.miningpoolhub.com:17020
eth-us.maxhash.org:8011
eth.2miners.ru:2020

**Please do some more tests on other pools before merging**

If all is ok next steps are to be taken to simplify user's life with ethminer :

* Remove schemes stratum1 and stratum2 from -P argument. It should be always "stratum"
* ...
* ...