### PR TITLE
CI: Downgrade CUDA SDK to 9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,13 @@ before_install: |
     if [ "$TRAVIS_OS_NAME" = linux ]; then
       sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
       sudo apt-get -q update
-      sudo apt-get -qy install g++-7
+      sudo apt-get -qy install g++-6
       scripts/install_cmake.sh
       . scripts/install-cuda-ubuntu1604.sh
       pyenv global 3.6
       pip install --user requests gitpython
-      export CC=gcc-7
-      export CXX=g++-7
+      export CC=gcc-6
+      export CXX=g++-6
     elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
       HOMEBREW_NO_AUTO_UPDATE=1 brew install -q python3
       pip3 install -q requests gitpython

--- a/scripts/install-cuda-ubuntu1604.sh
+++ b/scripts/install-cuda-ubuntu1604.sh
@@ -10,7 +10,7 @@
 
 set -e
 
-export CUDA_VER=9.2.148-1
+export CUDA_VER=9.1.85-1
 sudo apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub
 wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_${CUDA_VER}_amd64.deb
 sudo dpkg -i cuda-repo-ubuntu1604_${CUDA_VER}_amd64.deb


### PR DESCRIPTION
This allows using older Nvidia drivers without any performance lost.