### PR TITLE
Normalize hash rate sampling interval

### DIFF
--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -96,8 +96,6 @@ private:
     unsigned m_workgroupSize = 0;
     unsigned m_dagItems = 0;
     uint64_t m_lastNonce = 0;
-    uint64_t m_hashCount = 0;
-    uint8_t m_searchPasses = 0;
 
     static unsigned s_platformId;
     static unsigned s_numInstances;

--- a/libethash-cuda/CUDAMiner.h
+++ b/libethash-cuda/CUDAMiner.h
@@ -76,8 +76,6 @@ private:
     cudaStream_t* m_streams = nullptr;
     uint64_t m_current_target = 0;
 
-    uint16_t m_searchPasses = 0;
-
     /// The local work size for the search
     static unsigned s_blockSize;
     /// The initial global work size for the searches

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -467,6 +467,7 @@ private:
                 progress.minerMonitors.push_back(hw);
 
             }
+            miner->TriggerHashRateUpdate();
         }
 
         m_progress = progress;

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -330,7 +330,7 @@ public:
             Guard l(x_work);
             m_work = _work;
             if (g_logOptions & LOG_SWITCH_TIME)
-                workSwitchStart = std::chrono::steady_clock::now();
+                m_workSwitchStart = std::chrono::steady_clock::now();
         }
         kick_miner();
     }
@@ -395,6 +395,7 @@ public:
     bool is_mining_paused() { return m_mining_paused.is_mining_paused(); }
 
     float RetrieveHashRate() { return m_hashRate.load(std::memory_order_relaxed); }
+    void TriggerHashRateUpdate() { m_hashRateUpdate.store(true, std::memory_order_relaxed); }
 
 protected:
     /**
@@ -430,8 +431,10 @@ protected:
 
     const size_t index = 0;
     FarmFace& farm;
-    std::chrono::steady_clock::time_point workSwitchStart;
+    std::chrono::steady_clock::time_point m_workSwitchStart;
     HwMonitorInfo m_hwmoninfo;
+    atomic<bool> m_hashRateUpdate = {false};
+    uint64_t m_hashCount = 0;
 
 private:
     MiningPause m_mining_paused;


### PR DESCRIPTION
- The hardware data collector is invoked every 5 seconds.
  there is no need for hash rates to be calculated more
  frequently. Let the collector trigger hash rate calculation.
- This has the added advantage of decoupling the sampling
  interval from group and multiplier parameters.