### PR TITLE
API: miner_getstatdetail(). Several changes.

### DIFF
--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -198,11 +198,12 @@ and expect back a response like this:
     "epoch_changes": 1,                 // Ethminer starts with epoch 0. First connection to pool increments this counter
     "hashrate": 46709128,               // Overall HashRate in H/s
     "hostname": "<omitted-hostname>",
-    "runtime": 4,                       // Total running time in minutes
+    "runtime": 240,                     // Total running time in seconds
     "shares": {                         // Summarized info about shares
       "accepted": 5,
       "acceptedstale": 1,
       "invalid": 1,
+      "lastupdate": 58,                 // Latest update of any share info of is X seconds ago
       "rejected": 0
     },
     "tstart": 63,
@@ -221,7 +222,7 @@ and expect back a response like this:
          "accepted": 3,
          "acceptedstale": 0,
          "invalid": 0,
-         "lastupdate": 1,               // Share info from this GPU updated X minutes ago
+         "lastupdate": 58,              // Share info from this GPU updated X seconds ago
          "rejected": 0
        },
        "temp": 53                       // Temperature in °C
@@ -238,7 +239,7 @@ and expect back a response like this:
          "accepted": 2,
          "acceptedstale": 1,
          "invalid": 1,
-         "lastupdate": 2,
+         "lastupdate": 134,
          "rejected": 0
        },
        "temp": 56

--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -675,7 +675,6 @@ void ApiConnection::processRequest(Json::Value& jRequest, Json::Value& jResponse
         {
             jResponse["result"] = false;
         }
-
     }
 
     else if (_method == "miner_setverbosity")
@@ -922,8 +921,8 @@ Json::Value ApiConnection::getMinerStatHR()
 }
 
 
-Json::Value ApiConnection::getMinerStatDetailPerMiner(
-    const WorkingProgress& p, const SolutionStats& s, size_t index)
+Json::Value ApiConnection::getMinerStatDetailPerMiner(const WorkingProgress& p,
+    const SolutionStats& s, size_t index, const std::chrono::steady_clock::time_point& now)
 {
     Json::Value jRes;
     auto const& miner = Farm::f().getMiner(index);
@@ -941,9 +940,10 @@ Json::Value ApiConnection::getMinerStatDetailPerMiner(
     jshares["rejected"] = s.getRejects(index);
     jshares["invalid"] = s.getFailures(index);
     jshares["acceptedstale"] = s.getAcceptedStales(index);
-    auto solution_lastupdated = std::chrono::duration_cast<std::chrono::minutes>(
-        std::chrono::steady_clock::now() - s.getLastUpdated(index));
-    jshares["lastupdate"] = uint64_t(solution_lastupdated.count()); // last update of this gpu stat was x minutes ago
+    auto solution_lastupdated =
+        std::chrono::duration_cast<std::chrono::seconds>(now - s.getLastUpdated(index));
+    jshares["lastupdate"] =
+        uint64_t(solution_lastupdated.count());  // last update of this gpu stat was x seconds ago
     jRes["shares"] = jshares;
 
 
@@ -995,8 +995,9 @@ Json::Value ApiConnection::getMinerStatDetailPerMiner(
  */
 Json::Value ApiConnection::getMinerStatDetail()
 {
-    auto runningTime = std::chrono::duration_cast<std::chrono::minutes>(
-        std::chrono::steady_clock::now() - Farm::f().farmLaunched());
+    const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+    auto runningTime =
+        std::chrono::duration_cast<std::chrono::seconds>(now - Farm::f().farmLaunched());
 
     SolutionStats s = Farm::f().getSolutionStats();
     WorkingProgress p = Farm::f().miningProgress();
@@ -1007,7 +1008,7 @@ Json::Value ApiConnection::getMinerStatDetail()
     Json::Value jRes;
 
     jRes["version"] = ethminer_get_buildinfo()->project_name_with_version;  // miner version.
-    jRes["runtime"] = uint64_t(runningTime.count());  // running time, in minutes.
+    jRes["runtime"] = uint64_t(runningTime.count());  // running time, in seconds.
 
     {
         // Even the client should know which host was queried
@@ -1052,7 +1053,7 @@ Json::Value ApiConnection::getMinerStatDetail()
     {
         for (size_t i = 0; i < Farm::f().getMiners().size(); i++)
         {
-            jRes["gpus"].append(getMinerStatDetailPerMiner(p, s, i));
+            jRes["gpus"].append(getMinerStatDetailPerMiner(p, s, i, now));
         }
     }
     else
@@ -1069,6 +1070,10 @@ Json::Value ApiConnection::getMinerStatDetail()
     jshares["rejected"] = s.getRejects();
     jshares["invalid"] = s.getFailures();
     jshares["acceptedstale"] = s.getAcceptedStales();
+    auto solution_lastupdated =
+        std::chrono::duration_cast<std::chrono::seconds>(now - s.getLastUpdated());
+    jshares["lastupdate"] =
+        uint64_t(solution_lastupdated.count());  // last update of this gpu stat was x seconds ago
     jRes["shares"] = jshares;
 
     return jRes;

--- a/libapicore/ApiServer.h
+++ b/libapicore/ApiServer.h
@@ -54,8 +54,8 @@ private:
     void onSendSocketDataCompleted(const boost::system::error_code& ec);
 
     Json::Value getMinerStatDetail();
-    Json::Value getMinerStatDetailPerMiner(
-        const WorkingProgress& p, const SolutionStats& s, size_t index);
+    Json::Value getMinerStatDetailPerMiner(const WorkingProgress& p, const SolutionStats& s,
+        size_t index, const std::chrono::steady_clock::time_point& now);
 
     Disconnected m_onDisconnected;
 

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -120,10 +120,7 @@ public:
      * @brief Get information on the progress of mining this work package.
      * @return The progress with mining so far.
      */
-    WorkingProgress const& miningProgress() const
-    {
-        return m_progress;
-    }
+    WorkingProgress const& miningProgress() const { return m_progress; }
 
     std::vector<std::shared_ptr<Miner>> getMiners() { return m_miners; }
 
@@ -134,7 +131,7 @@ public:
         return m_miners[index];
     }
 
-    SolutionStats getSolutionStats() { return m_solutionStats; } // returns a copy
+    SolutionStats getSolutionStats() { return m_solutionStats; }  // returns a copy
 
     void failedSolution(unsigned _miner_index) override { m_solutionStats.failed(_miner_index); }
 
@@ -233,8 +230,8 @@ private:
     boost::asio::deadline_timer m_collectTimer;
     static const int m_collectInterval = 5000;
 
-    mutable SolutionStats m_solutionStats;
     std::chrono::steady_clock::time_point m_farm_launched = std::chrono::steady_clock::now();
+    mutable SolutionStats m_solutionStats;
 
     string m_pool_addresses;
 
@@ -262,4 +259,3 @@ private:
 
 }  // namespace eth
 }  // namespace dev
-


### PR DESCRIPTION
Change times to seconds.
Add 'lastupdate' to global miner share info.
Set lastupdate initially to time when farm got launched.

This commit addresses a little bit of issue #1603.