### PR TITLE
moved dbusint include to after minelog definition

### DIFF
--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -18,9 +18,6 @@
 #include <CLI/CLI.hpp>
 
 #include <ethminer/buildinfo.h>
-#if ETH_DBUS
-#include <ethminer/DBusInt.h>
-#endif
 
 #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
 #define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
@@ -54,6 +51,10 @@ struct MiningChannel : public LogChannel
 };
 
 #define minelog clog(MiningChannel)
+
+#if ETH_DBUS
+#include <ethminer/DBusInt.h>
+#endif
 
 bool g_running = false;
 


### PR DESCRIPTION
This will fix issues on build running the `-DETHDBUS=ON` flag