### PR TITLE
Cleanup cuda miner

### DIFF
--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -480,14 +480,14 @@ void CUDAMiner::search(
                         h256 minerMix;
                         memcpy(minerMix.data(), (void*)&buffer.result[i].mix,
                             sizeof(buffer.result[i].mix));
-                        farm.submitProof(Solution{minerNonce, minerMix, w, m_new_work}, index);
+                        farm.submitProof(Solution{minerNonce, minerMix, w, done}, index);
                     }
                     else
                     {
                         Result r = EthashAux::eval(w.epoch, w.header, minerNonce);
                         if (r.value <= w.boundary)
                         {
-                            farm.submitProof(Solution{minerNonce, r.mixHash, w, m_new_work}, index);
+                            farm.submitProof(Solution{minerNonce, r.mixHash, w, done}, index);
                         }
                         else
                         {

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -460,12 +460,6 @@ void CUDAMiner::search(
             // store number of processed hashes
             CUDA_SAFE_CALL(cudaStreamSynchronize(stream));
 
-            if (shouldStop())
-            {
-                m_new_work.store(false, std::memory_order_relaxed);
-                done = true;
-            }
-
             // See if we got solutions in this batch
             uint32_t found_count = buffer.count;
             if (found_count)
@@ -515,6 +509,13 @@ void CUDAMiner::search(
         }
 
         updateHashRate(batch_size, s_numStreams);
+
+        if (shouldStop())
+        {
+            m_new_work.store(false, std::memory_order_relaxed);
+            break;
+        }
+
     }
 
     if (!shouldStop() && (g_logOptions & LOG_SWITCH_TIME))

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -78,9 +78,6 @@ bool CUDAMiner::init(int epoch)
                 << " (Compute " + to_string(device_props.major) + "." +
                        to_string(device_props.minor) + ")";
 
-        m_search_buf = new volatile search_results*[s_numStreams];
-        m_streams = new cudaStream_t[s_numStreams];
-
         const auto& context = ethash::get_global_epoch_context(epoch);
         const auto lightNumItems = context.light_cache_num_items;
         const auto lightSize = ethash::get_light_cache_size(lightNumItems);
@@ -135,7 +132,7 @@ bool CUDAMiner::init(int epoch)
             cudalog << "Generating mining buffers";
             for (unsigned i = 0; i != s_numStreams; ++i)
             {
-                CUDA_SAFE_CALL(cudaMallocHost(&m_search_buf[i], sizeof(search_results)));
+                CUDA_SAFE_CALL(cudaMallocHost(&m_search_buf[i], sizeof(Search_results)));
                 CUDA_SAFE_CALL(cudaStreamCreateWithFlags(&m_streams[i], cudaStreamNonBlocking));
             }
 
@@ -216,6 +213,10 @@ void CUDAMiner::workLoop()
 {
     WorkPackage current;
     current.header = h256{1u};
+
+    m_search_buf.resize(s_numStreams);
+    m_streams.resize(s_numStreams);
+
 
     try
     {
@@ -427,7 +428,6 @@ void CUDAMiner::search(
     const uint32_t batch_size = s_gridSize * s_blockSize;
     // Nonces processed in one pass by all streams
     const uint32_t streams_batch_size = batch_size * s_numStreams;
-    volatile search_results* buffer;
 
     // prime each stream and clear search result buffers
     uint32_t current_index;
@@ -435,16 +435,15 @@ void CUDAMiner::search(
          current_index++, current_nonce += batch_size)
     {
         cudaStream_t stream = m_streams[current_index];
-        buffer = m_search_buf[current_index];
-        buffer->count = 0;
+        volatile Search_results& buffer(*m_search_buf[current_index]);
+        buffer.count = 0;
 
         // Run the batch for this stream
-        run_ethash_search(s_gridSize, s_blockSize, stream, buffer, current_nonce, m_parallelHash);
+        run_ethash_search(s_gridSize, s_blockSize, stream, &buffer, current_nonce, m_parallelHash);
     }
 
     // process stream batches until we get new work.
     bool done = false;
-    bool stop = false;
     while (!done)
     {
         bool t = true;
@@ -455,7 +454,7 @@ void CUDAMiner::search(
              current_index++, current_nonce += batch_size)
         {
             cudaStream_t stream = m_streams[current_index];
-            buffer = m_search_buf[current_index];
+            volatile Search_results& buffer(*m_search_buf[current_index]);
 
             // Wait for stream batch to complete and immediately
             // store number of processed hashes
@@ -465,14 +464,15 @@ void CUDAMiner::search(
             {
                 m_new_work.store(false, std::memory_order_relaxed);
                 done = true;
-                stop = true;
             }
 
             // See if we got solutions in this batch
-            uint32_t found_count = std::min((unsigned)buffer->count, SEARCH_RESULTS);
+            uint32_t found_count = buffer.count;
             if (found_count)
             {
-                buffer->count = 0;
+                if (found_count > MAX_SEARCH_RESULTS)
+                    found_count = MAX_SEARCH_RESULTS;
+                buffer.count = 0;
                 uint64_t nonce_base = current_nonce - streams_batch_size;
 
                 // Pass the solution(s) for submission
@@ -480,12 +480,12 @@ void CUDAMiner::search(
 
                 for (uint32_t i = 0; i < found_count; i++)
                 {
-                    minerNonce = nonce_base + buffer->result[i].gid;
+                    minerNonce = nonce_base + buffer.result[i].gid;
                     if (s_noeval)
                     {
                         h256 minerMix;
-                        memcpy(minerMix.data(), (void*)&buffer->result[i].mix,
-                            sizeof(buffer->result[i].mix));
+                        memcpy(minerMix.data(), (void*)&buffer.result[i].mix,
+                            sizeof(buffer.result[i].mix));
                         farm.submitProof(Solution{minerNonce, minerMix, w, m_new_work}, index);
                     }
                     else
@@ -507,15 +507,17 @@ void CUDAMiner::search(
             }
 
             // restart the stream on the next batch of nonces
-            if (!done)
-                run_ethash_search(
-                    s_gridSize, s_blockSize, stream, buffer, current_nonce, m_parallelHash);
+            if (done)
+                continue;
+
+            run_ethash_search(
+                s_gridSize, s_blockSize, stream, &buffer, current_nonce, m_parallelHash);
         }
 
         updateHashRate(batch_size, s_numStreams);
     }
 
-    if (!stop && (g_logOptions & LOG_SWITCH_TIME))
+    if (!shouldStop() && (g_logOptions & LOG_SWITCH_TIME))
     {
         cudalog << "Switch time: "
                 << std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/libethash-cuda/CUDAMiner.h
+++ b/libethash-cuda/CUDAMiner.h
@@ -72,8 +72,8 @@ private:
     int m_dag_size = -1;
     uint32_t m_device_num = 0;
 
-    volatile search_results** m_search_buf = nullptr;
-    cudaStream_t* m_streams = nullptr;
+    std::vector<volatile Search_results*> m_search_buf;
+    std::vector<cudaStream_t> m_streams;
     uint64_t m_current_target = 0;
 
     /// The local work size for the search

--- a/libethash-cuda/ethash_cuda_miner_kernel.cu
+++ b/libethash-cuda/ethash_cuda_miner_kernel.cu
@@ -17,7 +17,7 @@
 template <uint32_t _PARALLEL_HASH>
 __global__ void 
 ethash_search(
-	volatile search_results* g_output,
+	volatile Search_results* g_output,
 	uint64_t start_nonce
 	)
 {
@@ -26,7 +26,7 @@ ethash_search(
         if (compute_hash<_PARALLEL_HASH>(start_nonce + gid, d_target, mix))
 		return;
 	uint32_t index = atomicInc((uint32_t *)&g_output->count, 0xffffffff);
-	if (index >= SEARCH_RESULTS)
+	if (index >= MAX_SEARCH_RESULTS)
 		return;
 	g_output->result[index].gid = gid;
 	g_output->result[index].mix[0] = mix[0].x;
@@ -43,7 +43,7 @@ void run_ethash_search(
 	uint32_t gridSize,
 	uint32_t blockSize,
 	cudaStream_t stream,
-	volatile search_results* g_output,
+	volatile Search_results* g_output,
 	uint64_t start_nonce,
 	uint32_t parallelHash
 )

--- a/libethash-cuda/ethash_cuda_miner_kernel.h
+++ b/libethash-cuda/ethash_cuda_miner_kernel.h
@@ -11,18 +11,20 @@
 // one solution per stream hash calculation
 // Leave room for up to 4 results. A power
 // of 2 here will yield better CUDA optimization
-#define SEARCH_RESULTS 4U
+#define MAX_SEARCH_RESULTS 4U
 
-struct search_results
+struct Result
+{
+    // One word for gid and 8 for mix hash
+    uint32_t gid;
+    uint32_t mix[8];
+    uint32_t pad[7];  // pad to size power of 2
+};
+
+struct Search_results
 {
     uint32_t count;
-    struct
-    {
-        // One word for gid and 8 for mix hash
-        uint32_t gid;
-        uint32_t mix[8];
-        uint32_t pad[7];  // pad to size power of 2
-    } result[SEARCH_RESULTS];
+    Result result[MAX_SEARCH_RESULTS];
 };
 
 #define ACCESSES 64
@@ -59,7 +61,7 @@ void set_header(hash32_t _header);
 void set_target(uint64_t _target);
 
 void run_ethash_search(uint32_t gridSize, uint32_t blockSize, cudaStream_t stream,
-    volatile search_results* g_output, uint64_t start_nonce, uint32_t parallelHash);
+    volatile Search_results* g_output, uint64_t start_nonce, uint32_t parallelHash);
 
 void ethash_generate_dag(uint64_t dag_size, uint32_t blocks, uint32_t threads, cudaStream_t stream);
 


### PR DESCRIPTION
- Capitalize type names of search_results structs
- Use references rather than pointers
- Scope variables