### PR TITLE
Apply simple moving average over 10 hash rate samples

### DIFF
--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -668,8 +668,6 @@ public:
             };
 
             CLMiner::setNumInstances(m_miningThreads);
-            // If not averaging set alpha to 1.0, effectively disabling it
-            Miner::EnableHashRateAveraging(.45);
 #else
             cerr << endl
                  << "Selected GPU mining without having compiled with -DETHASHCL=ON"
@@ -704,8 +702,6 @@ public:
             }
 
             CUDAMiner::setParallelHash(m_cudaParallelHash);
-            // Nvidia is stable and doesn't need averaging
-            Miner::EnableHashRateAveraging(1.0);
 #else
             cerr << endl
                  << "CUDA support disabled. Configure project build with -DETHASHCUDA=ON"

--- a/libethcore/Miner.cpp
+++ b/libethcore/Miner.cpp
@@ -33,8 +33,6 @@ bool Miner::s_exit = false;
 
 bool Miner::s_noeval = false;
 
-double Miner::s_alpha = 1.0;
-
 std::ostream& operator<<(std::ostream& os, HwMonitor _hw)
 {
     os << _hw.tempC << "C " << _hw.fanP << "%";


### PR DESCRIPTION
- Restore miner hash rate smoothing
- SMA does better job than exponential averaging