### PR TITLE
osx crash fix on opencl

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -287,8 +287,8 @@ struct SearchResults
 
 void CLMiner::workLoop()
 {
-    // Memory for zero-ing buffers. Cannot be static because crashes on macOS.
-    uint32_t const static zerox3[3] = {0, 0, 0};
+    // Memory for zero-ing buffers. Cannot be static or const because crashes on macOS.
+    uint32_t zerox3[3] = {0, 0, 0};
 
     uint64_t startNonce = 0;
 
@@ -442,7 +442,8 @@ void CLMiner::workLoop()
 
 void CLMiner::kick_miner()
 {
-    static const uint32_t one = 1;
+    // Memory for abort Cannot be static because crashes on macOS.
+    const uint32_t one = 1;
     if (m_abortqueue.size())
         m_abortqueue[0].enqueueWriteBuffer(
             m_searchBuffer[0], CL_TRUE, offsetof(SearchResults, abort), sizeof(one), &one);


### PR DESCRIPTION
Fixes the problem described here: #1446 

It seems osx does not like statics at all and if its an array it does not like const too.

I also tried keeping the const and using an reference on ``enqueueWriteBuffer`` for zerox3 but that did not work either.