### PR TITLE
Smooth AMD hash rate.

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -870,3 +870,14 @@ bool CLMiner::init(int epoch)
     }
     return true;
 }
+
+// Virtual attribute is inherited from parent object
+uint64_t CLMiner::RetrieveAndClearHashCount()
+{
+    auto expected = Miner::RetrieveAndClearHashCount();
+    // apply exponential sliding average
+    // ref: https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average
+    const double alpha = 0.45;
+    m_lastHashCount = alpha * expected + (1.0 - alpha) * m_lastHashCount;
+    return m_lastHashCount;
+}

--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -75,6 +75,7 @@ public:
 
 protected:
     void kick_miner() override;
+    uint64_t RetrieveAndClearHashCount();
 
 private:
     void workLoop() override;
@@ -96,6 +97,7 @@ private:
     unsigned m_workgroupSize = 0;
     unsigned m_dagItems = 0;
     uint64_t m_lastNonce = 0;
+    uint64_t m_lastHashCount = 0;
 
     static unsigned s_platformId;
     static unsigned s_numInstances;

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -256,7 +256,7 @@ public:
         kick_miner();
     }
 
-    uint64_t RetrieveAndClearHashCount()
+    virtual uint64_t RetrieveAndClearHashCount()
     {
         auto expected = m_hashCount.load(std::memory_order_relaxed);
         while (!m_hashCount.compare_exchange_weak(expected, 0, std::memory_order_relaxed))
@@ -265,6 +265,7 @@ public:
     }
 
     unsigned Index() { return index; };
+
     HwMonitorInfo hwmonInfo() { return m_hwmoninfo; }
 
     uint64_t get_start_nonce()


### PR DESCRIPTION
The new hashrate collecting algorithm induces high variability
in AMD card hash rate. This is likely most evident for individual
GPU measuremnt. Maybe this is because the AMD uses a very large global
work group multiplier in conjunction with a fast work group abort
mechanism. This means that a kernel pass can run for up to one
second. Since a batch can be aborted at any time a batch could
only run for much fewer hashes. This means there is a good likelihood
the large count from a single AMD batch will be allocated to the
wrong interval. It will depend on where the fixed poling hits the
kernel in a running batch. The worst case scenario allocates a
full batch of hashes incorrectly to one interval, effectively
drawing it from the next interval.

It is also possible that the AMD kernels really do deviate
significantly!

Nvidia is orders of magnitude less affected due to its comparatively
small batch size. For AMD hash rate easily varies +-1 MH/S out
of 30 between poling intervals.

This PR applies an exponential moving average calculation to the
AMD hashrate. Even so it still only reduces variability to +-0.3
MH/S! It's a simple algorithm requiring a fixed small amount of
storage. Reducing the variability gives the user a better idea
of what to expect from the pool as effective hash rate over
time.

The down side is this gives the false impression of GPU
'warm-up' at startup until enough samples have been
processed.

Till we find a better way to calculate hash rate... best I could do!

Reference:

https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average