### PR TITLE
Move function bodies (non methods) to cpp.

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -541,14 +541,14 @@ bool CLMiner::configureGPU(unsigned _localWorkSize, unsigned _globalWorkSizeMult
         if (result >= dagSize)
         {
             cnote << "Found suitable OpenCL device [" << device.getInfo<CL_DEVICE_NAME>()
-                  << "] with " << FormatMemSize(result) << " of GPU memory";
+                  << "] with " << FormattedMemSize(result) << " of GPU memory";
             foundSuitableDevice = true;
         }
         else
         {
             cnote << "OpenCL device " << device.getInfo<CL_DEVICE_NAME>()
-                  << " has insufficient GPU memory." << FormatMemSize(result)
-                  << " GB of memory found < " << FormatMemSize(dagSize) << " of memory required";
+                  << " has insufficient GPU memory." << FormattedMemSize(result)
+                  << " GB of memory found < " << FormattedMemSize(dagSize) << " of memory required";
         }
     }
     if (foundSuitableDevice)
@@ -782,7 +782,7 @@ bool CLMiner::init(int epoch)
         if (result < dagSize)
         {
             cnote << "OpenCL device " << device_name << " has insufficient GPU memory."
-                  << FormatMemSize(result) << " of memory found, " << FormatMemSize(dagSize)
+                  << FormattedMemSize(result) << " of memory found, " << FormattedMemSize(dagSize)
                   << " of memory required";
             return false;
         }
@@ -790,11 +790,11 @@ bool CLMiner::init(int epoch)
         // create buffer for dag
         try
         {
-            cllog << "Creating light cache buffer, size: " << FormatMemSize(lightSize);
+            cllog << "Creating light cache buffer, size: " << FormattedMemSize(lightSize);
             m_light.clear();
             m_light.push_back(cl::Buffer(m_context[0], CL_MEM_READ_ONLY, lightSize));
-            cllog << "Creating DAG buffer, size: " << FormatMemSize(dagSize)
-                  << ", free: " << FormatMemSize(result - lightSize - dagSize);
+            cllog << "Creating DAG buffer, size: " << FormattedMemSize(dagSize)
+                  << ", free: " << FormattedMemSize(result - lightSize - dagSize);
             m_dag.clear();
             m_dag.push_back(cl::Buffer(m_context[0], CL_MEM_READ_ONLY, dagSize));
             cllog << "Loading kernels";
@@ -860,7 +860,7 @@ bool CLMiner::init(int epoch)
         auto endDAG = std::chrono::steady_clock::now();
 
         auto dagTime = std::chrono::duration_cast<std::chrono::milliseconds>(endDAG - startDAG);
-        cnote << FormatMemSize(dagSize) << " of DAG data generated in " << dagTime.count()
+        cnote << FormattedMemSize(dagSize) << " of DAG data generated in " << dagTime.count()
               << " ms.";
     }
     catch (cl::Error const& err)

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -96,8 +96,8 @@ bool CUDAMiner::init(int epoch)
             {
                 cudalog << "CUDA device " << string(device_props.name)
                         << " has insufficient GPU memory. "
-                        << FormatMemSize(device_props.totalGlobalMem) << " of memory found, "
-                        << FormatMemSize(dagSize) << " of memory required";
+                        << FormattedMemSize(device_props.totalGlobalMem) << " of memory found, "
+                        << FormattedMemSize(dagSize) << " of memory required";
                 return false;
             }
             // We need to reset the device and recreate the dag
@@ -116,7 +116,7 @@ bool CUDAMiner::init(int epoch)
 
         if (!light)
         {
-            cudalog << "Allocating light with size: " << FormatMemSize(lightSize);
+            cudalog << "Allocating light with size: " << FormattedMemSize(lightSize);
             CUDA_SAFE_CALL(cudaMalloc(reinterpret_cast<void**>(&light), lightSize));
         }
         // copy lightData to device
@@ -146,8 +146,8 @@ bool CUDAMiner::init(int epoch)
                 if ((m_device_num == s_dagCreateDevice) || (s_dagLoadMode != DAG_LOAD_MODE_SINGLE))
                 {
                     cudalog << "Generating DAG for GPU #" << m_device_num
-                            << " with dagSize: " << FormatMemSize(dagSize) << " ("
-                            << FormatMemSize(device_props.totalGlobalMem - dagSize - lightSize)
+                            << " with dagSize: " << FormattedMemSize(dagSize) << " ("
+                            << FormattedMemSize(device_props.totalGlobalMem - dagSize - lightSize)
                             << " left)";
                     auto startDAG = std::chrono::steady_clock::now();
 

--- a/libethcore/Miner.cpp
+++ b/libethcore/Miner.cpp
@@ -1,19 +1,101 @@
+/*
+ This file is part of cpp-ethereum.
+
+ cpp-ethereum is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ cpp-ethereum is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "Miner.h"
-#include "EthashAux.h"
 
-using namespace dev;
-using namespace eth;
+namespace dev
+{
+namespace eth
+{
+unsigned Miner::s_dagLoadMode = 0;
 
-unsigned dev::eth::Miner::s_dagLoadMode = 0;
+unsigned Miner::s_dagLoadIndex = 0;
 
-unsigned dev::eth::Miner::s_dagLoadIndex = 0;
+unsigned Miner::s_dagCreateDevice = 0;
 
-unsigned dev::eth::Miner::s_dagCreateDevice = 0;
+uint8_t* Miner::s_dagInHostMemory = nullptr;
 
-uint8_t* dev::eth::Miner::s_dagInHostMemory = nullptr;
+bool Miner::s_exit = false;
 
-bool dev::eth::Miner::s_exit = false;
+bool Miner::s_noeval = false;
 
-bool dev::eth::Miner::s_noeval = false;
+double Miner::s_alpha = 1.0;
 
-double dev::eth::Miner::s_alpha = 1.0;
+std::ostream& operator<<(std::ostream& os, HwMonitor _hw)
+{
+    os << _hw.tempC << "C " << _hw.fanP << "%";
+    if (_hw.powerW)
+        os << ' ' << fixed << setprecision(0) << _hw.powerW << "W";
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, FormattedMemSize s)
+{
+    static const char* suffixes[] = {"bytes", "KB", "MB", "GB"};
+    double d = s.m_size;
+    unsigned i;
+    for (i = 0; i < 3; i++)
+    {
+        if (d < 1024.0)
+            break;
+        d /= 1024.0;
+    }
+    return os << fixed << setprecision(3) << d << ' ' << suffixes[i];
+}
+
+std::ostream& operator<<(std::ostream& _out, WorkingProgress _p)
+{
+    float mh = _p.rate() / 1000000.0f;
+    _out << "Speed " << EthTealBold << std::fixed << std::setprecision(2) << mh << EthReset
+         << " Mh/s";
+
+    for (size_t i = 0; i < _p.minersHashes.size(); ++i)
+    {
+        mh = _p.minerRate(_p.minersHashes[i]) / 1000000.0f;
+
+        if (_p.miningIsPaused.size() == _p.minersHashes.size())
+        {
+            // red color if mining is paused on this gpu
+            if (_p.miningIsPaused[i])
+            {
+                _out << EthRed;
+            }
+        }
+
+        _out << " gpu" << i << " " << EthTeal << std::fixed << std::setprecision(2) << mh
+             << EthReset;
+        if (_p.minerMonitors.size() == _p.minersHashes.size())
+            _out << " " << EthTeal << _p.minerMonitors[i] << EthReset;
+    }
+
+    return _out;
+}
+
+std::ostream& operator<<(std::ostream& os, SolutionStats s)
+{
+    os << "[A" << s.getAccepts();
+    if (s.getAcceptedStales())
+        os << "+" << s.getAcceptedStales();
+    if (s.getRejects())
+        os << ":R" << s.getRejects();
+    if (s.getFailures())
+        os << ":F" << s.getFailures();
+    return os << "]";
+}
+
+}  // namespace eth
+}  // namespace dev

--- a/libethcore/Miner.cpp
+++ b/libethcore/Miner.cpp
@@ -1,7 +1,7 @@
 /*
  This file is part of cpp-ethereum.
 
- cpp-ethereum is free software: you can redistribute it and/or modify
+ ethminer is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
@@ -12,7 +12,7 @@
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+ along with ethminer.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "Miner.h"

--- a/libethcore/Miner.cpp
+++ b/libethcore/Miner.cpp
@@ -1,12 +1,12 @@
 /*
- This file is part of cpp-ethereum.
+ This file is part of ethereum.
 
  ethminer is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- cpp-ethereum is distributed in the hope that it will be useful,
+ ethereum is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -79,36 +79,17 @@ struct HwMonitor
     double powerW = 0;
 };
 
-inline std::ostream& operator<<(std::ostream& os, HwMonitor _hw)
-{
-    os << _hw.tempC << "C " << _hw.fanP << "%";
-    if (_hw.powerW)
-        os << ' ' << fixed << setprecision(0) << _hw.powerW << "W";
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, HwMonitor _hw);
 
-class FormatMemSize
+class FormattedMemSize
 {
 public:
-    FormatMemSize() = delete;
-    FormatMemSize(uint64_t s) { m_size = s; }
+    FormattedMemSize() = delete;
+    FormattedMemSize(uint64_t s) { m_size = s; }
     uint64_t m_size;
 };
 
-inline std::ostream& operator<<(std::ostream& os, FormatMemSize s)
-{
-    const char* suffixes[] = {"bytes", "KB", "MB", "GB"};
-    double d = s.m_size;
-    unsigned i;
-    for (i = 0; i < 3; i++)
-    {
-        if (d < 1024.0)
-            break;
-        d /= 1024.0;
-    }
-    os << fixed << setprecision(3) << d << ' ' << suffixes[i];
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, FormattedMemSize s);
 
 /// Pause mining
 typedef enum {
@@ -162,33 +143,7 @@ struct WorkingProgress
     }
 };
 
-inline std::ostream& operator<<(std::ostream& _out, WorkingProgress _p)
-{
-    float mh = _p.rate() / 1000000.0f;
-    _out << "Speed " << EthTealBold << std::fixed << std::setprecision(2) << mh << EthReset
-         << " Mh/s";
-
-    for (size_t i = 0; i < _p.minersHashes.size(); ++i)
-    {
-        mh = _p.minerRate(_p.minersHashes[i]) / 1000000.0f;
-
-        if (_p.miningIsPaused.size() == _p.minersHashes.size())
-        {
-            // red color if mining is paused on this gpu
-            if (_p.miningIsPaused[i])
-            {
-                _out << EthRed;
-            }
-        }
-
-        _out << " gpu" << i << " " << EthTeal << std::fixed << std::setprecision(2) << mh
-             << EthReset;
-        if (_p.minerMonitors.size() == _p.minersHashes.size())
-            _out << " " << EthTeal << _p.minerMonitors[i] << EthReset;
-    }
-
-    return _out;
-}
+std::ostream& operator<<(std::ostream& _out, WorkingProgress _p);
 
 class SolutionStats
 {
@@ -214,17 +169,7 @@ private:
     unsigned acceptedStales = 0;
 };
 
-inline std::ostream& operator<<(std::ostream& os, SolutionStats s)
-{
-    os << "[A" << s.getAccepts();
-    if (s.getAcceptedStales())
-        os << "+" << s.getAcceptedStales();
-    if (s.getRejects())
-        os << ":R" << s.getRejects();
-    if (s.getFailures())
-        os << ":F" << s.getFailures();
-    return os << "]";
-}
+std::ostream& operator<<(std::ostream& os, SolutionStats s);
 
 class Miner;
 
@@ -286,7 +231,7 @@ public:
             ;
         // apply exponential sliding average
         // ref: https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average
-        m_lastHashCount = s_alpha * expected + (1.0 - s_alpha) * m_lastHashCount;
+        m_lastHashCount = uint64_t(s_alpha * expected + (1.0 - s_alpha) * m_lastHashCount);
         return m_lastHashCount;
     }
 

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -1,7 +1,7 @@
 /*
  This file is part of cpp-ethereum.
 
- cpp-ethereum is free software: you can redistribute it and/or modify
+ ethminer is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
@@ -12,11 +12,7 @@
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
- */
-/** @file Miner.h
- * @author Gav Wood <i@gavwood.com>
- * @date 2015
+ along with ethminer.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once
@@ -84,8 +80,7 @@ std::ostream& operator<<(std::ostream& os, HwMonitor _hw);
 class FormattedMemSize
 {
 public:
-    FormattedMemSize() = delete;
-    FormattedMemSize(uint64_t s) { m_size = s; }
+    explicit FormattedMemSize(uint64_t s) noexcept { m_size = s; }
     uint64_t m_size;
 };
 

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -1,12 +1,12 @@
 /*
- This file is part of cpp-ethereum.
+ This file is part of ethminer.
 
  ethminer is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- cpp-ethereum is distributed in the hope that it will be useful,
+ ethminer is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.


### PR DESCRIPTION
- These functions were inlined for convenience, to avoid
  multiple declaration errors. This is not a good reason to
  inline a function.
- None of these are used in performance critical areas