### PR TITLE
Remove unused variable

### DIFF
--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -1128,7 +1128,6 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
 
                     if (sHeaderHash != "" && sSeedHash != "" && sShareTarget != "")
                     {
-                        h256 headerHash = h256(sHeaderHash);
 
                         reset_work_timeout();
 


### PR DESCRIPTION
After removal of dup check headerHash becomes unused