### PR TITLE
Fix for crash error within stratum on reconnect with a different security level

### DIFF
--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -348,11 +348,8 @@ void EthStratumClient::resolve_handler(
         m_connected.store(false, std::memory_order_relaxed);
         m_connecting.store(false, std::memory_order_relaxed);
 
-        // Trigger handlers
-        if (m_onDisconnected)
-        {
-            m_onDisconnected();
-        }
+        // We "simulate" a disconnect, to ensure a fully shutdown state
+        disconnect_finalize();
     }
 }
 
@@ -402,11 +399,8 @@ void EthStratumClient::start_connect()
         m_connecting.store(false, std::memory_order_relaxed);
         cwarn << "No more IP addresses to try for host: " << m_conn->Host();
 
-        // Trigger handlers
-        if (m_onDisconnected)
-        {
-            m_onDisconnected();
-        }
+        // We "simulate" a disconnect, to ensure a fully shutdown state
+        disconnect_finalize();
     }
 }
 


### PR DESCRIPTION
This fixes #1620 and similar cases when multiple pools are defined.

The actual crash problem: (in caase of #1620)
Secure socket is not initialised, but it tries to call it because the failover pool uses ssl.

The underlying problem:
In case of a clean disconnect, ``disconnect`` and finally ``disconnect_finalize`` is called. In case of errors it's not called and only some values are reset and the onDisconnect callback is called.
This means, the sockets are never nulled (which normally happens in``disconnect_finalize``) and reused in the next connection attempt. Which works fine, if the pool to connect to is of the same security level. (probably even works if switch SSL->TCP) but it does not work TCP->SSL, because the ssl socket is not initialized.

This fix changes the callback/handler calls to call disconnect_finalize, which ensures that the socket is completely destroyed and reinitalized on the next connect for the correct security level.