### PR TITLE
Generate DAG only on change - even when switching connection

### DIFF
--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -179,8 +179,6 @@ public:
 
         m_isMining.store(true, std::memory_order_relaxed);
         m_lastSealer = _sealer;
-        b_lastMixed = mixed;
-
 
         return true;
     }
@@ -536,7 +534,6 @@ private:
 
     std::map<std::string, SealerDescriptor> m_sealers;
     std::string m_lastSealer;
-    bool b_lastMixed = false;
 
     boost::asio::io_service::strand m_io_strand;
     boost::asio::deadline_timer m_collectTimer;

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -237,17 +237,11 @@ void PoolManager::workLoop()
                         m_activeConnectionIdx = 0;
                     }
 
-                    // Stop mining if applicable as we're switching
+                    // Suspend mining if applicable as we're switching
                     if (m_farm.isMining())
                     {
-                        cnote << "Shutting down miners...";
-                        m_farm.stop();
-
-                        // Give some time to mining threads to shutdown
-                        for (auto i = 4; --i; this_thread::sleep_for(chrono::seconds(1)))
-                        {
-                            cnote << "Retrying in " << i << "... \r";
-                        }
+                        cnote << "Suspend mining due connection change...";
+                        m_farm.setWork({}); /* suspend by setting empty work package */
                     }
                 }
 
@@ -336,17 +330,16 @@ void PoolManager::setActiveConnection(unsigned int idx)
     // Sets the active connection to the requested index
     if (idx != m_activeConnectionIdx)
     {
-
-        // Stop mining if applicable as we're switching
-        if (m_farm.isMining())
-        {
-            cnote << "Shutting down miners...";
-            m_farm.stop();
-        }
-
         m_activeConnectionIdx = idx;
         m_connectionAttempt = 0;
         p_client->disconnect();
+
+        // Suspend mining if applicable as we're switching
+        if (m_farm.isMining())
+        {
+            cnote << "Suspend mining due connection change...";
+            m_farm.setWork({}); /* suspend by setting empty work package */
+        }
     }
 }
 


### PR DESCRIPTION
As the DAG only depends on the epoch we don't have to destroy all mining
threads and delete the DAG if we change a connection.
Keep the mining threads alive but suspend them while connection change.
If the new connection has a different epoch DAG will be generated when mining is resumed.
    
This should result in faster pool failover switches and faster connection
switches via API as the DAG will be only generated if we get a different epoch.