### PR TITLE
NFC: Correct an assertion condition.

### DIFF
--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -852,7 +852,7 @@ Json::Value ApiConnection::getMinerStatHR()
     runtime << toString(runningTime.count());
     poolAddresses << m_farm.get_pool_addresses();
 
-    assert(p.minersHashes.size() == p.minerMonitors.size());
+    assert(p.minersHashes.size() == p.minerMonitors.size() || p.minerMonitors.size() == 0);
     assert(p.minersHashes.size() == p.miningIsPaused.size());
 
     for (unsigned gpuIndex = 0; gpuIndex < p.minersHashes.size(); gpuIndex++)


### PR DESCRIPTION
Now p.minerMonitors.size() can also be 0 if  --HWMON option was not supplied.