### PR TITLE
Auto stratum

### DIFF
--- a/docs/POOL_EXAMPLES_ETH.md
+++ b/docs/POOL_EXAMPLES_ETH.md
@@ -1,8 +1,39 @@
 # Pool Examples for ETH
 
-This is a collection of examples how to connect ethminer to your favorite ETH pool (alphabetic order).
+Pool connection definition is issued via `-P` argument which has this syntax
 
-* Stratum connection is preferred than getwork connection due to its better network latency.
+```
+-P scheme://user[.workername][:password]@hostname:port[/...]
+```
+__values in square brackets are optional__
+
+where `scheme` can be any of:
+
+* `http` for getwork mode (geth)
+* `stratum+tcp` for plain stratum mode
+* `stratum1+tcp` for plain stratum eth-proxy compatible mode
+* `stratum2+tcp` for plain stratum NiceHash compatible mode
+
+## Secure socket comunications for stratum only
+
+Ethminer supports secure socket communications (where pool implements and offers it) to avoid the risk of a [man-in-the-middle attack](https://en.wikipedia.org/wiki/Man-in-the-middle_attack)
+To enable it simply replace tcp with either:
+
+* `ssl` to enable secure socket communication
+* `tls12` to enable secure socket communication **with strong TLS12** checking
+
+thus your connection scheme changes to `-P stratum+ssl://[...]` or `-P stratum+tls12://[...]`. Same applies for `stratum1` and `stratum2`
+
+## Only for version 0.16+ (older versions not affected)
+
+Stratum autodetection has been introduced to mitigate user's duty to guess/find which stratum flavour to apply (stratum or stratum1 or stratum2).
+If you want to let ethminer do the tests for you simply enter scheme as `stratum://` (note `+tcp` is missing) or `stratums://` for secure socket or `stratumss://` for secure socket with strong TLS12 checking.
+
+## Common samples
+
+Here you can find a collection of samples to connect to most commonly used ethash pools. (alphabetic order).
+
+* Stratum connection is **always to be preferred** over **getwork** when pool offers it due to its better network latency.
 * If possible the samples use a protocol which supports reporting of hashrate (`--report-hashrate`) if pool supports this.
 
 **Check for updates in the pool connection settings visiting the pools homepage.**

--- a/docs/POOL_EXAMPLES_ETH.md
+++ b/docs/POOL_EXAMPLES_ETH.md
@@ -19,15 +19,15 @@ where `scheme` can be any of:
 Ethminer supports secure socket communications (where pool implements and offers it) to avoid the risk of a [man-in-the-middle attack](https://en.wikipedia.org/wiki/Man-in-the-middle_attack)
 To enable it simply replace tcp with either:
 
-* `ssl` to enable secure socket communication
-* `tls12` to enable secure socket communication **with strong TLS12** checking
+* `tls` to enable secure socket communication
+* `ssl` or `tls12` to enable secure socket communication **allowing only TLS 1.2** encryption
 
-thus your connection scheme changes to `-P stratum+ssl://[...]` or `-P stratum+tls12://[...]`. Same applies for `stratum1` and `stratum2`
+thus your connection scheme changes to `-P stratum+tls://[...]` or `-P stratum+tls12://[...]`. Same applies for `stratum1` and `stratum2`
 
 ## Only for version 0.16+ (older versions not affected)
 
 Stratum autodetection has been introduced to mitigate user's duty to guess/find which stratum flavour to apply (stratum or stratum1 or stratum2).
-If you want to let ethminer do the tests for you simply enter scheme as `stratum://` (note `+tcp` is missing) or `stratums://` for secure socket or `stratumss://` for secure socket with strong TLS12 checking.
+If you want to let ethminer do the tests for you simply enter scheme as `stratum://` (note `+tcp` is missing) or `stratums://` for secure socket or `stratumss://` for secure socket **allowing only TLS 1.2** encryption.
 
 ## Common samples
 

--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -474,10 +474,10 @@ public:
             << "    URL takes the form: scheme://user[.workername][:password]@hostname:port[/...]."
             << endl
             << "    where can be any of : " << endl
-            << "    http     for getWork mode" << endl
-            << "    tcp      for stratum mode" << endl
-            << "    tcps     for secure stratum mode" << endl
-            << "    tcpss    for secure stratum mode with strong TLS12 verification" << endl
+            << "    getwork     for getWork mode" << endl
+            << "    stratum     for stratum mode" << endl
+            << "    stratums    for secure stratum mode" << endl
+            << "    stratumss   for secure stratum mode with strong TLS12 verification" << endl
             << endl
             << "    Example 1: "
                "    tcps://0x012345678901234567890234567890123.miner1@ethermine.org:5555"

--- a/libpoolprotocols/PoolURI.cpp
+++ b/libpoolprotocols/PoolURI.cpp
@@ -51,14 +51,17 @@ static std::map<std::string, SchemeAttributes> s_schemes = {
     {"stratum1+ssl", {ProtocolFamily::STRATUM, SecureLevel::TLS12, 1}},
     {"stratum2+ssl", {ProtocolFamily::STRATUM, SecureLevel::TLS12, 2}},
     {"http", {ProtocolFamily::GETWORK, SecureLevel::NONE, 0}},
+    {"getwork", {ProtocolFamily::GETWORK, SecureLevel::NONE, 0}},
 
     /*
     Any TCP scheme has, at the moment, only STRATUM protocol thus
     reiterating "stratum" word would be pleonastic
+    Version 9 means auto-detect stratum mode
     */
-    {"tcp", {ProtocolFamily::STRATUM, SecureLevel::NONE, 0}},
-    {"tcps", {ProtocolFamily::STRATUM, SecureLevel::TLS, 0}},
-    {"tcpss", {ProtocolFamily::STRATUM, SecureLevel::TLS12, 0}}
+
+    {"stratum", {ProtocolFamily::STRATUM, SecureLevel::NONE, 999}},
+    {"stratums", {ProtocolFamily::STRATUM, SecureLevel::TLS, 999}},
+    {"stratumss", {ProtocolFamily::STRATUM, SecureLevel::TLS12, 999}}
 
 };
 

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -567,7 +567,7 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec)
 
     if (m_conn->Version() < 999)
     {
-        m_conn->SetStratumMode(m_conn->Version, true);
+        m_conn->SetStratumMode(m_conn->Version(), true);
     }
     else
     {

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -553,28 +553,34 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec)
     }
 
     /*
-    If this connection has not gone through an autodetection of stratum mode
-    begin it now.
+
+    If connection has been set-up with a specific scheme then
+    set it's related stratum version as confirmed.
+
+    Otherwise let's go through an autodetection.
+
     Autodetection process passes all known stratum modes.
     - 1st pass EthStratumClient::ETHEREUMSTRATUM  (2)
     - 2nd pass EthStratumClient::ETHPROXY         (1)
     - 3rd pass EthStratumClient::STRATUM          (0)
     */
 
+    if (m_conn->Version() < 999)
+    {
+        m_conn->SetStratumMode(m_conn->Version, true);
+    }
+    else
+    {
+        if (!m_conn->StratumModeConfirmed() && m_conn->StratumMode() == 999)
+            m_conn->SetStratumMode(2, false);
+    }
+
+
     Json::Value jReq;
     jReq["id"] = unsigned(1);
     jReq["method"] = "mining.subscribe";
     jReq["params"] = Json::Value(Json::arrayValue);
 
-    if (m_conn->Version() == 999)
-    {
-        if (!m_conn->StratumModeConfirmed() && m_conn->StratumMode() == 999)
-            m_conn->SetStratumMode(2, false);
-    }
-    else
-    {
-        m_conn->SetStratumMode(m_conn->Version(), true);
-    }
 
     switch (m_conn->StratumMode())
     {

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -566,8 +566,11 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec)
     jReq["method"] = "mining.subscribe";
     jReq["params"] = Json::Value(Json::arrayValue);
 
-    if (!m_conn->StratumModeConfirmed() && m_conn->StratumMode() == 999)
-        m_conn->SetStratumMode(2, false);
+    if (m_conn->Version() == 999)
+    {
+        if (!m_conn->StratumModeConfirmed() && m_conn->StratumMode() == 999)
+            m_conn->SetStratumMode(2, false);
+    }
 
     switch (m_conn->StratumMode())
     {

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -571,6 +571,10 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec)
         if (!m_conn->StratumModeConfirmed() && m_conn->StratumMode() == 999)
             m_conn->SetStratumMode(2, false);
     }
+    else
+    {
+        m_conn->SetStratumMode(m_conn->Version(), true);
+    }
 
     switch (m_conn->StratumMode())
     {


### PR DESCRIPTION
Sets some basic aliases for job retrieval mode:

* getwork:// default scheme for http mode. (http:// is also kept)
* stratum:// default scheme for tcp mode. This also endorses stratum auto-detection
* stratums:// default scheme for tcp mode **secure**. This also endorses stratum auto-detection
* stratumss:// default scheme for tcp mode **secure with TLS validation**. This also endorses stratum auto-detection

Older schemes are preserved for backward compatibility and, if set, do not activate stratum autodection. So when -P argument is valued : 
* `stratum+tcp://` means the user wants to stick to stratum mode 
* `stratum1+tcp://` means the user wants to stick to ethproxy compatible mode 
* `stratum2+tcp://` means the user wants to stick to nicehash mode 

All those previous also keep combinations with ssl/tls flags.