### PR TITLE
Faster exit with CUDA devices.

### DIFF
--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -218,7 +218,8 @@ public:
 #ifdef DEV_BUILD
         logOptions << ", log connection messages = " << LOG_CONNECT
                    << ", log switch delay = " << LOG_SWITCH
-                   << ", log submit delay = " << LOG_SUBMIT;
+                   << ", log submit delay = " << LOG_SUBMIT
+                   << ", log program flow = " << LOG_PROGRAMFLOW;
 #endif
         app.add_option("-v,--verbosity", g_logOptions, logOptions.str(), true)
             ->group(CommonGroup)
@@ -570,7 +571,7 @@ public:
 #endif
 #ifndef DEV_BUILD
         if ((g_logOptions & LOG_CONNECT) || (g_logOptions & LOG_SWITCH) ||
-            (g_logOptions & LOG_SUBMIT))
+            (g_logOptions & LOG_SUBMIT) || (g_logOptions & LOG_PROGRAMFLOW))
         {
             clog << "Some log options ignored. Compile with -DDEVBUILD=ON\n";
         }

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -38,9 +38,15 @@
 #define LOG_CONNECT 32
 #define LOG_SWITCH 64
 #define LOG_SUBMIT 128
-#define LOG_NEXT 256
+#define LOG_PROGRAMFLOW 256
+#define LOG_NEXT 512
 
-
+#if DEV_BUILD
+#define DEV_BUILD_LOG_PROGRAMFLOW(_S, _V) \
+    if (g_logOptions & LOG_PROGRAMFLOW) { _S << _V; } ((void)(0))
+#else
+#define DEV_BUILD_LOG_PROGRAMFLOW(_S, _V) ((void)(0))
+#endif
 
 extern unsigned g_logOptions;
 extern bool g_logNoColor;

--- a/libdevcore/Worker.cpp
+++ b/libdevcore/Worker.cpp
@@ -30,6 +30,7 @@ using namespace dev;
 
 void Worker::startWorking()
 {
+    DEV_BUILD_LOG_PROGRAMFLOW(cnote, "Worker::startWorking() start");
     //	cnote << "startWorking for thread" << m_name;
     Guard l(x_work);
     if (m_work)
@@ -76,23 +77,29 @@ void Worker::startWorking()
     }
     while (m_state == WorkerState::Starting)
         this_thread::sleep_for(chrono::microseconds(20));
+    DEV_BUILD_LOG_PROGRAMFLOW(cnote, "Worker::startWorking() end");
 }
 
 void Worker::stopWorking()
 {
+    DEV_BUILD_LOG_PROGRAMFLOW(cnote, "Worker::stopWorking() start");
     DEV_GUARDED(x_work)
     if (m_work)
     {
         WorkerState ex = WorkerState::Started;
         m_state.compare_exchange_strong(ex, WorkerState::Stopping);
 
+        DEV_BUILD_LOG_PROGRAMFLOW(cnote, "Worker::stopWorking()-stopWorkers start");
         while (m_state != WorkerState::Stopped)
             this_thread::sleep_for(chrono::microseconds(20));
+        DEV_BUILD_LOG_PROGRAMFLOW(cnote, "Worker::stopWorking()-stopWorkers end");
     }
+    DEV_BUILD_LOG_PROGRAMFLOW(cnote, "Worker::stopWorking() end");
 }
 
 Worker::~Worker()
 {
+    DEV_BUILD_LOG_PROGRAMFLOW(cnote, "Worker::~Worker() start");
     DEV_GUARDED(x_work)
     if (m_work)
     {
@@ -100,4 +107,5 @@ Worker::~Worker()
         m_work->join();
         m_work.reset();
     }
+    DEV_BUILD_LOG_PROGRAMFLOW(cnote, "Worker::~Worker() end");
 }

--- a/libdevcore/Worker.cpp
+++ b/libdevcore/Worker.cpp
@@ -82,6 +82,7 @@ void Worker::startWorking()
 
 void Worker::requestStopWorking()
 {
+#error "GENERATE COMPILE ERROR TO PREVENT MERGE (till anl-refactor branch was merged)"
     DEV_GUARDED(x_work)
     if (m_work)
     {

--- a/libdevcore/Worker.cpp
+++ b/libdevcore/Worker.cpp
@@ -80,6 +80,16 @@ void Worker::startWorking()
     DEV_BUILD_LOG_PROGRAMFLOW(cnote, "Worker::startWorking() end");
 }
 
+void Worker::requestStopWorking()
+{
+    DEV_GUARDED(x_work)
+    if (m_work)
+    {
+        WorkerState ex = WorkerState::Started;
+        m_state.compare_exchange_strong(ex, WorkerState::Stopping);
+    }
+}
+
 void Worker::stopWorking()
 {
     DEV_BUILD_LOG_PROGRAMFLOW(cnote, "Worker::stopWorking() start");

--- a/libdevcore/Worker.h
+++ b/libdevcore/Worker.h
@@ -52,7 +52,10 @@ public:
     /// Starts worker thread; causes startedWorking() to be called.
     void startWorking();
 
-    /// Stop worker thread; causes call to stopWorking().
+    /// Inform worker thread it should stop
+    void requestStopWorking();
+
+    /// Stop worker thread; causes call to stopWorking(). Waits till working is stopped
     void stopWorking();
 
     bool shouldStop() const { return m_state != WorkerState::Started; }

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -39,8 +39,10 @@ CUDAMiner::CUDAMiner(unsigned _index) : Miner("cuda-", _index), m_io_strand(g_io
 
 CUDAMiner::~CUDAMiner()
 {
+    DEV_BUILD_LOG_PROGRAMFLOW(cudalog, "cuda-" << m_index << "CUDAMiner::~CUDAMiner() start");
     stopWorking();
     kick_miner();
+    DEV_BUILD_LOG_PROGRAMFLOW(cudalog, "cuda-" << m_index << "CUDAMiner::~CUDAMiner() end");
 }
 
 unsigned CUDAMiner::m_parallelHash = 4;

--- a/libethcore/Farm.cpp
+++ b/libethcore/Farm.cpp
@@ -26,6 +26,8 @@ Farm* Farm::m_this = nullptr;
 
 Farm::Farm(unsigned hwmonlvl, bool noeval) : m_io_strand(g_io_service), m_collectTimer(g_io_service)
 {
+    DEV_BUILD_LOG_PROGRAMFLOW(cnote, "Farm::Farm() start");
+
     m_this = this;
     m_hwmonlvl = hwmonlvl;
     m_noeval = noeval;
@@ -49,10 +51,13 @@ Farm::Farm(unsigned hwmonlvl, bool noeval) : m_io_strand(g_io_service), m_collec
     m_collectTimer.expires_from_now(boost::posix_time::milliseconds(m_collectInterval));
     m_collectTimer.async_wait(
         m_io_strand.wrap(boost::bind(&Farm::collectData, this, boost::asio::placeholders::error)));
+
+    DEV_BUILD_LOG_PROGRAMFLOW(cnote, "Farm::Farm() end");
 }
 
 Farm::~Farm()
 {
+    DEV_BUILD_LOG_PROGRAMFLOW(cnote, "Farm::~Farm() start");
     // Deinit HWMON
     if (adlh)
         wrap_adl_destroy(adlh);
@@ -68,6 +73,8 @@ Farm::~Farm()
 
     // Stop data collector
     m_collectTimer.cancel();
+
+    DEV_BUILD_LOG_PROGRAMFLOW(cnote, "Farm::~Farm() end");
 }
 
 /**
@@ -93,6 +100,7 @@ void Farm::setSealers(std::map<std::string, SealerDescriptor> const& _sealers)
  */
 bool Farm::start(std::string const& _sealer, bool mixed)
 {
+    DEV_BUILD_LOG_PROGRAMFLOW(cnote, "Farm::start() start");
     Guard l(x_minerWork);
     if (!m_miners.empty() && m_lastSealer == _sealer)
         return true;
@@ -127,7 +135,7 @@ bool Farm::start(std::string const& _sealer, bool mixed)
 
     m_isMining.store(true, std::memory_order_relaxed);
     m_lastSealer = _sealer;
-
+    DEV_BUILD_LOG_PROGRAMFLOW(cnote, "Farm::start() end");
     return true;
 }
 
@@ -136,6 +144,8 @@ bool Farm::start(std::string const& _sealer, bool mixed)
  */
 void Farm::stop()
 {
+    DEV_BUILD_LOG_PROGRAMFLOW(cnote, "Farm::stop() start");
+
     // Avoid re-entering if not actually mining.
     // This, in fact, is also called by destructor
     if (isMining())
@@ -146,6 +156,7 @@ void Farm::stop()
             m_isMining.store(false, std::memory_order_relaxed);
         }
     }
+    DEV_BUILD_LOG_PROGRAMFLOW(cnote, "Farm::stop() end");
 }
 
 /**

--- a/libethcore/Farm.cpp
+++ b/libethcore/Farm.cpp
@@ -152,6 +152,8 @@ void Farm::stop()
     {
         {
             Guard l(x_minerWork);
+            for (auto const& miner : m_miners)
+                miner->requestStopWorking();
             m_miners.clear();
             m_isMining.store(false, std::memory_order_relaxed);
         }

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -15,6 +15,7 @@ PoolManager::PoolManager(
     m_submithrtimer(g_io_service),
     m_minerType(minerType)
 {
+    DEV_BUILD_LOG_PROGRAMFLOW(cnote, "PoolManager::PoolManager() start");
     m_this = this;
     p_client = client;
     m_maxConnectionAttempts = maxTries;
@@ -185,10 +186,13 @@ PoolManager::PoolManager(
             Farm::f().start("opencl", true);
         }
     });
+
+    DEV_BUILD_LOG_PROGRAMFLOW(cnote, "PoolManager::PoolManager() end");
 }
 
 void PoolManager::stop()
 {
+    DEV_BUILD_LOG_PROGRAMFLOW(cnote, "PoolManager::stop() start");
     if (m_running.load(std::memory_order_relaxed))
     {
         m_stopping.store(true, std::memory_order_relaxed);
@@ -213,6 +217,7 @@ void PoolManager::stop()
             }
         }
     }
+    DEV_BUILD_LOG_PROGRAMFLOW(cnote, "PoolManager::stop end");
 }
 
 void PoolManager::addConnection(URI& conn)


### PR DESCRIPTION
A call to cudaDeviceReset() needs in my environment between 1 and 5 seconds.
When stopping ethminer, Farm::stop() clears the m_miners list.
This involves that *sequential* the destructor of each m_miner element is called.
As the destructer waits till mining of the thread has stopped that
way can cause exiting needs 5 seconds per card.

With this patch the mining threads gets async informed to stop
which causes a faster exit time.