### PR TITLE
Fix false duplicate jobs when using stratum 2

### DIFF
--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -117,8 +117,6 @@ public:
 
 		// Set work to each miner
 		Guard l(x_minerWork);
-		if (_wp.header == m_work.header && _wp.startNonce == m_work.startNonce)
-			return;
 		m_work = _wp;
 		for (auto const& m: m_miners)
 			m->setWork(m_work);

--- a/libpoolprotocols/PoolClient.h
+++ b/libpoolprotocols/PoolClient.h
@@ -43,9 +43,9 @@ namespace dev
 			using SolutionRejected = std::function<void(bool const&)>;
 			using Disconnected = std::function<void()>;
 			using Connected = std::function<void()>;
-			using WorkReceived = std::function<void(WorkPackage const&, bool checkForDuplicates)>;
+            using WorkReceived = std::function<void(WorkPackage const&)>;
 
-			void onSolutionAccepted(SolutionAccepted const& _handler) { m_onSolutionAccepted = _handler; }
+            void onSolutionAccepted(SolutionAccepted const& _handler) { m_onSolutionAccepted = _handler; }
 			void onSolutionRejected(SolutionRejected const& _handler) { m_onSolutionRejected = _handler; }
 			void onDisconnected(Disconnected const& _handler) { m_onDisconnected = _handler; }
 			void onConnected(Connected const& _handler) { m_onConnected = _handler; }

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -67,19 +67,17 @@ PoolManager::PoolManager(boost::asio::io_service& io_service, PoolClient* client
 
 	});
 
-	p_client->onWorkReceived([&](WorkPackage const& wp, bool check_for_duplicates)
-	{
-		if (check_for_duplicates) {
-			for (auto h : m_headers)
-				if (h == wp.header)
-				{
-					cwarn << EthYellow "Duplicate job #" << wp.header.abridged() << " discarded" EthReset;
-					return;
-				}
-		}
-		m_headers.push_back(wp.header);
+    p_client->onWorkReceived([&](WorkPackage const& wp) {
+        for (auto h : m_headers)
+            if (h == wp.header)
+            {
+                cwarn << EthYellow "Duplicate job #" << wp.header.abridged()
+                      << " discarded" EthReset;
+                return;
+            }
+        m_headers.push_back(wp.header);
 		if (m_headers.size() > 4)
-				m_headers.pop_front();
+            m_headers.pop_front();
 
 		cnote << "Job: " EthWhite "#"<< wp.header.abridged() << EthReset " " << m_connections.at(m_activeConnectionIdx).Host()
 			<< p_client->ActiveEndPoint();
@@ -101,10 +99,9 @@ PoolManager::PoolManager(boost::asio::io_service& io_service, PoolClient* client
 		}
 
 		m_farm.setWork(wp);
-		
-	});
+    });
 
-	p_client->onSolutionAccepted([&](bool const& stale)
+    p_client->onSolutionAccepted([&](bool const& stale)
 	{
 		using namespace std::chrono;
 		milliseconds ms(0);

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -239,12 +239,9 @@ void PoolManager::workLoop()
                         }
                     }
                     m_connections.clear();
-                    if (!m_connections_copy.empty())
+                    for (unsigned i = 0; i < m_connections_copy.size(); i++)
                     {
-                        for (unsigned i = 0; i < m_connections_copy.size(); i++)
-                        {
-                            m_connections.push_back(m_connections_copy.at(i));
-                        }
+                        m_connections.push_back(m_connections_copy.at(i));
                     }
 
 

--- a/libpoolprotocols/getwork/EthGetworkClient.cpp
+++ b/libpoolprotocols/getwork/EthGetworkClient.cpp
@@ -121,7 +121,7 @@ void EthGetworkClient::workLoop()
 
                     if (m_onWorkReceived)
                     {
-                        m_onWorkReceived(m_prevWorkPackage, true);
+                        m_onWorkReceived(m_prevWorkPackage);
                     }
                 }
             }

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -1116,7 +1116,7 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
 
                         if (m_onWorkReceived)
                         {
-                            m_onWorkReceived(m_current, true);
+                            m_onWorkReceived(m_current);
                         }
                     }
                 }
@@ -1149,7 +1149,7 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
 
                             if (m_onWorkReceived)
                             {
-                                m_onWorkReceived(m_current, true);
+                                m_onWorkReceived(m_current);
                             }
                         }
                     }
@@ -1168,10 +1168,6 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
                 diffToTarget((uint32_t*)m_nextWorkBoundary.data(), nextWorkDifficulty);
                 cnote << "Difficulty set to " EthWhite << nextWorkDifficulty
                       << EthReset " (nicehash)";
-                if (m_onWorkReceived && (m_current.epoch != -1))
-                {
-                    m_onWorkReceived(m_current, false);
-                }
             }
         }
         else if (_method == "mining.set_extranonce" &&
@@ -1182,10 +1178,6 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
             {
                 std::string enonce = jPrm.get((Json::Value::ArrayIndex)0, "").asString();
                 processExtranonce(enonce);
-                if (m_onWorkReceived && (m_current.epoch != -1))
-                {
-                    m_onWorkReceived(m_current, false);
-                }
             }
         }
         else if (_method == "client.get_version")

--- a/libpoolprotocols/testing/SimulateClient.cpp
+++ b/libpoolprotocols/testing/SimulateClient.cpp
@@ -101,8 +101,8 @@ void SimulateClient::workLoop()
 					current.header = h256::random();
 					current.boundary = genesis.boundary();
 
-					m_onWorkReceived(current, false);
-				}
+                    m_onWorkReceived(current);
+                }
 			}
 			else {
 				this_thread::sleep_for(chrono::milliseconds(100));


### PR DESCRIPTION
- We should not resubmit the current job upon receiving a new
  difficulty or extranonce from stratum 2. Theses changes only
  apply to the next job received.