### PR TITLE
Provide more granular control of logging options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Implemented fast job switch algorithm on AMD reducing switch time to 1-2 milliseconds.
 - Added localization support for output number formatting.
 - Changed the --verbosity option to allow individual enable/disable of logging features.
+- Improved hash rate measurement accuracy.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - AMD auto kernel selection. Try bin first, if not fall back to OpenCL.
 - API: New method `miner_setverbosity`. [#1382](https://github.com/ethereum-mining/ethminer/pull/1382).
 - Implemented fast job switch algorithm on AMD reducing switch time to 1-2 milliseconds.
-- Added localization support for output number formatting
+- Added localization support for output number formatting.
+- Changed the --verbosity to allow individual enable/disable of logging features.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - API: New method `miner_setverbosity`. [#1382](https://github.com/ethereum-mining/ethminer/pull/1382).
 - Implemented fast job switch algorithm on AMD reducing switch time to 1-2 milliseconds.
 - Added localization support for output number formatting.
-- Changed the --verbosity to allow individual enable/disable of logging features.
+- Changed the --verbosity option to allow individual enable/disable of logging features.
 
 ### Removed
 

--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -910,14 +910,16 @@ private:
             }
             if (mgr.isConnected())
             {
-                auto mp = f.miningProgress();
                 auto solstats = f.getSolutionStats();
-                ostringstream ss;
-                ss << mp << ' ';
-                if (!(g_logOptions & LOG_PER_GPU))
-                    ss << solstats << ' ';
-                ss << f.farmLaunchedFormatted();
-                minelog << ss.str();
+                {
+                    auto mp = f.miningProgress();
+                    ostringstream os;
+                    os << mp << ' ';
+                    if (!(g_logOptions & LOG_PER_GPU))
+                        os << solstats << ' ';
+                    os << f.farmLaunchedFormatted();
+                    minelog << os.str();
+                }
 
                 if (g_logOptions & LOG_PER_GPU)
                 {

--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -205,9 +205,14 @@ public:
         bool version = false;
         app.add_flag("-V,--version", version, "Show program version")->group(CommonGroup);
 
-        app.add_option("-v,--verbosity", g_logVerbosity, "Set log verbosity level", true)
+        stringstream logOptions;
+        logOptions << "Set log display options. Use the summ of: Log switch time = "
+                   << LOG_SWITCH_TIME << ", log json messages = " << LOG_JSON
+                   << ", log per GPU solutions = " << LOG_PER_GPU
+                   << ", log additional debug info = " << LOG_DEBUG;
+        app.add_option("-v,--verbosity", g_logOptions, logOptions.str(), true)
             ->group(CommonGroup)
-            ->check(CLI::Range(9));
+            ->check(CLI::Range(15));
 
         app.add_option("--farm-recheck", m_farmRecheckPeriod,
                "Set check interval in milliseconds for changed work", true)
@@ -909,7 +914,7 @@ private:
                 auto solstats = f.getSolutionStats();
                 minelog << mp << ' ' << solstats << ' ' << f.farmLaunchedFormatted();
 
-                if (g_logVerbosity >= 5)
+                if (g_logOptions & LOG_PER_GPU)
                 {
                     ostringstream statdetails;
                     for (size_t i = 0; i < f.getMiners().size(); i++)

--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -205,7 +205,7 @@ public:
         bool version = false;
         app.add_flag("-V,--version", version, "Show program version")->group(CommonGroup);
 
-        stringstream logOptions;
+        ostringstream logOptions;
         logOptions << "Set log display options. Use the summ of: Log switch time = "
                    << LOG_SWITCH_TIME << ", log json messages = " << LOG_JSON
                    << ", log per GPU solutions = " << LOG_PER_GPU
@@ -473,7 +473,7 @@ public:
             ->group(CommonGroup)
             ->check(CLI::Range(30, 100));
 
-        stringstream ssHelp;
+        ostringstream ssHelp;
         ssHelp
             << "Pool URL Specification:" << endl
             << "    URL takes the form: scheme://user[.workername][:password]@hostname:port[/...]."
@@ -912,9 +912,8 @@ private:
             {
                 auto solstats = f.getSolutionStats();
                 {
-                    auto mp = f.miningProgress();
                     ostringstream os;
-                    os << mp << ' ';
+                    os << f.miningProgress() << ' ';
                     if (!(g_logOptions & LOG_PER_GPU))
                         os << solstats << ' ';
                     os << f.farmLaunchedFormatted();

--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -212,7 +212,7 @@ public:
                    << ", log additional debug info = " << LOG_DEBUG;
         app.add_option("-v,--verbosity", g_logOptions, logOptions.str(), true)
             ->group(CommonGroup)
-            ->check(CLI::Range(15));
+            ->check(CLI::Range(LOG_ALL));
 
         app.add_option("--farm-recheck", m_farmRecheckPeriod,
                "Set check interval in milliseconds for changed work", true)

--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -912,11 +912,17 @@ private:
             {
                 auto mp = f.miningProgress();
                 auto solstats = f.getSolutionStats();
-                minelog << mp << ' ' << solstats << ' ' << f.farmLaunchedFormatted();
+                ostringstream ss;
+                ss << mp << ' ';
+                if (!(g_logOptions & LOG_PER_GPU))
+                    ss << solstats << ' ';
+                ss << f.farmLaunchedFormatted();
+                minelog << ss.str();
 
                 if (g_logOptions & LOG_PER_GPU)
                 {
                     ostringstream statdetails;
+                    statdetails << "Solutions " << solstats << ' ';
                     for (size_t i = 0; i < f.getMiners().size(); i++)
                     {
                         if (i) statdetails << " ";

--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -686,10 +686,11 @@ void ApiConnection::processRequest(Json::Value& jRequest, Json::Value& jResponse
         if (!getRequestValue("verbosity", verbosity, jRequestParams, false, jResponse))
             return;
 
-        if (verbosity > 9)
+        if (verbosity > LOG_ALL)
         {
             jResponse["error"]["code"] = -422;
-            jResponse["error"]["message"] = "Verbosity out of bounds (0-9)";
+            jResponse["error"]["message"] =
+                "Verbosity out of bounds (0-" + to_string(LOG_ALL) + ")";
             return;
         }
         cnote << "Setting verbosity level to " << verbosity;

--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -693,7 +693,7 @@ void ApiConnection::processRequest(Json::Value& jRequest, Json::Value& jResponse
             return;
         }
         cnote << "Setting verbosity level to " << verbosity;
-        g_logVerbosity = verbosity;
+        g_logOptions = verbosity;
         jResponse["result"] = true;
     }
 

--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -32,7 +32,7 @@ using namespace dev;
 //⊳⊲◀▶■▣▢□▷◁▧▨▩▲◆◉◈◇◎●◍◌○◼☑☒☎☢☣☰☀♽♥♠✩✭❓✔✓✖✕✘✓✔✅⚒⚡⦸⬌∅⁕«««»»»⚙
 
 // Logging
-int g_logOptions = 0;
+unsigned g_logOptions = 0;
 bool g_logNoColor = false;
 bool g_logSyslog = false;
 

--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -32,7 +32,7 @@ using namespace dev;
 //⊳⊲◀▶■▣▢□▷◁▧▨▩▲◆◉◈◇◎●◍◌○◼☑☒☎☢☣☰☀♽♥♠✩✭❓✔✓✖✕✘✓✔✅⚒⚡⦸⬌∅⁕«««»»»⚙
 
 // Logging
-int g_logVerbosity = 4;
+int g_logOptions = 0;
 bool g_logNoColor = false;
 bool g_logSyslog = false;
 
@@ -49,11 +49,9 @@ const char* NoteChannel::name()
     return EthBlue " i";
 }
 
-LogOutputStreamBase::LogOutputStreamBase(char const* _id, unsigned _v) : m_verbosity(_v)
+LogOutputStreamBase::LogOutputStreamBase(char const* _id)
 {
     static std::locale logLocl = std::locale("");
-    if ((int)_v <= g_logVerbosity)
-    {
         m_sstr.imbue(logLocl);
         if (g_logSyslog)
             m_sstr << std::left << std::setw(8) << getThreadName() << " " EthReset;
@@ -66,7 +64,6 @@ LogOutputStreamBase::LogOutputStreamBase(char const* _id, unsigned _v) : m_verbo
             m_sstr << _id << " " EthViolet << buf << " " EthBlue << std::left << std::setw(8)
                    << getThreadName() << " " EthReset;
         }
-    }
 }
 
 /// Associate a name with each thread for nice logging.

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -37,7 +37,8 @@
 #define LOG_JSON 2
 #define LOG_PER_GPU 4
 #define LOG_DEBUG 8
-extern int g_logOptions;
+#define LOG_ALL (LOG_SWITCH_TIME | LOG_JSON | LOG_PER_GPU | LOG_DEBUG)
+extern unsigned g_logOptions;
 extern bool g_logNoColor;
 extern bool g_logSyslog;
 

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -33,7 +33,11 @@
 #include "vector_ref.h"
 
 /// The logging system's current verbosity.
-extern int g_logVerbosity;
+#define LOG_SWITCH_TIME 1
+#define LOG_JSON 2
+#define LOG_PER_GPU 4
+#define LOG_DEBUG 8
+extern int g_logOptions;
 extern bool g_logNoColor;
 extern bool g_logSyslog;
 
@@ -53,12 +57,10 @@ std::string getThreadName();
 struct LogChannel
 {
     static const char* name();
-    static const int verbosity = 1;
 };
 struct WarnChannel : public LogChannel
 {
     static const char* name();
-    static const int verbosity = 2;
 };
 struct NoteChannel : public LogChannel
 {
@@ -68,7 +70,7 @@ struct NoteChannel : public LogChannel
 class LogOutputStreamBase
 {
 public:
-    LogOutputStreamBase(char const* _id, unsigned _v);
+    LogOutputStreamBase(char const* _id);
 
     template <class T>
     void append(T const& _t)
@@ -77,7 +79,6 @@ public:
     }
 
 protected:
-    unsigned m_verbosity = 0;
     std::stringstream m_sstr;  ///< The accrued log entry.
 };
 
@@ -89,21 +90,16 @@ public:
     /// Construct a new object.
     /// If _term is true the the prefix info is terminated with a ']' character; if not it ends only
     /// with a '|' character.
-    LogOutputStream() : LogOutputStreamBase(Id::name(), Id::verbosity) {}
+    LogOutputStream() : LogOutputStreamBase(Id::name()) {}
 
     /// Destructor. Posts the accrued log entry to the g_logPost function.
-    ~LogOutputStream()
-    {
-        if (Id::verbosity <= g_logVerbosity)
-            simpleDebugOut(m_sstr.str());
-    }
+    ~LogOutputStream() { simpleDebugOut(m_sstr.str()); }
 
     /// Shift arbitrary data to the log. Spaces will be added between items as required.
     template <class T>
     LogOutputStream& operator<<(T const& _t)
     {
-        if (Id::verbosity <= g_logVerbosity)
-            append(_t);
+        append(_t);
         return *this;
     }
 };

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -384,7 +384,7 @@ void CLMiner::workLoop()
                 m_searchKernel.setArg(5, target);
                 m_searchKernel.setArg(6, 0xffffffff);
 
-                if (g_logVerbosity >= 6)
+                if (g_logOptions & LOG_SWITCH_TIME)
                     cllog << "Switch time: "
                           << std::chrono::duration_cast<std::chrono::microseconds>(
                                  std::chrono::steady_clock::now() - workSwitchStart)

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -522,7 +522,7 @@ void CUDAMiner::search(
         }
     }
 
-    if (!stop && (g_logVerbosity >= 6))
+    if (!stop && (g_logOptions & LOG_SWITCH_TIME))
     {
         cudalog << "Switch time: "
                 << std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -329,7 +329,7 @@ public:
         {
             Guard l(x_work);
             m_work = _work;
-            if (g_logVerbosity >= 6)
+            if (g_logOptions & LOG_SWITCH_TIME)
                 workSwitchStart = std::chrono::steady_clock::now();
         }
         kick_miner();

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -271,7 +271,7 @@ void EthStratumClient::disconnect_finalize()
     }
 
     // Release locking flag and set connection status
-    if (g_logVerbosity >= 6)
+    if (g_logOptions & LOG_DEBUG)
         cnote << "Socket disconnected from " << ActiveEndPoint();
     m_connected.store(false, std::memory_order_relaxed);
     m_subscribed.store(false, std::memory_order_relaxed);
@@ -373,7 +373,7 @@ void EthStratumClient::start_connect()
 
         dev::setThreadName("stratum");
 
-        if (g_logVerbosity >= 6)
+        if (g_logOptions & LOG_DEBUG)
             cnote << ("Trying " + toString(m_endpoint) + " ...");
 
         clear_response_pleas();
@@ -541,7 +541,7 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec)
 
     // We got a socket connection established
     m_canconnect.store(true, std::memory_order_relaxed);
-    if (g_logVerbosity >= 6)
+    if (g_logOptions & LOG_DEBUG)
         cnote << "Socket connected to " << ActiveEndPoint();
 
     if (m_conn->SecLevel() != SecureLevel::NONE)
@@ -736,7 +736,7 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
     dev::setThreadName("stratum");
 
     // Out received message only for debug purpouses
-    if (g_logVerbosity >= 9)
+    if (g_logOptions & LOG_JSON)
     {
         cnote << responseObject;
     }
@@ -1243,7 +1243,7 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
                     double nextWorkDifficulty =
                         max(jPrm.get(Json::Value::ArrayIndex(0), 1).asDouble(), 0.0001);
                     diffToTarget((uint32_t*)m_nextWorkBoundary.data(), nextWorkDifficulty);
-                    if (g_logVerbosity >= 8)
+                    if (g_logOptions & LOG_DEBUG)
                         cnote << "Difficulty set to " EthWhite << nextWorkDifficulty
                               << EthReset " (nicehash)";
                 }
@@ -1480,7 +1480,7 @@ void EthStratumClient::sendSocketData(Json::Value const& jReq)
         return;
 
     // Out received message only for debug purpouses
-    if (g_logVerbosity >= 9)
+    if (g_logOptions & LOG_JSON)
     {
         cnote << jReq;
     }


### PR DESCRIPTION
The verbosity level was intended to indicate severity of
a log entry. Over time we've used it inappropriately to
enable various log options. This has led us to a situation
where it is impossible to enable some options without
also enabling others.

This changes the global verbosity setting to be a set of
bits, each indicating if a log feature is enabled.

The following choices are defined and spelled out in the
help.

 #define LOG_SWITCH_TIME 1
 #define LOG_JSON 2
 #define LOG_PER_GPU 4
 #define LOG_DEBUG 8

Any combination of the sum of these options (0-15) is allowed.