### PR TITLE
Farm automation

### DIFF
--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -742,7 +742,7 @@ private:
         genesis.setNumber(m_benchmarkBlock);
         genesis.setDifficulty(u256(1) << 64);
 
-        Farm f(m_io_service);
+        Farm f(m_io_service, m_show_hwmonitors, m_show_power);
         map<string, Farm::SealerDescriptor> sealers;
 #if ETH_ETHASHCL
         sealers["opencl"] = Farm::SealerDescriptor{&CLMiner::instances,
@@ -853,7 +853,7 @@ private:
         }
 
         // sealers, m_minerType
-        Farm f(m_io_service);
+        Farm f(m_io_service, m_show_hwmonitors, m_show_power);
         f.setSealers(sealers);
 
         PoolManager mgr(m_io_service, client, f, m_minerType, m_maxFarmRetries, m_failovertimeout);
@@ -905,7 +905,7 @@ private:
             }
             if (mgr.isConnected())
             {
-                auto mp = f.miningProgress(m_show_hwmonitors, m_show_power);
+                auto mp = f.miningProgress();
                 minelog << mp << ' ' << f.getSolutionStats() << ' ' << f.farmLaunchedFormatted();
 
 #if ETH_DBUS

--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -637,7 +637,7 @@ void ApiConnection::processRequest(Json::Value& jRequest, Json::Value& jResponse
         if (!getRequestValue("pause", pause, jRequestParams, false, jResponse))
             return;
 
-        WorkingProgress p = m_farm.miningProgress(false, false);
+        WorkingProgress p = m_farm.miningProgress();
         if (index >= p.miningIsPaused.size())
         {
             jResponse["error"]["code"] = -422;
@@ -773,7 +773,7 @@ Json::Value ApiConnection::getMinerStat1()
         steady_clock::now() - this->m_farm.farmLaunched());
 
     SolutionStats s = m_farm.getSolutionStats();
-    WorkingProgress p = m_farm.miningProgress(true);
+    WorkingProgress p = m_farm.miningProgress();
 
     ostringstream totalMhEth;
     ostringstream totalMhDcr;
@@ -836,7 +836,7 @@ Json::Value ApiConnection::getMinerStatHR()
         steady_clock::now() - this->m_farm.farmLaunched());
 
     SolutionStats s = m_farm.getSolutionStats();
-    WorkingProgress p = m_farm.miningProgress(true, true);
+    WorkingProgress p = m_farm.miningProgress();
 
     ostringstream version;
     ostringstream runtime;

--- a/libapicore/httpServer.cpp
+++ b/libapicore/httpServer.cpp
@@ -36,7 +36,7 @@ void httpServer::tableHeader(stringstream& ss, unsigned columns)
 void httpServer::getstat1(stringstream& ss)
 {
     using namespace std::chrono;
-    WorkingProgress p = m_farm->miningProgress(m_show_hwmonitors, m_show_power);
+    WorkingProgress p = m_farm->miningProgress();
     SolutionStats s = m_farm->getSolutionStats();
     tableHeader(ss, 5);
     ss << "<tr valign=top align=center style=background-color:Yellow>"

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -477,13 +477,13 @@ void CUDAMiner::search(
                 
                 // Pass the solution(s) for submission
                 uint64_t minerNonce;
-                h256 minerMix;
 
                 for (uint32_t i = 0; i < found_count; i++)
                 {
                     minerNonce = nonce_base + buffer->result[i].gid;
                     if (s_noeval)
                     {
+                        h256 minerMix;
                         memcpy(minerMix.data(), (void*)&buffer->result[i].mix,
                             sizeof(buffer->result[i].mix));
                         farm.submitProof(Solution{minerNonce, minerMix, w, m_new_work});

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -454,65 +454,66 @@ void CUDAMiner::search(
         {
             cudaStream_t stream = m_streams[current_index];
             buffer = m_search_buf[current_index];
-            // Wait for stream batch to complete
+
+            // Wait for stream batch to complete and immediately
+            // store number of processed hashes
             CUDA_SAFE_CALL(cudaStreamSynchronize(stream));
+            addHashCount(batch_size);
+
             if (shouldStop())
             {
                 m_new_work.store(false, std::memory_order_relaxed);
                 done = true;
                 stop = true;
             }
+
             // See if we got solutions in this batch
-            uint32_t found_count = buffer->count;
+            uint32_t found_count = std::min((unsigned)buffer->count, SEARCH_RESULTS);
             if (found_count)
             {
+
                 buffer->count = 0;
-                uint64_t nonces[SEARCH_RESULTS];
-                h256 mixes[SEARCH_RESULTS];
-                // handle the highly unlikely possibility that there are more
-                // solutions found than we can handle
-                if (found_count > SEARCH_RESULTS)
-                    found_count = SEARCH_RESULTS;
                 uint64_t nonce_base = current_nonce - streams_batch_size;
-                // stash the solutions, so we can reuse the search buffer
-                for (unsigned int j = 0; j < found_count; j++)
-                {
-                    nonces[j] = nonce_base + buffer->result[j].gid;
-                    if (s_noeval)
-                        memcpy(mixes[j].data(), (void*)&buffer->result[j].mix,
-                            sizeof(buffer->result[j].mix));
-                }
-                // restart the stream on the next batch of nonces
-                if (!done)
-                    run_ethash_search(
-                        s_gridSize, s_blockSize, stream, buffer, current_nonce, m_parallelHash);
-                // Pass the solutions up to the higher level
+                
+                // Pass the solution(s) for submission
+                uint64_t minerNonce;
+                h256 minerMix;
+
                 for (uint32_t i = 0; i < found_count; i++)
+                {
+                    minerNonce = nonce_base + buffer->result[i].gid;
                     if (s_noeval)
-                        farm.submitProof(Solution{nonces[i], mixes[i], w, m_new_work});
+                    {
+                        memcpy(minerMix.data(), (void*)&buffer->result[i].mix,
+                            sizeof(buffer->result[i].mix));
+                        farm.submitProof(Solution{minerNonce, minerMix, w, m_new_work});
+                    }
                     else
                     {
-                        Result r = EthashAux::eval(w.epoch, w.header, nonces[i]);
+                        Result r = EthashAux::eval(w.epoch, w.header, minerNonce);
                         if (r.value <= w.boundary)
-                            farm.submitProof(Solution{nonces[i], r.mixHash, w, m_new_work});
+                        {
+                            farm.submitProof(Solution{minerNonce, r.mixHash, w, m_new_work});
+                        }
                         else
                         {
                             farm.failedSolution();
-                            cwarn << "GPU gave incorrect result!";
+                            cwarn
+                                << "GPU gave incorrect result! Lower OC if this happens frequently";
                         }
                     }
-            }
-            else
-            {
-                // restart the stream on the next batch of nonces
-                if (!done)
-                    run_ethash_search(
-                        s_gridSize, s_blockSize, stream, buffer, current_nonce, m_parallelHash);
+                        
+                }
             }
 
-            addHashCount(batch_size);
+            // restart the stream on the next batch of nonces
+            if (!done)
+                run_ethash_search(
+                    s_gridSize, s_blockSize, stream, buffer, current_nonce, m_parallelHash);
+
         }
     }
+
     if (!stop && (g_logVerbosity >= 6))
     {
         cudalog << "Switch time: "

--- a/libethash-cuda/ethash_cuda_miner_kernel.h
+++ b/libethash-cuda/ethash_cuda_miner_kernel.h
@@ -11,7 +11,7 @@
 // one solution per stream hash calculation
 // Leave room for up to 4 results. A power
 // of 2 here will yield better CUDA optimization
-#define SEARCH_RESULTS 4
+#define SEARCH_RESULTS 4U
 
 typedef struct
 {

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -69,12 +69,15 @@ public:
         m_hwmon = hwmon;
         m_pwron = pwron;
 
-        // Init HWMON
-        adlh = wrap_adl_create();
+        // Init HWMON if needed
+        if (m_hwmon)
+        {
+            adlh = wrap_adl_create();
 #if defined(__linux)
-        sysfsh = wrap_amdsysfs_create();
+            sysfsh = wrap_amdsysfs_create();
 #endif
-        nvmlh = wrap_nvml_create();
+            nvmlh = wrap_nvml_create();
+        }
 
         // Initialize nonce_scrambler
         shuffle();

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -112,8 +112,6 @@ public:
      */
     void setWork(WorkPackage const& _wp)
     {
-        // Collect hashrate before miner reset their work
-        collectHashRate();
 
         // Set work to each miner
         Guard l(x_minerWork);

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -535,7 +535,6 @@ private:
     std::string m_lastSealer;
     bool b_lastMixed = false;
 
-    std::chrono::steady_clock::time_point m_lastStart;
     uint64_t m_hashrateSmoothInterval = 30000;
 
     boost::asio::io_service::strand m_io_strand;

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -535,8 +535,6 @@ private:
     std::string m_lastSealer;
     bool b_lastMixed = false;
 
-    uint64_t m_hashrateSmoothInterval = 30000;
-
     boost::asio::io_service::strand m_io_strand;
     boost::asio::deadline_timer m_collectTimer;
     int m_collectInterval = 5000;

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -64,8 +64,11 @@ public:
         std::function<Miner*(FarmFace&, unsigned)> create;
     };
 
-    Farm(boost::asio::io_service& io_service) : m_io_strand(io_service), m_hashrateTimer(io_service)
+    Farm(boost::asio::io_service& io_service, bool hwmon, bool pwron) : m_io_strand(io_service), m_collectTimer(io_service)
     {
+        m_hwmon = hwmon;
+        m_pwron = pwron;
+
         // Init HWMON
         adlh = wrap_adl_create();
 #if defined(__linux)
@@ -75,6 +78,13 @@ public:
 
         // Initialize nonce_scrambler
         shuffle();
+
+        // Start data collector timer
+        // It should work for the whole lifetime of Farm
+        // regardless it's mining state
+        m_collectTimer.expires_from_now(boost::posix_time::milliseconds(m_collectInterval));
+        m_collectTimer.async_wait(m_io_strand.wrap(
+            boost::bind(&Farm::collectData, this, boost::asio::placeholders::error)));
     }
 
     ~Farm()
@@ -91,6 +101,9 @@ public:
 
         // Stop mining
         stop();
+
+        // Stop data collector
+        m_collectTimer.cancel();
     }
 
     /**
@@ -112,7 +125,6 @@ public:
      */
     void setWork(WorkPackage const& _wp)
     {
-
         // Set work to each miner
         Guard l(x_minerWork);
         m_work = _wp;
@@ -166,10 +178,6 @@ public:
         m_lastSealer = _sealer;
         b_lastMixed = mixed;
 
-        // Start hashrate collector
-        m_hashrateTimer.expires_from_now(boost::posix_time::milliseconds(1000));
-        m_hashrateTimer.async_wait(m_io_strand.wrap(
-            boost::bind(&Farm::processHashRate, this, boost::asio::placeholders::error)));
 
         return true;
     }
@@ -188,58 +196,6 @@ public:
                 m_miners.clear();
                 m_isMining.store(false, std::memory_order_relaxed);
             }
-
-            m_hashrateTimer.cancel();
-
-            m_lastProgresses.clear();
-        }
-    }
-
-    void collectHashRate()
-    {
-        std::lock_guard<std::mutex> lock(x_minerWork);
-
-        auto now = std::chrono::steady_clock::now();
-
-        WorkingProgress p;
-        p.ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_lastStart).count();
-        m_lastStart = now;
-
-        // Collect & Reset
-        for (auto const& i : m_miners)
-        {
-            auto minerHashCount = i->RetrieveAndClearHashCount();
-            p.hashes += minerHashCount;
-            p.minersHashes.push_back(minerHashCount);
-        }
-
-        m_lastProgresses.push_back(p);
-
-        // We smooth the hashrate over the last x seconds
-        uint64_t allMs = 0;
-        for (auto const& cp : m_lastProgresses)
-            allMs += cp.ms;
-
-        if (allMs > m_hashrateSmoothInterval)
-            m_lastProgresses.erase(m_lastProgresses.begin());
-    }
-
-    void processHashRate(const boost::system::error_code& ec)
-    {
-        if (!ec)
-        {
-            // Stop mining causes m_hashrateTimer to cancel but
-            // io_service cannot guarantee this event is cancelled (it may be too close to deadline)
-            // Thus do not process if not mining.
-            if (!isMining())
-                return;
-
-            collectHashRate();
-
-            // Resubmit timer only if actually mining
-            m_hashrateTimer.expires_from_now(boost::posix_time::milliseconds(1000));
-            m_hashrateTimer.async_wait(m_io_strand.wrap(
-                boost::bind(&Farm::processHashRate, this, boost::asio::placeholders::error)));
         }
     }
 
@@ -283,109 +239,8 @@ public:
      * @brief Get information on the progress of mining this work package.
      * @return The progress with mining so far.
      */
-    WorkingProgress const& miningProgress(bool hwmon = false, bool power = false) const
+    WorkingProgress const& miningProgress() const
     {
-        std::lock_guard<std::mutex> lock(x_minerWork);
-        WorkingProgress p;
-        p.ms = 0;
-        p.hashes = 0;
-        for (auto const& i : m_miners)
-        {
-            p.miningIsPaused.push_back(i->is_mining_paused());
-            p.minersHashes.push_back(0);
-            if (hwmon)
-            {
-                HwMonitorInfo hwInfo = i->hwmonInfo();
-                HwMonitor hw;
-                unsigned int tempC = 0, fanpcnt = 0, powerW = 0;
-                if (hwInfo.deviceIndex >= 0)
-                {
-                    if (hwInfo.deviceType == HwMonitorInfoType::NVIDIA && nvmlh)
-                    {
-                        int typeidx = 0;
-                        if (hwInfo.indexSource == HwMonitorIndexSource::CUDA)
-                        {
-                            typeidx = nvmlh->cuda_nvml_device_id[hwInfo.deviceIndex];
-                        }
-                        else if (hwInfo.indexSource == HwMonitorIndexSource::OPENCL)
-                        {
-                            typeidx = nvmlh->opencl_nvml_device_id[hwInfo.deviceIndex];
-                        }
-                        else
-                        {
-                            // Unknown, don't map
-                            typeidx = hwInfo.deviceIndex;
-                        }
-                        wrap_nvml_get_tempC(nvmlh, typeidx, &tempC);
-                        wrap_nvml_get_fanpcnt(nvmlh, typeidx, &fanpcnt);
-                        if (power)
-                        {
-                            wrap_nvml_get_power_usage(nvmlh, typeidx, &powerW);
-                        }
-                    }
-                    else if (hwInfo.deviceType == HwMonitorInfoType::AMD && adlh)
-                    {
-                        int typeidx = 0;
-                        if (hwInfo.indexSource == HwMonitorIndexSource::OPENCL)
-                        {
-                            typeidx = adlh->opencl_adl_device_id[hwInfo.deviceIndex];
-                        }
-                        else
-                        {
-                            // Unknown, don't map
-                            typeidx = hwInfo.deviceIndex;
-                        }
-                        wrap_adl_get_tempC(adlh, typeidx, &tempC);
-                        wrap_adl_get_fanpcnt(adlh, typeidx, &fanpcnt);
-                        if (power)
-                        {
-                            wrap_adl_get_power_usage(adlh, typeidx, &powerW);
-                        }
-                    }
-#if defined(__linux)
-                    // Overwrite with sysfs data if present
-                    if (hwInfo.deviceType == HwMonitorInfoType::AMD && sysfsh)
-                    {
-                        int typeidx = 0;
-                        if (hwInfo.indexSource == HwMonitorIndexSource::OPENCL)
-                        {
-                            typeidx = sysfsh->opencl_sysfs_device_id[hwInfo.deviceIndex];
-                        }
-                        else
-                        {
-                            // Unknown, don't map
-                            typeidx = hwInfo.deviceIndex;
-                        }
-                        wrap_amdsysfs_get_tempC(sysfsh, typeidx, &tempC);
-                        wrap_amdsysfs_get_fanpcnt(sysfsh, typeidx, &fanpcnt);
-                        if (power)
-                        {
-                            wrap_amdsysfs_get_power_usage(sysfsh, typeidx, &powerW);
-                        }
-                    }
-#endif
-                }
-
-                i->update_temperature(tempC);
-
-                hw.tempC = tempC;
-                hw.fanP = fanpcnt;
-                hw.powerW = powerW / ((double)1000.0);
-                p.minerMonitors.push_back(hw);
-            }
-        }
-
-        for (auto const& cp : m_lastProgresses)
-        {
-            p.ms += cp.ms;
-            p.hashes += cp.hashes;
-            for (unsigned int i = 0; i < cp.minersHashes.size() && i < p.minersHashes.size(); i++)
-            {
-                p.minersHashes.at(i) += cp.minersHashes.at(i);
-            }
-        }
-
-        m_progress = p;
         return m_progress;
     }
 
@@ -498,6 +353,123 @@ public:
     unsigned get_tstop() override { return m_tstop; }
 
 private:
+    // Collects data about hashing and hardware status
+    void collectData(const boost::system::error_code& ec)
+    {
+        if (ec)
+            return;
+
+        WorkingProgress progress;
+        progress.ms = m_collectInterval;
+
+        // Process miners
+        for (auto const& miner : m_miners)
+        {
+            // Collect and reset hashrates
+            auto minerHashCount = miner->RetrieveAndClearHashCount();
+            if (!miner->is_mining_paused())
+            {
+                progress.hashes += minerHashCount;
+                progress.minersHashes.push_back(minerHashCount);
+                progress.miningIsPaused.push_back(false);
+            }
+            else
+            {
+                progress.minersHashes.push_back(0);
+                progress.miningIsPaused.push_back(true);
+            }
+
+            if (m_hwmon)
+            {
+                HwMonitorInfo hwInfo = miner->hwmonInfo();
+                HwMonitor hw;
+                unsigned int tempC = 0, fanpcnt = 0, powerW = 0;
+                if (hwInfo.deviceIndex >= 0)
+                {
+                    if (hwInfo.deviceType == HwMonitorInfoType::NVIDIA && nvmlh)
+                    {
+                        int typeidx = 0;
+                        if (hwInfo.indexSource == HwMonitorIndexSource::CUDA)
+                        {
+                            typeidx = nvmlh->cuda_nvml_device_id[hwInfo.deviceIndex];
+                        }
+                        else if (hwInfo.indexSource == HwMonitorIndexSource::OPENCL)
+                        {
+                            typeidx = nvmlh->opencl_nvml_device_id[hwInfo.deviceIndex];
+                        }
+                        else
+                        {
+                            // Unknown, don't map
+                            typeidx = hwInfo.deviceIndex;
+                        }
+                        wrap_nvml_get_tempC(nvmlh, typeidx, &tempC);
+                        wrap_nvml_get_fanpcnt(nvmlh, typeidx, &fanpcnt);
+                        if (m_pwron)
+                        {
+                            wrap_nvml_get_power_usage(nvmlh, typeidx, &powerW);
+                        }
+                    }
+                    else if (hwInfo.deviceType == HwMonitorInfoType::AMD && adlh)
+                    {
+                        int typeidx = 0;
+                        if (hwInfo.indexSource == HwMonitorIndexSource::OPENCL)
+                        {
+                            typeidx = adlh->opencl_adl_device_id[hwInfo.deviceIndex];
+                        }
+                        else
+                        {
+                            // Unknown, don't map
+                            typeidx = hwInfo.deviceIndex;
+                        }
+                        wrap_adl_get_tempC(adlh, typeidx, &tempC);
+                        wrap_adl_get_fanpcnt(adlh, typeidx, &fanpcnt);
+                        if (m_pwron)
+                        {
+                            wrap_adl_get_power_usage(adlh, typeidx, &powerW);
+                        }
+                    }
+#if defined(__linux)
+                    // Overwrite with sysfs data if present
+                    if (hwInfo.deviceType == HwMonitorInfoType::AMD && sysfsh)
+                    {
+                        int typeidx = 0;
+                        if (hwInfo.indexSource == HwMonitorIndexSource::OPENCL)
+                        {
+                            typeidx = sysfsh->opencl_sysfs_device_id[hwInfo.deviceIndex];
+                        }
+                        else
+                        {
+                            // Unknown, don't map
+                            typeidx = hwInfo.deviceIndex;
+                        }
+                        wrap_amdsysfs_get_tempC(sysfsh, typeidx, &tempC);
+                        wrap_amdsysfs_get_fanpcnt(sysfsh, typeidx, &fanpcnt);
+                        if (m_pwron)
+                        {
+                            wrap_amdsysfs_get_power_usage(sysfsh, typeidx, &powerW);
+                        }
+                    }
+#endif
+                }
+
+                miner->update_temperature(tempC);
+
+                hw.tempC = tempC;
+                hw.fanP = fanpcnt;
+                hw.powerW = powerW / ((double)1000.0);
+                progress.minerMonitors.push_back(hw);
+
+            }
+        }
+
+        m_progress = progress;
+
+        // Resubmit timer for another loop
+        m_collectTimer.expires_from_now(boost::posix_time::milliseconds(m_collectInterval));
+        m_collectTimer.async_wait(m_io_strand.wrap(
+            boost::bind(&Farm::collectData, this, boost::asio::placeholders::error)));
+    }
+
     /**
      * @brief Spawn a file - must be located in the directory of ethminer binary
      * @return false if file was not found or it is not executeable
@@ -567,22 +539,29 @@ private:
     uint64_t m_hashrateSmoothInterval = 30000;
 
     boost::asio::io_service::strand m_io_strand;
-    boost::asio::deadline_timer m_hashrateTimer;
-    std::vector<WorkingProgress> m_lastProgresses;
+    boost::asio::deadline_timer m_collectTimer;
+    int m_collectInterval = 5000;
 
     mutable SolutionStats m_solutionStats;
     std::chrono::steady_clock::time_point m_farm_launched = std::chrono::steady_clock::now();
 
     string m_pool_addresses;
-    uint64_t m_nonce_scrambler;
-    unsigned int m_nonce_segment_with =
-        40;  // This is the exponent of the power 2^n which determines the width of each search
-             // segment assigned to each gpu
 
+    // StartNonce (non-NiceHash Mode) and
+    // segment width assigned to each GPU as exponent of 2
+    uint64_t m_nonce_scrambler;
+    unsigned int m_nonce_segment_with = 40;
+
+    // Switches for hw monitoring and power drain monitoring
+    bool m_hwmon, m_pwron;
+
+    // Hardware monitoring temperatures
     unsigned m_tstart = 0, m_tstop = 0;
 
+    // Wrappers for hardware monitoring libraries
     wrap_nvml_handle* nvmlh = nullptr;
     wrap_adl_handle* adlh = nullptr;
+
 #if defined(__linux)
     wrap_amdsysfs_handle* sysfsh = nullptr;
 #endif

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -89,8 +89,7 @@ inline std::ostream& operator<<(std::ostream& os, HwMonitor _hw)
 
 
 /// Pause mining
-typedef enum
-{
+typedef enum {
     MINING_NOT_PAUSED = 0x00000000,
     MINING_PAUSED_WAIT_FOR_T_START = 0x00000001,
     MINING_PAUSED_API = 0x00000002
@@ -251,7 +250,8 @@ public:
         {
             Guard l(x_work);
             m_work = _work;
-            workSwitchStart = std::chrono::steady_clock::now();
+            if (g_logVerbosity >= 6)
+                workSwitchStart = std::chrono::steady_clock::now();
         }
         kick_miner();
     }


### PR DESCRIPTION
Data collecting (hashing and hw info) lives in it's own timer (5 seconds) not influenced by `--display-interval` or by the number of calls issued via API.

Hashing average is, as said, on last 5 seconds which gives (IMHO) a better feeling of hashing lost on frequent job changes issued by pool.

All process has been greatly simplified.

Addresses #1478 

# Please test before any merge