### PR TITLE
Fix build error when compiling CUDA only.

### DIFF
--- a/ethminer/CMakeLists.txt
+++ b/ethminer/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
 hunter_add_package(CLI11)
 find_package(CLI11 CONFIG REQUIRED)
 
-target_link_libraries(ethminer PRIVATE ethcore poolprotocols devcore ethminer-buildinfo CLI11::CLI11 Boost::system)
+target_link_libraries(ethminer PRIVATE ethcore poolprotocols devcore ethminer-buildinfo CLI11::CLI11 Boost::filesystem Boost::system)
 
 if(ETHDBUS)
 	find_package(PkgConfig)


### PR DESCRIPTION
I think this should address
#1473 and #1466 
(As I can not reproduce the problem maybe it's depending on the installed hunter version - nothing else the used library should be included)