### PR TITLE
Introduce solutions per gpu

### DIFF
--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -753,7 +753,7 @@ private:
             [](FarmFace& _farm, unsigned _index) { return new CUDAMiner(_farm, _index); }};
 #endif
         f.setSealers(sealers);
-        f.onSolutionFound([&](Solution) { return false; });
+        f.onSolutionFound([&](Solution, unsigned const& miner_index) { (void)miner_index; return false; });
 
         f.setTStartTStop(m_tstart, m_tstop);
 

--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -2,6 +2,9 @@
 
 #include <ethminer/buildinfo.h>
 
+#ifndef HOST_NAME_MAX
+#define HOST_NAME_MAX 255
+#endif
 
 /* helper functions getting values from a JSON request */
 static bool getRequestValue(const char* membername, bool& refValue, Json::Value& jRequest,
@@ -932,7 +935,7 @@ Json::Value ApiConnection::getMinerStatDetailPerMiner(
     jshares["acceptedstale"] = s.getAcceptedStales(index);
     auto solution_lastupdated = std::chrono::duration_cast<std::chrono::minutes>(
         std::chrono::steady_clock::now() - s.getLastUpdated(index));
-    jshares["lastupdate"] = solution_lastupdated.count();
+    jshares["lastupdate"] = uint64_t(solution_lastupdated.count());
     jRes["shares"] = jshares;
 
 
@@ -992,7 +995,7 @@ Json::Value ApiConnection::getMinerStatDetail()
     Json::Value jRes;
 
     jRes["version"] = ethminer_get_buildinfo()->project_name_with_version;  // miner version.
-    jRes["runtime"] = runningTime.count();  // running time, in minutes.
+    jRes["runtime"] = uint64_t(runningTime.count());  // running time, in minutes.
 
     {
         // Even the client should know which host was queried

--- a/libapicore/ApiServer.h
+++ b/libapicore/ApiServer.h
@@ -56,6 +56,10 @@ private:
     void sendSocketData(Json::Value const& jReq);
     void onSendSocketDataCompleted(const boost::system::error_code& ec);
 
+    Json::Value getMinerStatDetail();
+    Json::Value getMinerStatDetailPerMiner(
+        const WorkingProgress& p, const SolutionStats& s, size_t index);
+
     Disconnected m_onDisconnected;
 
     int m_sessionId;

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -408,16 +408,16 @@ void CLMiner::workLoop()
                     {
                         h256 mix;
                         memcpy(mix.data(), (char*)results.rslt[i].mix, sizeof(results.rslt[i].mix));
-                        farm.submitProof(Solution{nonce, mix, current, false});
+                        farm.submitProof(Solution{nonce, mix, current, false}, index);
                     }
                     else
                     {
                         Result r = EthashAux::eval(current.epoch, current.header, nonce);
                         if (r.value <= current.boundary)
-                            farm.submitProof(Solution{nonce, r.mixHash, current, false});
+                            farm.submitProof(Solution{nonce, r.mixHash, current, false}, index);
                         else
                         {
-                            farm.failedSolution();
+                            farm.failedSolution(index);
                             cwarn << "GPU gave incorrect result!";
                         }
                     }

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -494,18 +494,18 @@ void CUDAMiner::search(
                         h256 minerMix;
                         memcpy(minerMix.data(), (void*)&buffer->result[i].mix,
                             sizeof(buffer->result[i].mix));
-                        farm.submitProof(Solution{minerNonce, minerMix, w, m_new_work});
+                        farm.submitProof(Solution{minerNonce, minerMix, w, m_new_work}, index);
                     }
                     else
                     {
                         Result r = EthashAux::eval(w.epoch, w.header, minerNonce);
                         if (r.value <= w.boundary)
                         {
-                            farm.submitProof(Solution{minerNonce, r.mixHash, w, m_new_work});
+                            farm.submitProof(Solution{minerNonce, r.mixHash, w, m_new_work}, index);
                         }
                         else
                         {
-                            farm.failedSolution();
+                            farm.failedSolution(index);
                             cwarn
                                 << "GPU gave incorrect result! Lower OC if this happens frequently";
                         }

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -247,25 +247,25 @@ public:
 
     std::shared_ptr<Miner> getMiner(unsigned index) { return m_miners[index]; }
 
-    SolutionStats getSolutionStats() { return m_solutionStats; }
+    SolutionStats getSolutionStats() { return m_solutionStats; } // returns a copy
 
-    void failedSolution() override { m_solutionStats.failed(); }
+    void failedSolution(unsigned _miner_index) override { m_solutionStats.failed(_miner_index); }
 
-    void acceptedSolution(bool _stale)
+    void acceptedSolution(bool _stale, unsigned _miner_index)
     {
         if (!_stale)
         {
-            m_solutionStats.accepted();
+            m_solutionStats.accepted(_miner_index);
         }
         else
         {
-            m_solutionStats.acceptedStale();
+            m_solutionStats.acceptedStale(_miner_index);
         }
     }
 
-    void rejectedSolution() { m_solutionStats.rejected(); }
+    void rejectedSolution(unsigned _miner_index) { m_solutionStats.rejected(_miner_index); }
 
-    using SolutionFound = std::function<void(const Solution&)>;
+    using SolutionFound = std::function<void(const Solution&, unsigned)>;
     using MinerRestart = std::function<void()>;
 
     /**
@@ -510,14 +510,13 @@ private:
 
     /**
      * @brief Called from a Miner to note a WorkPackage has a solution.
-     * @param _p The solution.
-     * @param _wp The WorkPackage that the Solution is for.
-     * @return true iff the solution was good (implying that mining should be .
+     * @param _s The solution.
+     * @param _miner_index Index of the miner
      */
-    void submitProof(Solution const& _s) override
+    void submitProof(Solution const& _s, unsigned _miner_index) override
     {
         assert(m_onSolutionFound);
-        m_onSolutionFound(_s);
+        m_onSolutionFound(_s, _miner_index);
     }
 
     mutable Mutex x_minerWork;

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -245,7 +245,14 @@ public:
         return m_progress;
     }
 
-    std::shared_ptr<Miner> getMiner(unsigned index) { return m_miners[index]; }
+    std::vector<std::shared_ptr<Miner>> getMiners() { return m_miners; }
+
+    std::shared_ptr<Miner> getMiner(unsigned index)
+    {
+        if (index >= m_miners.size())
+            return nullptr;
+        return m_miners[index];
+    }
 
     SolutionStats getSolutionStats() { return m_solutionStats; } // returns a copy
 

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -116,10 +116,37 @@ struct MiningPause
         return (MinigPauseReason)m_mining_paused_flag.load(std::memory_order_relaxed);
     }
 
+    bool is_mining_paused(const MinigPauseReason& pause_reason)
+    {
+        return (pause_reason != MinigPauseReason::MINING_NOT_PAUSED);
+    }
+
     bool is_mining_paused()
     {
-        return (m_mining_paused_flag.load(std::memory_order_relaxed) !=
-                MinigPauseReason::MINING_NOT_PAUSED);
+        return is_mining_paused(get_mining_paused());
+    }
+
+    std::string get_mining_paused_string(const MinigPauseReason& pause_reason)
+    {
+        std::string seperator = "";
+        std::string r = "";
+
+        if (pause_reason & MinigPauseReason::MINING_PAUSED_WAIT_FOR_T_START)
+        {
+            r += seperator + "temperature";
+            seperator = ",";
+        }
+        if (pause_reason & MinigPauseReason::MINING_PAUSED_API)
+        {
+            r += seperator + "api";
+            seperator = ",";
+        }
+        return r;
+    }
+
+    std::string get_mining_paused_string()
+    {
+        return get_mining_paused_string(get_mining_paused());
     }
 };
 
@@ -353,6 +380,8 @@ public:
     {
         m_mining_paused.clear_mining_paused(pause_reason);
     }
+
+    MinigPauseReason get_mining_paused() { return m_mining_paused.get_mining_paused(); }
 
     bool is_mining_paused() { return m_mining_paused.is_mining_paused(); }
 

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -128,19 +128,14 @@ struct MiningPause
 
     std::string get_mining_paused_string(const MinigPauseReason& pause_reason)
     {
-        std::string seperator = "";
-        std::string r = "";
+        std::string r;
 
         if (pause_reason & MinigPauseReason::MINING_PAUSED_WAIT_FOR_T_START)
-        {
-            r += seperator + "temperature";
-            seperator = ",";
-        }
+            r = "temperature";
+
         if (pause_reason & MinigPauseReason::MINING_PAUSED_API)
-        {
-            r += seperator + "api";
-            seperator = ",";
-        }
+            r += (string)(r.empty() ? "" : ",") + "api";
+
         return r;
     }
 

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -176,34 +176,42 @@ public:
 
     void accepted(unsigned miner_index)
     {
-        extendArray(m_accepts, 0u, miner_index);
+        if (m_accepts.size() <= miner_index)
+            m_accepts.resize(miner_index + 1);
         m_accepts[miner_index]++;
         auto now = std::chrono::steady_clock::now();
-        extendArray(m_lastUpdated, now, miner_index);
+        if (m_lastUpdated.size() <= miner_index)
+            m_lastUpdated.resize(miner_index + 1, now);
         m_lastUpdated[miner_index] = now;
     }
     void rejected(unsigned miner_index)
     {
-        extendArray(m_rejects, 0u, miner_index);
+        if (m_rejects.size() <= miner_index)
+            m_rejects.resize(miner_index + 1);
         m_rejects[miner_index]++;
         auto now = std::chrono::steady_clock::now();
-        extendArray(m_lastUpdated, now, miner_index);
+        if (m_lastUpdated.size() <= miner_index)
+            m_lastUpdated.resize(miner_index + 1, now);
         m_lastUpdated[miner_index] = now;
     }
     void failed(unsigned miner_index)
     {
-        extendArray(m_failures, 0u, miner_index);
+        if (m_failures.size() <= miner_index)
+            m_failures.resize(miner_index + 1);
         m_failures[miner_index]++;
         auto now = std::chrono::steady_clock::now();
-        extendArray(m_lastUpdated, now, miner_index);
+        if (m_lastUpdated.size() <= miner_index)
+            m_lastUpdated.resize(miner_index + 1, now);
         m_lastUpdated[miner_index] = now;
     }
     void acceptedStale(unsigned miner_index)
     {
-        extendArray(m_acceptedStales, 0u, miner_index);
+        if (m_acceptedStales.size() <= miner_index)
+            m_acceptedStales.resize(miner_index + 1);
         m_acceptedStales[miner_index]++;
         auto now = std::chrono::steady_clock::now();
-        extendArray(m_lastUpdated, now, miner_index);
+        if (m_lastUpdated.size() <= miner_index)
+            m_lastUpdated.resize(miner_index + 1, now);
         m_lastUpdated[miner_index] = now;
     }
 
@@ -250,18 +258,6 @@ private:
         for (size_t i = 0; i < array.size(); i++)
             r += array[i];
         return r;
-    }
-
-    template <typename T>
-    void extendArray(std::vector<T>& array, const T& initial_value, const size_t n) const
-    {
-        if (array.size() <= n)
-        {
-            do
-            {
-                array.push_back(initial_value);
-            } while (array.size() <= n);
-        }
     }
 
     std::vector<unsigned> m_accepts = {};

--- a/libpoolprotocols/PoolClient.h
+++ b/libpoolprotocols/PoolClient.h
@@ -26,6 +26,7 @@ public:
         m_canconnect.store(false, std::memory_order_relaxed);
     }
 
+    const URI* getConnection() { return m_conn; }
     void unsetConnection() { m_conn = nullptr; }
 
     virtual void connect() = 0;

--- a/libpoolprotocols/PoolClient.h
+++ b/libpoolprotocols/PoolClient.h
@@ -32,13 +32,13 @@ public:
     virtual void disconnect() = 0;
 
     virtual void submitHashrate(string const& rate) = 0;
-    virtual void submitSolution(const Solution& solution) = 0;
+    virtual void submitSolution(const Solution& solution, unsigned const& miner_index) = 0;
     virtual bool isConnected() = 0;
     virtual bool isPendingState() = 0;
     virtual string ActiveEndPoint() = 0;
 
-    using SolutionAccepted = std::function<void(bool const&, std::chrono::milliseconds const&)>;
-    using SolutionRejected = std::function<void(bool const&, std::chrono::milliseconds const&)>;
+    using SolutionAccepted = std::function<void(bool const&, std::chrono::milliseconds const&, unsigned const& miner_index)>;
+    using SolutionRejected = std::function<void(bool const&, std::chrono::milliseconds const&, unsigned const& miner_index)>;
     using Disconnected = std::function<void()>;
     using Connected = std::function<void()>;
     using WorkReceived = std::function<void(WorkPackage const&)>;

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -319,6 +319,13 @@ void PoolManager::setActiveConnection(unsigned int idx)
     }
 }
 
+const URI *PoolManager::getActiveConnection()
+{
+    if (m_connections.size() > m_activeConnectionIdx)
+        return &m_connections.at(m_activeConnectionIdx);
+    return nullptr;
+}
+
 Json::Value PoolManager::getConnectionsJson()
 {
     // Returns the list of configured connections

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -74,7 +74,8 @@ PoolManager::PoolManager(boost::asio::io_service& io_service, PoolClient* client
                 "0xffff000000000000000000000000000000000000000000000000000000000000");
             const uint256_t divisor(string("0x") + m_lastBoundary.hex());
             std::stringstream ss;
-            ss << fixed << setprecision(2) << double(dividend / divisor) / 1000000000.0
+            m_lastDifficulty = double(dividend / divisor);
+            ss << fixed << setprecision(2) << m_lastDifficulty / 1000000000.0
                << "K megahash";
             cnote << "Pool difficulty: " EthWhite << ss.str() << EthReset;
         }
@@ -363,4 +364,13 @@ void PoolManager::check_failover_timeout(const boost::system::error_code& ec)
             }
         }
     }
+}
+
+double PoolManager::getCurrentDifficulty()
+{
+    if (!m_running.load(std::memory_order_relaxed))
+        return 0.0;
+    if (!p_client->isConnected())
+        return 0.0;
+    return m_lastDifficulty;
 }

--- a/libpoolprotocols/PoolManager.h
+++ b/libpoolprotocols/PoolManager.h
@@ -25,6 +25,7 @@ public:
     void clearConnections();
     Json::Value getConnectionsJson();
     void setActiveConnection(unsigned int idx);
+    const URI *getActiveConnection();
     void removeConnection(unsigned int idx);
     void start();
     void stop();

--- a/libpoolprotocols/PoolManager.h
+++ b/libpoolprotocols/PoolManager.h
@@ -30,6 +30,7 @@ public:
     void stop();
     bool isConnected() { return p_client->isConnected(); };
     bool isRunning() { return m_running; };
+    double getCurrentDifficulty();
 
 private:
     unsigned m_hashrateReportingTime = 60;
@@ -59,6 +60,7 @@ private:
     MinerType m_minerType;
 
     int m_lastEpoch = 0;
+    double m_lastDifficulty = 0.0;
 };
 }  // namespace eth
 }  // namespace dev

--- a/libpoolprotocols/getwork/EthGetworkClient.cpp
+++ b/libpoolprotocols/getwork/EthGetworkClient.cpp
@@ -64,7 +64,7 @@ void EthGetworkClient::submitHashrate(string const& rate)
     m_currentHashrateToSubmit = rate;
 }
 
-void EthGetworkClient::submitSolution(const Solution& solution)
+void EthGetworkClient::submitSolution(const Solution& solution, unsigned const& miner_index)
 {
     // Immediately send found solution without wait for loop
     if (m_connected.load(std::memory_order_relaxed))
@@ -81,14 +81,14 @@ void EthGetworkClient::submitSolution(const Solution& solution)
             {
                 if (m_onSolutionAccepted)
                 {
-                    m_onSolutionAccepted(false, response_delay_ms);
+                    m_onSolutionAccepted(false, response_delay_ms, miner_index);
                 }
             }
             else
             {
                 if (m_onSolutionRejected)
                 {
-                    m_onSolutionRejected(false, response_delay_ms);
+                    m_onSolutionRejected(false, response_delay_ms, miner_index);
                 }
             }
         }

--- a/libpoolprotocols/getwork/EthGetworkClient.h
+++ b/libpoolprotocols/getwork/EthGetworkClient.h
@@ -28,7 +28,7 @@ public:
     string ActiveEndPoint() override { return ""; };
 
     void submitHashrate(string const& rate) override;
-    void submitSolution(const Solution& solution) override;
+    void submitSolution(const Solution& solution, unsigned const& miner_index) override;
 
 private:
     void workLoop() override;

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -307,6 +307,7 @@ void EthStratumClient::disconnect_finalize()
     // Clear plea queue and stop timing
     std::chrono::steady_clock::time_point m_response_plea_time;
     clear_response_pleas();
+    m_solution_submitted_max_id = 0;
 
     // Put the actor back to sleep
     m_workloop_timer.expires_at(boost::posix_time::pos_infin);
@@ -378,6 +379,7 @@ void EthStratumClient::start_connect()
         clear_response_pleas();
         m_connecting.store(true, std::memory_order::memory_order_relaxed);
         enqueue_response_plea();
+        m_solution_submitted_max_id = 0;
 
         // Start connecting async
         if (m_conn->SecLevel() != SecureLevel::NONE)
@@ -745,8 +747,8 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
                                    // _isNotification = false)
     string _errReason = "";        // Content of the error reason
     string _method = "";           // The method of the notification (or request from pool)
-    int _id = 0;  // This SHOULD be the same id as the request it is responding to (known exception
-                  // is ethermine.org using 999)
+    unsigned _id = 0;  // This SHOULD be the same id as the request it is responding to (known exception
+                       // is ethermine.org using 999)
 
 
     // Retrieve essential values
@@ -790,13 +792,8 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
         Json::Value jResult = responseObject.get("result", Json::Value::null);
         std::chrono::milliseconds response_delay_ms(0);
 
-        if (_id >= 10 && _id <= 30) /* allow up to max 20 GPUs */
-            goto respond_to_submit_solution;
-
-        switch (_id)
+        if (_id == 1)
         {
-        case 1:
-
             response_delay_ms = dequeue_response_plea();
 
             /*
@@ -977,10 +974,10 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
             }
 
             sendSocketData(jReq);
-            break;
+        }
 
-        case 2:
-
+        else if (_id == 2)
+        {
             // This is the response to mining.extranonce.subscribe
             // according to this
             // https://github.com/nicehash/Specifications/blob/master/NiceHash_extranonce_subscribe_extension.txt
@@ -989,11 +986,10 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
             // changes correctly
 
             // Nothing to do here.
+        }
 
-            break;
-
-        case 3:
-
+        else if (_id == 3)
+        {
             response_delay_ms = dequeue_response_plea();
 
             // Response to "mining.authorize"
@@ -1029,13 +1025,10 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
                     m_onConnected();
                 }
             }
+        }
 
-            break;
-
-        // case 4:
-        // case 10 till case 30
-respond_to_submit_solution:
-
+        else if (_id >= 40 && _id <= m_solution_submitted_max_id)
+        {
             response_delay_ms = dequeue_response_plea();
 
             // Response to solution submission mining.submit
@@ -1049,7 +1042,7 @@ respond_to_submit_solution:
             }
 
             {
-                const unsigned miner_index = _id - 10;
+                const unsigned miner_index = _id - 40;
                 dequeue_response_plea();
                 if (_isSuccess)
                 {
@@ -1068,11 +1061,10 @@ respond_to_submit_solution:
                     }
                 }
             }
-            break;
+        }
 
-
-        case 5:
-
+        else if (_id == 5)
+        {
             // This is the response we get on first get_work request issued
             // in mode EthStratumClient::ETHPROXY
             // thus we change it to a mining.notify notification
@@ -1082,10 +1074,10 @@ respond_to_submit_solution:
                 _method = "mining.notify";
                 _isNotification = true;
             }
-            break;
+        }
 
-        case 9:
-
+        else if (_id == 9)
+        {
             // Response to hashrate submit
             // Shall we do anything ?
             // Hashrate submit is actually out of stratum spec
@@ -1094,10 +1086,10 @@ respond_to_submit_solution:
                 cwarn << "Submit hashRate failed:"
                       << (_errReason.empty() ? "Unspecified error" : _errReason);
             }
-            break;
+        }
 
-        case 999:
-
+        else if (_id == 999)
+        {
             // This unfortunate case should not happen as none of the outgoing requests is marked
             // with id 999 However it has been tested that ethermine.org responds with this id when
             // error replying to either mining.subscribe (1) or mining.authorize requests (3) To
@@ -1126,15 +1118,13 @@ respond_to_submit_solution:
                     return;
                 }
             };
+        }
 
-            break;
-
-
-        default:
+        else
+        {
 
             cnote << "Got response for unknown message id [" << _id << "] Discarding...";
             return;
-            break;
         }
     }
 
@@ -1351,7 +1341,9 @@ void EthStratumClient::submitSolution(const Solution& solution, unsigned const& 
 
     Json::Value jReq;
 
-    jReq["id"] = unsigned(10) + miner_index;
+    unsigned id = 40 + miner_index;
+    jReq["id"] = id;
+    m_solution_submitted_max_id = max(m_solution_submitted_max_id, id);
     jReq["method"] = "mining.submit";
     jReq["params"] = Json::Value(Json::arrayValue);
 

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -51,7 +51,7 @@ public:
     string ActiveEndPoint() override { return " [" + toString(m_endpoint) + "]"; };
 
     void submitHashrate(string const& rate) override;
-    void submitSolution(const Solution& solution) override;
+    void submitSolution(const Solution& solution, unsigned const& miner_index) override;
 
     h256 currentHeaderHash() { return m_current.header; }
     bool current() { return static_cast<bool>(m_current); }

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -132,4 +132,6 @@ private:
 
     bool m_submit_hashrate;
     std::string m_submit_hashrate_id;
+
+    unsigned m_solution_submitted_max_id; // greatest id we sent a solution
 };

--- a/libpoolprotocols/testing/SimulateClient.cpp
+++ b/libpoolprotocols/testing/SimulateClient.cpp
@@ -48,7 +48,7 @@ void SimulateClient::submitHashrate(string const& rate)
     cnote << "On difficulty" << m_difficulty << "for" << sec.count() << "seconds";
 }
 
-void SimulateClient::submitSolution(const Solution& solution)
+void SimulateClient::submitSolution(const Solution& solution, unsigned const& miner_index)
 {
     m_uppDifficulty = true;
     cnote << "Difficulty:" << m_difficulty;
@@ -64,14 +64,14 @@ void SimulateClient::submitSolution(const Solution& solution)
     {
         if (m_onSolutionAccepted)
         {
-            m_onSolutionAccepted(false, response_delay_ms);
+            m_onSolutionAccepted(false, response_delay_ms, miner_index);
         }
     }
     else
     {
         if (m_onSolutionRejected)
         {
-            m_onSolutionRejected(false, response_delay_ms);
+            m_onSolutionRejected(false, response_delay_ms, miner_index);
         }
     }
 }

--- a/libpoolprotocols/testing/SimulateClient.h
+++ b/libpoolprotocols/testing/SimulateClient.h
@@ -27,7 +27,7 @@ public:
     string ActiveEndPoint() override { return ""; };
 
     void submitHashrate(string const& rate) override;
-    void submitSolution(const Solution& solution) override;
+    void submitSolution(const Solution& solution, unsigned const& miner_index) override;
 
 private:
     void workLoop() override;


### PR DESCRIPTION
* Introduce solutions per gpu
  * @AndreaLanfranchi : I submit solutions with an id of (10 + miner_index) so I can map the response back to the corresponding gpu.
  * @chfast : Don't know if coverty likes the changes as the SolutionStat is written by Poolmanager and read by API thread. Any suggestions ?

* Keep value of last received difficulty

* Introduce API call miner_getstatdetail()
  * Use the infos "solutions per gpu" and last received difficulty
  * API interface inspired by [Andrea's comment](https://github.com/ethereum-mining/ethminer/pull/1232#discussion_r193995891) of #1232 (goto  `AndreaLanfranchi requested changes on Jun 8`  and show Outdated)
  * Think API interface is not ready being official documented