### PR TITLE
Restores option to disable certificate validation

### DIFF
--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -213,8 +213,7 @@ public:
                    << ", log per GPU solutions = " << LOG_PER_GPU;
 #ifdef DEV_BUILD
         logOptions << ", log connection messages = " << LOG_CONNECT
-                   << ", log switch delay = " << LOG_SWITCH
-                   << ", log submit delay = " << LOG_SUBMIT
+                   << ", log switch delay = " << LOG_SWITCH << ", log submit delay = " << LOG_SUBMIT
                    << ", log program flow = " << LOG_PROGRAMFLOW;
 #endif
         app.add_option("-v,--verbosity", g_logOptions, logOptions.str(), true)
@@ -539,7 +538,16 @@ public:
             << "    SSL_CERT_FILE - full path to your CA certificates file if elsewhere than "
                "/etc/ssl/certs/ca-certificates.crt"
 #endif
-            ;
+            << endl
+            << "    SSL_NOVERIFY - set to any value to to disable the verification chain for"
+            << endl
+            << "                   certificates. WARNING ! Disabling certificate validation"
+            << endl
+            << "                   declines every security implied in connecting to a secured"
+            << endl
+            << "                   SSL/TLS remote endpoint."
+            << endl
+            << "                   USE AT YOU OWN RISK AND ONLY IF YOU KNOW WHAT YOU'RE DOING";
         app.footer(ssHelp.str());
 
         try
@@ -795,9 +803,7 @@ private:
             &CUDAMiner::instances, [](unsigned _index) { return new CUDAMiner(_index); }};
 #endif
         Farm::f().setSealers(sealers);
-        Farm::f().onSolutionFound([&](Solution) {
-            return false;
-        });
+        Farm::f().onSolutionFound([&](Solution) { return false; });
 
         Farm::f().setTStartTStop(m_tstart, m_tstop);
 

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -56,6 +56,7 @@ public:
     bool current() { return static_cast<bool>(m_current); }
 
 private:
+    bool fake_certificate_validation(bool preverified, boost::asio::ssl::verify_context& ctx);
     void disconnect_finalize();
     void enqueue_response_plea();
     std::chrono::milliseconds dequeue_response_plea();


### PR DESCRIPTION
As per #1629 the option to disable verification chain for certificates might be useful when used in controlled environments with self-signed certificates.
In any other case this should be considered a bad practice.

The option is enabled only by env variable and the absence of a CLI argument is expressly meant.