### PR TITLE
Remove unused variable.

### DIFF
--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -131,7 +131,7 @@ public:
 			{
 				outport=std::stoi(portstr);
 			}
-			catch(const std::out_of_range& ex)
+			catch(const std::out_of_range)
 			{
 				out_of_int_range=true;
 			}


### PR DESCRIPTION
Remove compiler warning [warning C4101: 'ex': unreferenced local variable (see Line 982)](https://ci.appveyor.com/project/ethereum-mining/ethminer/build/1937#L982)