### PR TITLE
Rearrange includes - fixes gcc-5 compile error

### DIFF
--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -15,9 +15,12 @@
     along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <ethminer/buildinfo.h>
-
 #include <CLI/CLI.hpp>
+
+#include <ethminer/buildinfo.h>
+#if ETH_DBUS
+#include <ethminer/DBusInt.h>
+#endif
 
 #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
 #define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
@@ -51,10 +54,6 @@ struct MiningChannel : public LogChannel
 };
 
 #define minelog clog(MiningChannel)
-
-#if ETH_DBUS
-#include <ethminer/DBusInt.h>
-#endif
 
 bool g_running = false;
 

--- a/libapicore/ApiServer.h
+++ b/libapicore/ApiServer.h
@@ -1,12 +1,14 @@
 #pragma once
 
-#include <json/json.h>
-#include <libethcore/Farm.h>
-#include <libethcore/Miner.h>
-#include <libpoolprotocols/PoolManager.h>
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
+
+#include <json/json.h>
+
+#include <libethcore/Farm.h>
+#include <libethcore/Miner.h>
+#include <libpoolprotocols/PoolManager.h>
 
 using namespace dev;
 using namespace dev::eth;

--- a/libapicore/httpServer.cpp
+++ b/libapicore/httpServer.cpp
@@ -1,15 +1,13 @@
-#include "httpServer.h"
-#include "libdevcore/Common.h"
-#include "libdevcore/Log.h"
-
-#include <ethminer/buildinfo.h>
-
-#include <mongoose/mongoose.h>
-
 #include <limits.h>
 #include <chrono>
 #include <thread>
 
+#include <mongoose/mongoose.h>
+
+#include "ethminer/buildinfo.h"
+#include "httpServer.h"
+#include "libdevcore/Common.h"
+#include "libdevcore/Log.h"
 
 #ifndef HOST_NAME_MAX
 #define HOST_NAME_MAX 255

--- a/libapicore/httpServer.h
+++ b/libapicore/httpServer.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <libethcore/Farm.h>
 #include <thread>
+
+#include <libethcore/Farm.h>
 
 class httpServer
 {

--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -9,10 +9,10 @@
 
 #include "vector_ref.h"
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 #include <string>
 #include <vector>
+
+#include <boost/multiprecision/cpp_int.hpp>
 
 using byte = uint8_t;
 

--- a/libdevcore/CommonData.cpp
+++ b/libdevcore/CommonData.cpp
@@ -19,9 +19,10 @@
  * @date 2014
  */
 
+#include <cstdlib>
+
 #include "CommonData.h"
 #include "Exceptions.h"
-#include <cstdlib>
 
 using namespace std;
 using namespace dev;

--- a/libdevcore/CommonData.h
+++ b/libdevcore/CommonData.h
@@ -23,13 +23,14 @@
 
 #pragma once
 
-#include "Common.h"
 #include <algorithm>
 #include <cstring>
 #include <string>
 #include <type_traits>
 #include <unordered_set>
 #include <vector>
+
+#include "Common.h"
 
 namespace dev
 {

--- a/libdevcore/Exceptions.h
+++ b/libdevcore/Exceptions.h
@@ -21,12 +21,14 @@
 
 #pragma once
 
-#include "CommonData.h"
-#include "FixedHash.h"
-#include <boost/exception/all.hpp>
-#include <boost/throw_exception.hpp>
 #include <exception>
 #include <string>
+
+#include <boost/exception/all.hpp>
+#include <boost/throw_exception.hpp>
+
+#include "CommonData.h"
+#include "FixedHash.h"
 
 namespace dev
 {

--- a/libdevcore/FixedHash.cpp
+++ b/libdevcore/FixedHash.cpp
@@ -19,8 +19,9 @@
  * @date 2014
  */
 
-#include "FixedHash.h"
 #include <boost/algorithm/string.hpp>
+
+#include "FixedHash.h"
 
 using namespace std;
 using namespace dev;

--- a/libdevcore/FixedHash.h
+++ b/libdevcore/FixedHash.h
@@ -23,11 +23,12 @@
 
 #pragma once
 
-#include "CommonData.h"
 #include <algorithm>
 #include <array>
 #include <cstdint>
 #include <random>
+
+#include "CommonData.h"
 
 namespace dev
 {

--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -23,7 +23,9 @@
 #ifdef __APPLE__
 #include <pthread.h>
 #endif
+
 #include "Guards.h"
+
 using namespace std;
 using namespace dev;
 

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -23,13 +23,14 @@
 
 #pragma once
 
+#include <chrono>
+#include <ctime>
+
 #include "Common.h"
 #include "CommonData.h"
 #include "FixedHash.h"
 #include "Terminal.h"
 #include "vector_ref.h"
-#include <chrono>
-#include <ctime>
 
 /// The logging system's current verbosity.
 extern int g_logVerbosity;

--- a/libdevcore/RLP.cpp
+++ b/libdevcore/RLP.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "RLP.h"
+
 using namespace std;
 using namespace dev;
 

--- a/libdevcore/RLP.h
+++ b/libdevcore/RLP.h
@@ -23,15 +23,16 @@
 
 #pragma once
 
-#include "Common.h"
-#include "Exceptions.h"
-#include "FixedHash.h"
-#include "vector_ref.h"
 #include <array>
 #include <exception>
 #include <iomanip>
 #include <iostream>
 #include <vector>
+
+#include "Common.h"
+#include "Exceptions.h"
+#include "FixedHash.h"
+#include "vector_ref.h"
 
 namespace dev
 {

--- a/libdevcore/Worker.cpp
+++ b/libdevcore/Worker.cpp
@@ -19,11 +19,12 @@
  * @date 2014
  */
 
-#include "Worker.h"
-
-#include "Log.h"
 #include <chrono>
 #include <thread>
+
+#include "Log.h"
+#include "Worker.h"
+
 using namespace std;
 using namespace dev;
 

--- a/libdevcore/Worker.h
+++ b/libdevcore/Worker.h
@@ -21,11 +21,12 @@
 
 #pragma once
 
-#include "Guards.h"
 #include <atomic>
 #include <cassert>
 #include <string>
 #include <thread>
+
+#include "Guards.h"
 
 namespace dev
 {

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -3,11 +3,12 @@
 /// @file
 /// @copyright GNU General Public License
 
+#include <boost/dll.hpp>
+
+#include <ethash/ethash.hpp>
+
 #include "CLMiner.h"
 #include "ethash.h"
-
-#include <boost/dll.hpp>
-#include <ethash/ethash.hpp>
 
 using namespace dev;
 using namespace eth;

--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -5,10 +5,11 @@
 
 #pragma once
 
+#include <fstream>
+
 #include <libdevcore/Worker.h>
 #include <libethcore/EthashAux.h>
 #include <libethcore/Miner.h>
-#include <fstream>
 
 #pragma GCC diagnostic push
 #if __GNUC__ >= 6

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -15,9 +15,9 @@ You should have received a copy of the GNU General Public License
 along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "CUDAMiner.h"
-
 #include <ethash/ethash.hpp>
+
+#include "CUDAMiner.h"
 
 using namespace std;
 using namespace dev;

--- a/libethash-cuda/ethash_cuda_miner_kernel.h
+++ b/libethash-cuda/ethash_cuda_miner_kernel.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <cuda_runtime.h>
 #include <stdint.h>
 #include <sstream>
 #include <stdexcept>
 #include <string>
+
+#include <cuda_runtime.h>
 
 // It is virtually impossible to get more than
 // one solution per stream hash calculation

--- a/libethcore/BlockHeader.h
+++ b/libethcore/BlockHeader.h
@@ -4,10 +4,10 @@
 
 #pragma once
 
-#include "Exceptions.h"
-
 #include <libdevcore/Common.h>
 #include <libdevcore/RLP.h>
+
+#include "Exceptions.h"
 
 namespace dev
 {

--- a/libethcore/EthashAux.h
+++ b/libethcore/EthashAux.h
@@ -17,11 +17,10 @@
 
 #pragma once
 
-#include "BlockHeader.h"
-
 #include <libdevcore/Worker.h>
-
 #include <ethash/ethash.hpp>
+
+#include "BlockHeader.h"
 
 namespace dev
 {

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -21,18 +21,21 @@
 
 #pragma once
 
+#include <atomic>
+#include <list>
+#include <thread>
+
+#include <boost/asio.hpp>
+#include <boost/bind.hpp>
+
 #include <json/json.h>
+
 #include <libdevcore/Common.h>
 #include <libdevcore/Worker.h>
 #include <libethcore/BlockHeader.h>
 #include <libethcore/Miner.h>
 #include <libhwmon/wrapadl.h>
 #include <libhwmon/wrapnvml.h>
-#include <boost/asio.hpp>
-#include <boost/bind.hpp>
-#include <atomic>
-#include <list>
-#include <thread>
 #if defined(__linux)
 #include <libhwmon/wrapamdsysfs.h>
 #endif

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -21,17 +21,18 @@
 
 #pragma once
 
-#include "EthashAux.h"
-#include <libdevcore/Common.h>
-#include <libdevcore/Log.h>
-#include <libdevcore/Worker.h>
-#include <boost/timer.hpp>
 #include <list>
 #include <string>
 #include <thread>
 
-#define MINER_WAIT_STATE_WORK 1
+#include <boost/timer.hpp>
 
+#include "EthashAux.h"
+#include <libdevcore/Common.h>
+#include <libdevcore/Log.h>
+#include <libdevcore/Worker.h>
+
+#define MINER_WAIT_STATE_WORK 1
 
 #define DAG_LOAD_MODE_PARALLEL 0
 #define DAG_LOAD_MODE_SEQUENTIAL 1

--- a/libhwmon/wrapadl.cpp
+++ b/libhwmon/wrapadl.cpp
@@ -3,12 +3,14 @@
  *
  * By Philipp Andreas - github@smurfy.de
  */
-#include "wrapadl.h"
-#include "wraphelper.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <string>
+
+#include "wrapadl.h"
+#include "wraphelper.h"
 
 #if defined(__cplusplus)
 extern "C" {

--- a/libhwmon/wrapamdsysfs.cpp
+++ b/libhwmon/wrapamdsysfs.cpp
@@ -7,6 +7,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
+#if defined(__linux)
+#include <dirent.h>
+#endif
+
 #include <algorithm>
 #include <climits>
 #include <cstdint>
@@ -16,9 +20,6 @@
 #include <limits>
 #include <regex>
 #include <string>
-#if defined(__linux)
-#include <dirent.h>
-#endif
 
 #include <libdevcore/Log.h>
 

--- a/libhwmon/wrapnvml.cpp
+++ b/libhwmon/wrapnvml.cpp
@@ -17,13 +17,14 @@
  * Philipp Andreas - github@smurfy.de
  */
 
-#include "wrapnvml.h"
-#include "wraphelper.h"
 #include <stdio.h>
 #include <stdlib.h>
 #if ETH_ETHASHCUDA
 #include "cuda_runtime.h"
 #endif
+
+#include "wraphelper.h"
+#include "wrapnvml.h"
 
 #if defined(__cplusplus)
 extern "C" {

--- a/libpoolprotocols/PoolClient.h
+++ b/libpoolprotocols/PoolClient.h
@@ -1,11 +1,12 @@
 #pragma once
 
+#include <queue>
+
 #include <boost/asio/ip/address.hpp>
 
 #include <libethcore/Farm.h>
 #include <libethcore/Miner.h>
 #include <libpoolprotocols/PoolURI.h>
-#include <queue>
 
 using namespace std;
 

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -1,5 +1,6 @@
-#include "PoolManager.h"
 #include <chrono>
+
+#include "PoolManager.h"
 
 using namespace std;
 using namespace dev;

--- a/libpoolprotocols/PoolManager.h
+++ b/libpoolprotocols/PoolManager.h
@@ -1,11 +1,14 @@
 #pragma once
 
+#include <iostream>
+
+#include <boost/lockfree/queue.hpp>
+
 #include <json/json.h>
+
 #include <libdevcore/Worker.h>
 #include <libethcore/Farm.h>
 #include <libethcore/Miner.h>
-#include <boost/lockfree/queue.hpp>
-#include <iostream>
 
 #include "PoolClient.h"
 

--- a/libpoolprotocols/PoolURI.cpp
+++ b/libpoolprotocols/PoolURI.cpp
@@ -1,10 +1,11 @@
-#include <libpoolprotocols/PoolURI.h>
+#include <iostream>
+#include <map>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/optional/optional_io.hpp>
-#include <map>
 #include <network/uri/detail/decode.hpp>
 
-#include <iostream>
+#include <libpoolprotocols/PoolURI.h>
 
 using namespace dev;
 

--- a/libpoolprotocols/PoolURI.h
+++ b/libpoolprotocols/PoolURI.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <network/uri.hpp>
 #include <string>
+
+#include <network/uri.hpp>
 
 // A simple URI parser specifically for mining pool endpoints
 namespace dev

--- a/libpoolprotocols/getwork/EthGetworkClient.cpp
+++ b/libpoolprotocols/getwork/EthGetworkClient.cpp
@@ -1,8 +1,8 @@
 #include "EthGetworkClient.h"
 
-#include <ethash/ethash.hpp>
-
 #include <chrono>
+
+#include <ethash/ethash.hpp>
 
 using namespace std;
 using namespace dev;

--- a/libpoolprotocols/getwork/EthGetworkClient.h
+++ b/libpoolprotocols/getwork/EthGetworkClient.h
@@ -1,10 +1,13 @@
 #pragma once
 
-#include "../PoolClient.h"
+#include <iostream>
+
 #include "jsonrpc_getwork.h"
 #include <jsonrpccpp/client/connectors/httpclient.h>
+
 #include <libdevcore/Worker.h>
-#include <iostream>
+
+#include "../PoolClient.h"
 
 using namespace std;
 using namespace dev;

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -1,9 +1,8 @@
-#include "EthStratumClient.h"
-#include <libdevcore/Log.h>
-
 #include <ethminer/buildinfo.h>
-
+#include <libdevcore/Log.h>
 #include <ethash/ethash.hpp>
+
+#include "EthStratumClient.h"
 
 #ifdef _WIN32
 #include <wincrypt.h>

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -1,18 +1,21 @@
 #pragma once
 
-#include "../PoolClient.h"
+#include <iostream>
+
+#include <boost/array.hpp>
+#include <boost/asio.hpp>
+#include <boost/asio/ssl.hpp>
+#include <boost/bind.hpp>
+
 #include <json/json.h>
+
 #include <libdevcore/FixedHash.h>
 #include <libdevcore/Log.h>
 #include <libethcore/EthashAux.h>
 #include <libethcore/Farm.h>
 #include <libethcore/Miner.h>
-#include <boost/array.hpp>
-#include <boost/asio.hpp>
-#include <boost/asio/ssl.hpp>
-#include <boost/bind.hpp>
-#include <iostream>
 
+#include "../PoolClient.h"
 
 using namespace std;
 using namespace dev;

--- a/libpoolprotocols/testing/SimulateClient.cpp
+++ b/libpoolprotocols/testing/SimulateClient.cpp
@@ -1,5 +1,6 @@
-#include "SimulateClient.h"
 #include <chrono>
+
+#include "SimulateClient.h"
 
 using namespace std;
 using namespace std::chrono;

--- a/libpoolprotocols/testing/SimulateClient.h
+++ b/libpoolprotocols/testing/SimulateClient.h
@@ -1,11 +1,13 @@
 #pragma once
 
-#include "../PoolClient.h"
+#include <iostream>
+
 #include <libdevcore/Worker.h>
 #include <libethcore/EthashAux.h>
 #include <libethcore/Farm.h>
 #include <libethcore/Miner.h>
-#include <iostream>
+
+#include "../PoolClient.h"
 
 using namespace std;
 using namespace dev;


### PR DESCRIPTION
- group and separate #includes such that clang-format doesn't
  sort them.