### PR TITLE
Correct handling of --display-interval. (Cherry pick for v0.16.1)

### DIFF
--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -897,12 +897,15 @@ private:
             // Wait at the beginning of the loop to give some time
             // services to start properly. Otherwise we get a "not-connected"
             // message immediately
-            this_thread::sleep_for(chrono::seconds(2));
-            if (interval > 2)
-            {
-                interval -= 2;
+
+            // Split m_displayInterval in 1 second parts to optain a faster exit
+            this_thread::sleep_for(chrono::seconds(1));
+            interval--;
+            if (interval)
                 continue;
-            }
+            interval = m_displayInterval;
+
+            // Display current stats of the farm if it's connected
             if (mgr.isConnected())
             {
                 auto mp = f.miningProgress();
@@ -916,7 +919,6 @@ private:
             {
                 minelog << "not-connected";
             }
-            interval = m_displayInterval;
         }
 
 #if API_CORE


### PR DESCRIPTION
To use less cpu ethminer slept always for two seconds till
display-interval was reached or exceeded.

This commit corrects the handling of display interval.

Cherry-pick of 75f43e8d05b340d96c1b271920c83be0cca33d6a (#1591)