### PR TITLE
Remove dependency on buggy version of network-uri package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,6 @@ find_package(jsoncpp CONFIG REQUIRED)
 hunter_add_package(libjson-rpc-cpp)
 find_package(libjson-rpc-cpp CONFIG REQUIRED)
 
-hunter_add_package(CppNetlibUri)
-find_package(CppNetlibUri CONFIG REQUIRED)
-
 hunter_add_package(ethash)
 find_package(ethash CONFIG REQUIRED)
 

--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -565,12 +565,8 @@ public:
         {
             if (url == "exit")  // add fake scheme and port to 'exit' url
                 url = "stratum+tcp://-:x@exit:0";
-            URI uri;
-            try
-            {
-                uri = url;
-            }
-            catch (...)
+            URI uri(url);
+            if (!uri.Valid())
             {
                 cerr << endl << "Bad endpoint address: " << url << "\n\n";
                 exit(-1);

--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -481,10 +481,15 @@ void ApiConnection::processRequest(Json::Value& jRequest, Json::Value& jResponse
         if (!getRequestValue("uri", sUri, jRequestParams, false, jResponse))
             return;
 
-        dev::URI uri;
         try
         {
-            uri = sUri;
+            URI uri(sUri);
+            if (!uri.Valid())
+            {
+                jResponse["error"]["code"] = -422;
+                jResponse["error"]["message"] = ("Invalid URI " + uri.String());
+                return;
+            }
             if (!uri.KnownScheme())
             {
                 jResponse["error"]["code"] = -422;

--- a/libpoolprotocols/CMakeLists.txt
+++ b/libpoolprotocols/CMakeLists.txt
@@ -11,5 +11,5 @@ hunter_add_package(OpenSSL)
 find_package(OpenSSL REQUIRED)
 
 add_library(poolprotocols ${SOURCES})
-target_link_libraries(poolprotocols PRIVATE devcore ethminer-buildinfo ethash::ethash libjson-rpc-cpp::client Boost::system jsoncpp_lib_static OpenSSL::SSL OpenSSL::Crypto network-uri)
+target_link_libraries(poolprotocols PRIVATE devcore ethminer-buildinfo ethash::ethash libjson-rpc-cpp::client Boost::system jsoncpp_lib_static OpenSSL::SSL OpenSSL::Crypto)
 target_include_directories(poolprotocols PRIVATE ..)

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -378,7 +378,7 @@ Json::Value PoolManager::getConnectionsJson()
         Json::Value JConn;
         JConn["index"] = (int)i;
         JConn["active"] = (i == m_activeConnectionIdx ? true : false);
-        JConn["uri"] = m_connections[i].string();
+        JConn["uri"] = m_connections[i].String();
         jRes.append(JConn);
     }
 

--- a/libpoolprotocols/PoolURI.cpp
+++ b/libpoolprotocols/PoolURI.cpp
@@ -1,9 +1,26 @@
+/*
+    This file is part of cpp-ethereum.
+
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <algorithm>
 #include <iostream>
 #include <map>
+#include <sstream>
 
-#include <boost/algorithm/string.hpp>
-#include <boost/optional/optional_io.hpp>
-#include <network/uri/detail/decode.hpp>
+#include <string.h>
 
 #include <libpoolprotocols/PoolURI.h>
 
@@ -31,51 +48,235 @@ static std::map<std::string, SchemeAttributes> s_schemes = {
     {"stratum2+ssl", {ProtocolFamily::STRATUM, SecureLevel::TLS12, 2}},
     {"http", {ProtocolFamily::GETWORK, SecureLevel::NONE, 0}}};
 
+// Check whether the character is permitted in scheme string
+static bool is_scheme_char(int c)
+{
+    return isalpha(c) || isdigit(c) || ('+' == c) || ('-' == c) || ('.' == c);
+}
+
 URI::URI(const std::string uri)
 {
-    std::string u = uri;
-    if (u.find("://") == std::string::npos)
-        u = std::string("unspecified://") + u;
-    m_uri = network::uri(u);
+    const char* tmpstr;
+    const char* curstr;
+    unsigned len;
+    bool userpass_flag;
+    bool ipv6_flag;
+
+    m_valid = true;
+    m_path.clear();
+    m_query.clear();
+    m_fragment.clear();
+    m_username.clear();
+    m_password.clear();
+    m_port = 0;
+
+    m_uri = uri;
+    curstr = m_uri.c_str();
+
+    // <scheme>:<scheme-specific-part>
+    // <scheme> := [a-z\+\-\.]+
+    //             upper case = lower case for resiliency
+    // Read scheme
+    tmpstr = strchr(curstr, ':');
+    if (nullptr == tmpstr)
+    {
+        // Not found
+        m_valid = false;
+        return;
+    }
+    // Get the scheme length
+    len = tmpstr - curstr;
+    // Check character restrictions
+    for (unsigned i = 0; i < len; i++)
+    {
+        if (!is_scheme_char(curstr[i]))
+        {
+            // Invalid
+            m_valid = false;
+            return;
+        }
+    }
+    // Copy the scheme to the string
+    // all lowecase
+    m_scheme.append(curstr, len);
+    std::transform(m_scheme.begin(), m_scheme.end(), m_scheme.begin(), ::tolower);
+
+    // Skip ':'
+    tmpstr++;
+    curstr = tmpstr;
+
+    // //<user>:<password>@<host>:<port>/<url-path>
+    // Any ":", "@" and "/" must be encoded.
+    // Eat "//"
+    for (unsigned i = 0; i < 2; i++)
+    {
+        if ('/' != *curstr)
+        {
+            m_valid = false;
+            return;
+        }
+        curstr++;
+    }
+
+    // Check if the user (and password) are specified.
+    userpass_flag = false;
+    tmpstr = curstr;
+    while ('\0' != *tmpstr)
+    {
+        if ('@' == *tmpstr)
+        {
+            // Username and password are specified
+            userpass_flag = true;
+            break;
+        }
+        else if ('/' == *tmpstr)
+        {
+            // End of <host>:<port> specification
+            userpass_flag = false;
+            break;
+        }
+        tmpstr++;
+    }
+
+    // User and password specification
+    tmpstr = curstr;
+    if (userpass_flag)
+    {
+        // Read username
+        while (('\0' != *tmpstr) && (':' != *tmpstr) && ('@' != *tmpstr))
+            tmpstr++;
+        len = tmpstr - curstr;
+        m_username.append(curstr, len);
+        // Proceed current pointer
+        curstr = tmpstr;
+        if (':' == *curstr)
+        {
+            // Skip ':'
+            curstr++;
+            // Read password
+            tmpstr = curstr;
+            while (('\0' != *tmpstr) && ('@' != *tmpstr))
+                tmpstr++;
+            len = tmpstr - curstr;
+            m_password.append(curstr, len);
+            curstr = tmpstr;
+        }
+        // Skip '@'
+        if ('@' != *curstr)
+        {
+            m_valid = false;
+            return;
+        }
+        curstr++;
+    }
+
+    ipv6_flag = '[' == *curstr;
+    // Proceed on by delimiters with reading host
+    tmpstr = curstr;
+    while ('\0' != *tmpstr)
+    {
+        if (ipv6_flag && ']' == *tmpstr)
+        {
+            // End of IPv6 address.
+            tmpstr++;
+            break;
+        }
+        else if (!ipv6_flag && ((':' == *tmpstr) || ('/' == *tmpstr)))
+            // Port number is specified.
+            break;
+        tmpstr++;
+    }
+    len = tmpstr - curstr;
+    m_host.append(curstr, len);
+    curstr = tmpstr;
+
+    // Is port number specified?
+    if (':' == *curstr)
+    {
+        curstr++;
+        // Read port number
+        tmpstr = curstr;
+        while (('\0' != *tmpstr) && ('/' != *tmpstr))
+            tmpstr++;
+        len = tmpstr - curstr;
+        std::string tempstr;
+        tempstr.append(curstr, len);
+        std::stringstream ss(tempstr);
+        ss >> m_port;
+        if (ss.fail())
+        {
+            m_valid = false;
+            return;
+        }
+        curstr = tmpstr;
+    }
+
+    // End of the string
+    if ('\0' == *curstr)
+        return;
+
+    // Skip '/'
+    if ('/' != *curstr)
+    {
+        m_valid = false;
+        return;
+    }
+    curstr++;
+
+    // Parse path
+    tmpstr = curstr;
+    while (('\0' != *tmpstr) && ('#' != *tmpstr) && ('?' != *tmpstr))
+        tmpstr++;
+    len = tmpstr - curstr;
+    m_path.append(curstr, len);
+    curstr = tmpstr;
+
+    // Is query specified?
+    if ('?' == *curstr)
+    {
+        // Skip '?'
+        curstr++;
+        // Read query
+        tmpstr = curstr;
+        while (('\0' != *tmpstr) && ('#' != *tmpstr))
+            tmpstr++;
+        len = tmpstr - curstr;
+        m_query.append(curstr, len);
+        curstr = tmpstr;
+    }
+
+    // Is fragment specified?
+    if ('#' == *curstr)
+    {
+        // Skip '#'
+        curstr++;
+        // Read fragment
+        tmpstr = curstr;
+        while ('\0' != *tmpstr)
+            tmpstr++;
+        len = tmpstr - curstr;
+        m_fragment.append(curstr, len);
+    }
 }
 
 bool URI::KnownScheme()
 {
-    if (!m_uri.scheme())
-        return false;
-    std::string s(*m_uri.scheme());
-    boost::trim(s);
-    return s_schemes.find(s) != s_schemes.end();
+    return s_schemes.find(m_scheme) != s_schemes.end();
 }
 
 ProtocolFamily URI::Family() const
 {
-    if (!m_uri.scheme())
-        return ProtocolFamily::STRATUM;
-    std::string s(*m_uri.scheme());
-    s = network::detail::decode(s);
-    boost::trim(s);
-    return s_schemes[s].family;
+    return s_schemes[m_scheme].family;
 }
 
 unsigned URI::Version() const
 {
-    if (!m_uri.scheme())
-        return 0;
-    std::string s(*m_uri.scheme());
-    s = network::detail::decode(s);
-    boost::trim(s);
-    return s_schemes[s].version;
+    return s_schemes[m_scheme].version;
 }
 
 SecureLevel URI::SecLevel() const
 {
-    if (!m_uri.scheme())
-        return SecureLevel::NONE;
-    std::string s(*m_uri.scheme());
-    s = network::detail::decode(s);
-    boost::trim(s);
-    return s_schemes[s].secure;
+    return s_schemes[m_scheme].secure;
 }
 
 std::string URI::KnownSchemes(ProtocolFamily family)
@@ -84,79 +285,6 @@ std::string URI::KnownSchemes(ProtocolFamily family)
     for (const auto& s : s_schemes)
         if (s.second.family == family)
             schemes += s.first + " ";
-    boost::trim(schemes);
     return schemes;
 }
 
-std::string URI::Scheme() const
-{
-    if (!m_uri.scheme())
-        return "";
-    std::string s(*m_uri.scheme());
-    s = network::detail::decode(s);
-    boost::trim(s);
-    return s;
-}
-
-std::string URI::Host() const
-{
-    if (!m_uri.host())
-        return "";
-    std::string s(*m_uri.host());
-    s = network::detail::decode(s);
-    boost::trim(s);
-    return s;
-}
-
-std::string URI::Path() const
-{
-    if (!m_uri.path())
-        return "";
-    std::string s(*m_uri.path());
-    s = network::detail::decode(s);
-    boost::trim(s);
-    return s;
-}
-
-unsigned short URI::Port() const
-{
-    if (!m_uri.port())
-        return 0;
-    std::string s(*m_uri.port());
-    s = network::detail::decode(s);
-    boost::trim(s);
-    try
-    {
-        return (unsigned short)std::stoul(s.c_str());
-    }
-    catch (...)
-    {
-        return 0;
-    }
-}
-
-std::string URI::User() const
-{
-    if (!m_uri.user_info())
-        return "";
-    std::string s(*m_uri.user_info());
-    s = network::detail::decode(s);
-    boost::trim(s);
-    size_t f = s.find(":");
-    if (f == std::string::npos)
-        return s;
-    return s.substr(0, f);
-}
-
-std::string URI::Pass() const
-{
-    if (!m_uri.user_info())
-        return "";
-    std::string s(*m_uri.user_info());
-    s = network::detail::decode(s);
-    boost::trim(s);
-    size_t f = s.find(":");
-    if (f == std::string::npos)
-        return "";
-    return s.substr(f + 1);
-}

--- a/libpoolprotocols/PoolURI.h
+++ b/libpoolprotocols/PoolURI.h
@@ -1,8 +1,23 @@
+/*
+    This file is part of cpp-ethereum.
+
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 #pragma once
 
 #include <string>
-
-#include <network/uri.hpp>
 
 // A simple URI parser specifically for mining pool endpoints
 namespace dev
@@ -22,19 +37,20 @@ enum class ProtocolFamily
 class URI
 {
 public:
-    URI(){};
+    URI() = delete;
     URI(const std::string uri);
 
-    std::string Scheme() const;
-    std::string Host() const;
-    std::string Path() const;
-    unsigned short Port() const;
-    std::string User() const;
-    std::string Pass() const;
+    std::string Scheme() const { return m_scheme; }
+    std::string Host() const { return m_host; }
+    std::string Path() const { return m_path; }
+    unsigned short Port() const { return m_port; }
+    std::string User() const { return m_username; }
+    std::string Pass() const { return m_password; }
     SecureLevel SecLevel() const;
     ProtocolFamily Family() const;
     unsigned Version() const;
-    std::string string() { return m_uri.string(); }
+    std::string String() const { return m_uri; }
+    bool Valid() const { return m_valid; }
 
     bool KnownScheme();
 
@@ -52,9 +68,18 @@ public:
     void MarkUnrecoverable() { m_unrecoverable = true; }
 
 private:
-    network::uri m_uri;
     bool m_stratumModeConfirmed = false;
     unsigned m_stratumMode = 999;  // Initial value 999 means not tested yet
     bool m_unrecoverable = false;
+    std::string m_scheme;
+    std::string m_host;
+    unsigned short m_port;
+    std::string m_path;
+    std::string m_query;
+    std::string m_fragment;
+    std::string m_username;
+    std::string m_password;
+    std::string m_uri;
+    bool m_valid;
 };
 }  // namespace dev


### PR DESCRIPTION
- Third party support is useful when it works, but...
- Replace buggy network-uri with in-house URI parser.