### PR TITLE
A method for nearly instantaneous hash rate measurements.

### DIFF
--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -789,7 +789,7 @@ private:
             auto mp = f.miningProgress();
             if (!i)
                 continue;
-            auto rate = mp.rate();
+            auto rate = mp.hashRate;
 
             cout << rate << endl;
             results.push_back(rate);

--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -789,11 +789,11 @@ private:
             auto mp = f.miningProgress();
             if (!i)
                 continue;
-            auto rate = mp.hashRate;
+            auto rate = uint64_t(mp.hashRate);
 
             cout << rate << endl;
             results.push_back(rate);
-            mean += rate;
+            mean += uint64_t(rate);
         }
         sort(results.begin(), results.end());
         cout << "min/mean/max: " << results.front() << "/" << (mean / _trials) << "/"

--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -794,7 +794,7 @@ Json::Value ApiConnection::getMinerStat1()
     int numGpus = p.minersHashRates.size();
     for (auto const& i : p.minersHashRates)
     {
-        detailedMhEth << std::fixed << std::setprecision(0) << p.minersHashRates[i] / 1000.0f
+        detailedMhEth << std::fixed << std::setprecision(0) << i / 1000.0f
                       << (((numGpus - 1) > gpuIndex) ? ";" : "");
         detailedMhDcr << "off"
                       << (((numGpus - 1) > gpuIndex) ? ";" : "");  // DualMining not supported

--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -783,7 +783,7 @@ Json::Value ApiConnection::getMinerStat1()
     ostringstream poolAddresses;
     ostringstream invalidStats;
 
-    totalMhEth << std::fixed << std::setprecision(0) << (p.rate() / 1000.0f) << ";"
+    totalMhEth << std::fixed << std::setprecision(0) << p.hashRate / 1000.0f << ";"
                << s.getAccepts() << ";" << s.getRejects();
     totalMhDcr << "0;0;0";                    // DualMining not supported
     invalidStats << s.getFailures() << ";0";  // Invalid + Pool switches
@@ -791,10 +791,10 @@ Json::Value ApiConnection::getMinerStat1()
     invalidStats << ";0;0";  // DualMining not supported
 
     int gpuIndex = 0;
-    int numGpus = p.minersHashes.size();
-    for (auto const& i : p.minersHashes)
+    int numGpus = p.minersHashRates.size();
+    for (auto const& i : p.minersHashRates)
     {
-        detailedMhEth << std::fixed << std::setprecision(0) << (p.minerRate(i) / 1000.0f)
+        detailedMhEth << std::fixed << std::setprecision(0) << p.minersHashRates[i] / 1000.0f
                       << (((numGpus - 1) > gpuIndex) ? ";" : "");
         detailedMhDcr << "off"
                       << (((numGpus - 1) > gpuIndex) ? ";" : "");  // DualMining not supported
@@ -855,11 +855,11 @@ Json::Value ApiConnection::getMinerStatHR()
     assert(p.minersHashes.size() == p.minerMonitors.size() || p.minerMonitors.size() == 0);
     assert(p.minersHashes.size() == p.miningIsPaused.size());
 
-    for (unsigned gpuIndex = 0; gpuIndex < p.minersHashes.size(); gpuIndex++)
+    for (unsigned gpuIndex = 0; gpuIndex < p.minersHashRates.size(); gpuIndex++)
     {
         bool doMonitors = (gpuIndex < p.minerMonitors.size());
 
-        detailedMhEth[gpuIndex] = p.minersHashes[gpuIndex];
+        detailedMhEth[gpuIndex] = p.minersHashRates[gpuIndex];
         // detailedMhDcr[gpuIndex] = "off"; //Not supported
 
         if (doMonitors)
@@ -882,7 +882,7 @@ Json::Value ApiConnection::getMinerStatHR()
     jRes["version"] = version.str();  // miner version.
     jRes["runtime"] = runtime.str();  // running time, in minutes.
     // total ETH hashrate in MH/s, number of ETH shares, number of ETH rejected shares.
-    jRes["ethhashrate"] = (p.rate());
+    jRes["ethhashrate"] = p.hashRate;
     jRes["ethhashrates"] = detailedMhEth;
     jRes["ethshares"] = s.getAccepts();
     jRes["ethrejected"] = s.getRejects();

--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -882,7 +882,7 @@ Json::Value ApiConnection::getMinerStatHR()
     jRes["version"] = version.str();  // miner version.
     jRes["runtime"] = runtime.str();  // running time, in minutes.
     // total ETH hashrate in MH/s, number of ETH shares, number of ETH rejected shares.
-    jRes["ethhashrate"] = p.hashRate;
+    jRes["ethhashrate"] = uint64_t(p.hashRate);
     jRes["ethhashrates"] = detailedMhEth;
     jRes["ethshares"] = s.getAccepts();
     jRes["ethrejected"] = s.getRejects();

--- a/libapicore/httpServer.cpp
+++ b/libapicore/httpServer.cpp
@@ -44,9 +44,9 @@ void httpServer::getstat1(stringstream& ss)
           "Percent.</th><th>Power (W)</th></tr>";
     double hashSum = 0.0;
     double powerSum = 0.0;
-    for (unsigned i = 0; i < p.minersHashes.size(); i++)
+    for (unsigned i = 0; i < p.minersHashRates.size(); i++)
     {
-        double rate = p.minerRate(p.minersHashes[i]) / 1000000.0;
+        double rate = p.minersHashRates[i] / 1000000.0;
 
         hashSum += rate;
         ss << "<tr valign=top align=center><td";

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -292,6 +292,8 @@ void CLMiner::workLoop()
 
     uint64_t startNonce = 0;
 
+    const uint8_t kIntervalPasses = 4;  // must be a power of 2 passes
+
     // The work package currently processed by GPU.
     WorkPackage current;
     current.header = h256{1u};
@@ -428,7 +430,12 @@ void CLMiner::workLoop()
             startNonce += results.hashCount * m_workgroupSize;
 
             // Report hash count
-            updateHashRate(results.hashCount * m_workgroupSize);
+            m_hashCount += results.hashCount;
+            if ((++m_searchPasses & (kIntervalPasses - 1)) == 0)
+            {
+                updateHashRate(m_hashCount * m_workgroupSize);
+                m_hashCount = 0;
+            }
         }
         m_queue[0].finish();
     }

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -428,7 +428,7 @@ void CLMiner::workLoop()
             startNonce += results.hashCount * m_workgroupSize;
 
             // Report hash count
-            addHashCount(results.hashCount * m_workgroupSize);
+            updateHashRate(results.hashCount * m_workgroupSize);
         }
         m_queue[0].finish();
     }

--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -96,6 +96,8 @@ private:
     unsigned m_workgroupSize = 0;
     unsigned m_dagItems = 0;
     uint64_t m_lastNonce = 0;
+    uint64_t m_hashCount = 0;
+    uint8_t m_searchPasses = 0;
 
     static unsigned s_platformId;
     static unsigned s_numInstances;

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -461,7 +461,12 @@ void CUDAMiner::search(
             // Wait for stream batch to complete and immediately
             // store number of processed hashes
             CUDA_SAFE_CALL(cudaStreamSynchronize(stream));
-            addHashCount(batch_size);
+
+            // stretch cuda passes to miniize the effects of
+            // OS latency variability
+            m_searchPasses++;
+            if ((m_searchPasses & 127) == 0)
+                updateHashRate(batch_size * 128);
 
             if (shouldStop())
             {

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -410,10 +410,10 @@ void CUDAMiner::setParallelHash(unsigned _parallelHash)
 }
 
 
-
 void CUDAMiner::search(
     uint8_t const* header, uint64_t target, uint64_t _startN, const dev::eth::WorkPackage& w)
 {
+    const uint16_t kReportingInterval = 512;  // Must be a power of 2 passes
     set_header(*reinterpret_cast<hash32_t const*>(header));
     if (m_current_target != target)
     {
@@ -465,8 +465,8 @@ void CUDAMiner::search(
             // stretch cuda passes to miniize the effects of
             // OS latency variability
             m_searchPasses++;
-            if ((m_searchPasses & 127) == 0)
-                updateHashRate(batch_size * 128);
+            if ((m_searchPasses & (kReportingInterval - 1)) == 0)
+                updateHashRate(batch_size * kReportingInterval);
 
             if (shouldStop())
             {

--- a/libethash-cuda/CUDAMiner.h
+++ b/libethash-cuda/CUDAMiner.h
@@ -76,7 +76,7 @@ private:
     cudaStream_t* m_streams = nullptr;
     uint64_t m_current_target = 0;
 
-    uint8_t m_searchPasses = 0;
+    uint16_t m_searchPasses = 0;
 
     /// The local work size for the search
     static unsigned s_blockSize;

--- a/libethash-cuda/CUDAMiner.h
+++ b/libethash-cuda/CUDAMiner.h
@@ -76,6 +76,8 @@ private:
     cudaStream_t* m_streams = nullptr;
     uint64_t m_current_target = 0;
 
+    uint8_t m_searchPasses = 0;
+
     /// The local work size for the search
     static unsigned s_blockSize;
     /// The initial global work size for the searches

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -361,22 +361,21 @@ private:
             return;
 
         WorkingProgress progress;
-        progress.ms = m_collectInterval;
 
         // Process miners
         for (auto const& miner : m_miners)
         {
             // Collect and reset hashrates
-            auto minerHashCount = miner->RetrieveAndClearHashCount();
             if (!miner->is_mining_paused())
             {
-                progress.hashes += minerHashCount;
-                progress.minersHashes.push_back(minerHashCount);
+                auto hr = miner->RetrieveHashRate();
+                progress.hashRate += hr;
+                progress.minersHashRates.push_back(hr);
                 progress.miningIsPaused.push_back(false);
             }
             else
             {
-                progress.minersHashes.push_back(0);
+                progress.minersHashRates.push_back(0.0);
                 progress.miningIsPaused.push_back(true);
             }
 

--- a/libethcore/Miner.cpp
+++ b/libethcore/Miner.cpp
@@ -37,12 +37,12 @@ void Miner::updateHashRate(uint64_t n)
 {
     m_hashCounter = n;
     std::chrono::steady_clock::time_point t = std::chrono::steady_clock::now();
-    float us = std::chrono::duration_cast<std::chrono::microseconds>(t - m_hashTime).count();
+    float us = float(std::chrono::duration_cast<std::chrono::microseconds>(t - m_hashTime).count());
     m_hashTime = t;
 
     float hr = 0;
     if (us)
-        hr = m_hashCounter / (us / 1000000.0);
+        hr = float(m_hashCounter) / (us / 1000000.0);
     m_hashRate.store(hr, std::memory_order_relaxed);
 }
 
@@ -57,7 +57,7 @@ std::ostream& operator<<(std::ostream& os, HwMonitor _hw)
 std::ostream& operator<<(std::ostream& os, FormattedMemSize s)
 {
     static const char* suffixes[] = {"bytes", "KB", "MB", "GB"};
-    double d = s.m_size;
+    double d = double(s.m_size);
     unsigned i;
     for (i = 0; i < 3; i++)
     {

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -287,7 +287,7 @@ void PoolManager::workLoop()
         if (m_hashrateReportingTimePassed > m_hashrateReportingTime)
         {
             auto mp = m_farm.miningProgress();
-            std::string h = toHex(toCompactBigEndian(mp.rate(), 1));
+            std::string h = toHex(toCompactBigEndian(uint64_t(mp.hashRate), 1));
             std::string res = h[0] != '0' ? h : h.substr(1);
 
             // Should be 32 bytes


### PR DESCRIPTION
Instead of calculating hash rate at the collector's polling pass,
calculate the current hash rate of the last n batches in real
time. N is chosen to provide relatively long (.5 secs) GPU search
loop driven calculation interval. For AMD n=1 works well, and for
Nvidia which uses short batches N=128.

This PR does not affect the collector thread or the display loop,
but the collector thread may not be needed.