### PR TITLE
Stop mining on API connection change

### DIFF
--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -336,6 +336,14 @@ void PoolManager::setActiveConnection(unsigned int idx)
     // Sets the active connection to the requested index
     if (idx != m_activeConnectionIdx)
     {
+
+        // Stop mining if applicable as we're switching
+        if (m_farm.isMining())
+        {
+            cnote << "Shutting down miners...";
+            m_farm.stop();
+        }
+
         m_activeConnectionIdx = idx;
         m_connectionAttempt = 0;
         p_client->disconnect();


### PR DESCRIPTION
When setting new active connection by API call shutdown mining as we do with regular connection switching due to failover