### PR TITLE
CUDA search loop optimization - pass 2!

### DIFF
--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -535,10 +535,10 @@ void CUDAMiner::search(
                     if (s_noeval)
                     {
                         // noeval... use the GPU calculated mix hash.
-                        h256 minerMix;
-                        memcpy(minerMix.data(), (void*)&buffer.result[i].mix,
-                            sizeof(buffer.result[i].mix));
-                        farm.submitProof(Solution{nonce, minerMix, w, done}, index);
+                        h256 mix;
+                        memcpy(mix.data(), (void*)&buffer.result[i].mix,
+                            sizeof(buffer.result[0].mix));
+                        farm.submitProof(Solution{nonce, mix, w, done}, index);
                     }
                     else
                     {

--- a/libethash-cuda/CUDAMiner.h
+++ b/libethash-cuda/CUDAMiner.h
@@ -73,6 +73,7 @@ private:
     uint32_t m_device_num = 0;
 
     std::vector<volatile Search_results*> m_search_buf;
+    std::vector<Search_results> m_save_buf;
     std::vector<cudaStream_t> m_streams;
     uint64_t m_current_target = 0;
 

--- a/libethash-cuda/ethash_cuda_miner_kernel.h
+++ b/libethash-cuda/ethash_cuda_miner_kernel.h
@@ -13,7 +13,7 @@
 // of 2 here will yield better CUDA optimization
 #define MAX_SEARCH_RESULTS 4U
 
-struct Result
+struct Search_Result
 {
     // One word for gid and 8 for mix hash
     uint32_t gid;
@@ -23,8 +23,8 @@ struct Result
 
 struct Search_results
 {
-    uint32_t count;
-    Result result[MAX_SEARCH_RESULTS];
+    uint32_t count = 0;
+    Search_Result result[MAX_SEARCH_RESULTS];
 };
 
 #define ACCESSES 64

--- a/libethash-cuda/ethash_cuda_miner_kernel.h
+++ b/libethash-cuda/ethash_cuda_miner_kernel.h
@@ -23,8 +23,8 @@ struct Search_Result
 
 struct Search_results
 {
-    uint32_t count = 0;
     Search_Result result[MAX_SEARCH_RESULTS];
+    uint32_t count = 0;
 };
 
 #define ACCESSES 64


### PR DESCRIPTION
It makes more sense to do non critical things like calculating
hash rates and submitting solutions while the CPU is idle instead
of when the GPU is idle. But the added complexity could not
be justified based on analysis.

That analysis was based on submit time measurements of less than
1 microsecond, which is indeed the case when using the --noeval
option. However software eval is on by default. Recalculating
the mix hash in software takes 4-5 milliseconds on a reasonably
fast CPU. This imposes a much more substantial delay restarting
a stream, and has a cascading effect delaying all other streams.

This approach is not much different from previous implementations.
It merely saves all found solutions till all cuda streams searches
have been restarted and are not waiting for the CPU. Once that
is done, the CPU is free to handle hash rate and submits without
delaying cuda streams.