### PR TITLE
Use singletons to access global objects

### DIFF
--- a/libapicore/ApiServer.h
+++ b/libapicore/ApiServer.h
@@ -19,15 +19,12 @@ using boost::asio::ip::tcp;
 class ApiConnection
 {
 public:
-    ApiConnection(boost::asio::io_service& io_service, int id, bool readonly, string password,
-        Farm& f, PoolManager& mgr)
+    ApiConnection(int id, bool readonly, string password)
       : m_sessionId(id),
-        m_socket(io_service),
-        m_io_strand(io_service),
+        m_socket(g_io_service),
+        m_io_strand(g_io_service),
         m_readonly(readonly),
-        m_password(std::move(password)),
-        m_farm(f),
-        m_mgr(mgr)
+        m_password(std::move(password))
     {
         if (!m_password.empty())
             m_is_authenticated = false;
@@ -72,8 +69,6 @@ private:
 
     bool m_readonly = false;
     std::string m_password = "";
-    Farm& m_farm;
-    PoolManager& m_mgr;
 
     bool m_is_authenticated = true;
 };
@@ -82,8 +77,7 @@ private:
 class ApiServer
 {
 public:
-    ApiServer(boost::asio::io_service& io_service, string address, int portnum, bool readonly,
-        string password, Farm& f, PoolManager& mgr);
+    ApiServer(string address, int portnum, string password);
     bool isRunning() { return m_running.load(std::memory_order_relaxed); };
     void start();
     void stop();
@@ -99,11 +93,8 @@ private:
     std::string m_password = "";
     std::atomic<bool> m_running = {false};
     string m_address;
-    int m_portnumber;
+    uint16_t m_portnumber;
     tcp::acceptor m_acceptor;
     boost::asio::io_service::strand m_io_strand;
     std::vector<std::shared_ptr<ApiConnection>> m_sessions;
-
-    Farm& m_farm;
-    PoolManager& m_mgr;
 };

--- a/libapicore/httpServer.cpp
+++ b/libapicore/httpServer.cpp
@@ -28,7 +28,7 @@ void httpServer::tableHeader(stringstream& ss)
 {
     char hostName[HOST_NAME_MAX + 1];
     gethostname(hostName, HOST_NAME_MAX + 1);
-    string l = m_farm->farmLaunchedFormatted();
+    string l = g_farm->farmLaunchedFormatted();
     ss << "<!doctype html>"
           "<html lang=en>"
           "<head>"
@@ -62,7 +62,7 @@ void httpServer::tableHeader(stringstream& ss)
           "<tr class=bg-header1>"
           "<th colspan=6>"
        << ethminer_get_buildinfo()->project_name_with_version << " on " << hostName << " - " << l
-       << "<br>Pool: " << m_manager->getActiveConnectionCopy().Host()
+       << "<br>Pool: " << g_mgr->getActiveConnectionCopy().Host()
        << "</th>"
           "</tr>"
           "<tr class=bg-header0>"
@@ -80,8 +80,8 @@ void httpServer::tableHeader(stringstream& ss)
 void httpServer::getstat1(stringstream& ss)
 {
     using namespace std::chrono;
-    WorkingProgress p = m_farm->miningProgress();
-    SolutionStats s = m_farm->getSolutionStats();
+    WorkingProgress p = g_farm->miningProgress();
+    SolutionStats s = g_farm->getSolutionStats();
     tableHeader(ss);
     ss << "<tbody>";
     double hashSum = 0.0;
@@ -136,13 +136,10 @@ static void ev_handler(struct mg_connection* c, int ev, void* p)
     }
 }
 
-void httpServer::run(string address, uint16_t port, dev::eth::Farm* farm, PoolManager* manager,
-    bool show_hwmonitors, bool show_power)
+void httpServer::run(string address, uint16_t port, bool show_hwmonitors, bool show_power)
 {
     if (port == 0)
         return;
-    m_farm = farm;
-    m_manager = manager;
     // admittedly, at this point, it's a bit hacky to call it "m_port" =/
     if (address.empty())
     {

--- a/libapicore/httpServer.cpp
+++ b/libapicore/httpServer.cpp
@@ -28,7 +28,7 @@ void httpServer::tableHeader(stringstream& ss)
 {
     char hostName[HOST_NAME_MAX + 1];
     gethostname(hostName, HOST_NAME_MAX + 1);
-    string l = g_farm->farmLaunchedFormatted();
+    string l = Farm::f().farmLaunchedFormatted();
     ss << "<!doctype html>"
           "<html lang=en>"
           "<head>"
@@ -62,7 +62,7 @@ void httpServer::tableHeader(stringstream& ss)
           "<tr class=bg-header1>"
           "<th colspan=6>"
        << ethminer_get_buildinfo()->project_name_with_version << " on " << hostName << " - " << l
-       << "<br>Pool: " << g_mgr->getActiveConnectionCopy().Host()
+       << "<br>Pool: " << PoolManager::p().getActiveConnectionCopy().Host()
        << "</th>"
           "</tr>"
           "<tr class=bg-header0>"
@@ -80,8 +80,8 @@ void httpServer::tableHeader(stringstream& ss)
 void httpServer::getstat1(stringstream& ss)
 {
     using namespace std::chrono;
-    WorkingProgress p = g_farm->miningProgress();
-    SolutionStats s = g_farm->getSolutionStats();
+    WorkingProgress p = Farm::f().miningProgress();
+    SolutionStats s = Farm::f().getSolutionStats();
     tableHeader(ss);
     ss << "<tbody>";
     double hashSum = 0.0;

--- a/libapicore/httpServer.h
+++ b/libapicore/httpServer.h
@@ -8,13 +8,10 @@
 class httpServer
 {
 public:
-    void run(string address, uint16_t port, dev::eth::Farm* farm, dev::eth::PoolManager* manager,
-        bool show_hwmonitors, bool show_power);
+    void run(string address, uint16_t port, bool show_hwmonitors, bool show_power);
     void run_thread();
     void getstat1(stringstream& ss);
 
-    dev::eth::Farm* m_farm;
-    dev::eth::PoolManager* m_manager;
     std::string m_port;
 
 private:

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -44,6 +44,8 @@
 #include <sys/stat.h>
 #endif
 
+extern boost::asio::io_service g_io_service;
+
 namespace dev
 {
 namespace eth
@@ -64,7 +66,7 @@ public:
         std::function<Miner*(FarmFace&, unsigned)> create;
     };
 
-    Farm(boost::asio::io_service& io_service, bool hwmon, bool pwron) : m_io_strand(io_service), m_collectTimer(io_service)
+    Farm(bool hwmon, bool pwron) : m_io_strand(g_io_service), m_collectTimer(g_io_service)
     {
         m_hwmon = hwmon;
         m_pwron = pwron;
@@ -563,3 +565,5 @@ private:
 
 }  // namespace eth
 }  // namespace dev
+
+extern dev::eth::Farm* g_farm;

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -68,6 +68,7 @@ public:
 
     Farm(bool hwmon, bool pwron) : m_io_strand(g_io_service), m_collectTimer(g_io_service)
     {
+        m_this = this;
         m_hwmon = hwmon;
         m_pwron = pwron;
 
@@ -110,6 +111,8 @@ public:
         // Stop data collector
         m_collectTimer.cancel();
     }
+
+    static Farm& f() { return *m_this; }
 
     /**
      * @brief Randomizes the nonce scrambler
@@ -561,9 +564,10 @@ private:
 #if defined(__linux)
     wrap_amdsysfs_handle* sysfsh = nullptr;
 #endif
+
+    static Farm* m_this;
 };
 
 }  // namespace eth
 }  // namespace dev
 
-extern dev::eth::Farm* g_farm;

--- a/libpoolprotocols/PoolManager.h
+++ b/libpoolprotocols/PoolManager.h
@@ -20,8 +20,8 @@ namespace eth
 class PoolManager
 {
 public:
-    PoolManager(boost::asio::io_service& io_service, PoolClient* client, Farm& farm,
-        MinerType const& minerType, unsigned maxTries, unsigned failovertimeout);
+    PoolManager(PoolClient* client, MinerType const& minerType, unsigned maxTries,
+        unsigned failovertimeout);
     void addConnection(URI& conn);
     void clearConnections();
     Json::Value getConnectionsJson();
@@ -65,12 +65,14 @@ private:
     boost::asio::io_service::strand m_io_strand;
     boost::asio::deadline_timer m_failovertimer;
     PoolClient* p_client;
-    Farm& m_farm;
     MinerType m_minerType;
 
     int m_lastEpoch = 0;
     std::atomic<unsigned> m_epochChanges = {0};
     double m_lastDifficulty = 0.0;
 };
+
 }  // namespace eth
 }  // namespace dev
+
+extern dev::eth::PoolManager* g_mgr;

--- a/libpoolprotocols/PoolManager.h
+++ b/libpoolprotocols/PoolManager.h
@@ -22,6 +22,7 @@ class PoolManager
 public:
     PoolManager(PoolClient* client, MinerType const& minerType, unsigned maxTries,
         unsigned failovertimeout);
+    static PoolManager& p() { return *m_this; }
     void addConnection(URI& conn);
     void clearConnections();
     Json::Value getConnectionsJson();
@@ -70,9 +71,10 @@ private:
     int m_lastEpoch = 0;
     std::atomic<unsigned> m_epochChanges = {0};
     double m_lastDifficulty = 0.0;
+
+    static PoolManager* m_this;
 };
 
 }  // namespace eth
 }  // namespace dev
 
-extern dev::eth::PoolManager* g_mgr;

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -41,17 +41,16 @@ static void diffToTarget(uint32_t* target, double diff)
 }
 
 
-EthStratumClient::EthStratumClient(
-    boost::asio::io_service& io_service, int worktimeout, int responsetimeout, bool submitHashrate)
+EthStratumClient::EthStratumClient(int worktimeout, int responsetimeout, bool submitHashrate)
   : PoolClient(),
     m_worktimeout(worktimeout),
     m_responsetimeout(responsetimeout),
-    m_io_service(io_service),
-    m_io_strand(io_service),
+    m_io_service(g_io_service),
+    m_io_strand(g_io_service),
     m_socket(nullptr),
-    m_workloop_timer(io_service),
+    m_workloop_timer(g_io_service),
     m_response_plea_times(64),
-    m_resolver(io_service),
+    m_resolver(g_io_service),
     m_endpoints(),
     m_submit_hashrate(submitHashrate)
 {

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -27,8 +27,7 @@ class EthStratumClient : public PoolClient
 public:
     typedef enum { STRATUM = 0, ETHPROXY, ETHEREUMSTRATUM } StratumProtocol;
 
-    EthStratumClient(boost::asio::io_service& io_service, int worktimeout, int responsetimeout,
-        bool submitHashrate);
+    EthStratumClient(int worktimeout, int responsetimeout, bool submitHashrate);
     ~EthStratumClient();
 
     void init_socket();


### PR DESCRIPTION
The io_service, farm, and pool manager instances are
frequently used global objects. There is a single
instance of each.

Avoid a lot of parameter passing by accessing these
objects via global reference or pointer.