### PR TITLE
Proper SSL verification

### DIFF
--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -620,6 +620,14 @@ public:
                 cerr << endl << "Unknown URI scheme " << uri.Scheme() << "\n\n";
                 exit(-1);
             }
+            if (uri.SecLevel() != dev::SecureLevel::NONE &&
+                uri.HostNameType() != dev::UriHostNameType::Dns && !getenv("SSL_NOVERIFY"))
+            {
+                cerr << endl
+                     << "For SSL/TLS connections you must enter a valid hostname: " << url
+                     << "\n\n";
+                exit(-1);
+            }
             m_endpoints.push_back(uri);
 
             OperationMode mode = OperationMode::None;

--- a/libpoolprotocols/PoolURI.cpp
+++ b/libpoolprotocols/PoolURI.cpp
@@ -124,7 +124,7 @@ URI::URI(const std::string uri)
     // Eat "//"
     if (('/' != *curstr) || ('/' != *(curstr + 1)))
     {
-            return;
+        return;
     }
     curstr += 2;
 
@@ -200,6 +200,29 @@ URI::URI(const std::string uri)
     m_host.append(curstr, len);
     m_host = urlDecode(m_host);
     curstr = tmpstr;
+
+    // Determine host type
+    boost::system::error_code ec;
+    boost::asio::ip::address address = boost::asio::ip::address::from_string(m_host, ec);
+    if (!ec)
+    {
+        // This is a valid Ip Address
+        if (address.is_v4())
+            m_hostType = UriHostNameType::IPV4;
+        if (address.is_v6())
+            m_hostType = UriHostNameType::IPV6;
+    }
+    else
+    {
+        // Check if valid DNS hostname
+        std::regex hostNamePattern(
+            "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-"
+            "Za-z0-9\\-]*[A-Za-z0-9])$");
+        if (std::regex_match(m_host, hostNamePattern))
+            m_hostType = UriHostNameType::Dns;
+        else
+            m_hostType = UriHostNameType::Basic;
+    }
 
     // Is port number specified?
     if (':' == *curstr)
@@ -299,6 +322,11 @@ SecureLevel URI::SecLevel() const
     return s_schemes[m_scheme].secure;
 }
 
+UriHostNameType URI::HostNameType() const
+{
+    return m_hostType;
+}
+
 std::string URI::KnownSchemes(ProtocolFamily family)
 {
     std::string schemes;
@@ -307,4 +335,3 @@ std::string URI::KnownSchemes(ProtocolFamily family)
             schemes += s.first + " ";
     return schemes;
 }
-

--- a/libpoolprotocols/PoolURI.h
+++ b/libpoolprotocols/PoolURI.h
@@ -18,6 +18,9 @@
 #pragma once
 
 #include <string>
+#include <regex>
+
+#include <boost/asio.hpp>
 
 // A simple URI parser specifically for mining pool endpoints
 namespace dev
@@ -34,6 +37,15 @@ enum class ProtocolFamily
     STRATUM
 };
 
+enum class UriHostNameType
+{
+    Unknown = 0,
+    Basic = 1,
+    Dns = 2,
+    IPV4 = 3,
+    IPV6 = 4
+};
+
 class URI
 {
 public:
@@ -48,6 +60,7 @@ public:
     std::string Pass() const { return m_password; }
     SecureLevel SecLevel() const;
     ProtocolFamily Family() const;
+    UriHostNameType HostNameType() const;
     unsigned Version() const;
     std::string String() const { return m_uri; }
     bool Valid() const { return m_valid; }
@@ -81,5 +94,7 @@ private:
     bool m_valid = false;
     bool m_stratumModeConfirmed = false;
     bool m_unrecoverable = false;
+
+    UriHostNameType m_hostType = UriHostNameType::Unknown;
 };
 }  // namespace dev


### PR DESCRIPTION
Up until know the SSL implementation has been quite weak.
The main reason is ethminer **never verified the correspondece between host name being connected and the CN registered in the certificate**. In fact the only thing verified was the certification chain for **any** certificate exposed by the remote endpoint: under this circumstances a DNS redirection to the wrong host (with a valid certificate) would have validated the connection.

This PR amends this and forces the check for host name to be present in the server certificate.
Due to this an additional control has been introduced for secured connections : host **must** be entered as DNS resolvable name and not by IP address.

Only exception is to disable certificate validation BY setting related environment variable.

Fake call back routine removed.