### PR TITLE
Possible double send fix

### DIFF
--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -92,16 +92,16 @@ private:
     void connect_handler(const boost::system::error_code& ec);
     void workloop_timer_elapsed(const boost::system::error_code& ec);
 
-    void processResponse(Json::Value& responseObject);
+    void processResponse(Json::Value & responseObject);
     std::string processError(Json::Value& erroresponseObject);
     void processExtranonce(std::string& enonce);
 
     void recvSocketData();
     void onRecvSocketDataCompleted(
         const boost::system::error_code& ec, std::size_t bytes_transferred);
-    void sendSocketData(Json::Value const& jReq);
-    void onSendSocketDataCompleted(const boost::system::error_code& ec);
+    void sendSocketData(Json::Value const & jReq);
     void onSSLShutdownCompleted(const boost::system::error_code& ec);
+    void processSendQ();
 
     string m_user;    // Only user part
     string m_worker;  // eth-proxy only; No ! It's for all !!!
@@ -166,4 +166,10 @@ private:
     {
         return verbose_verification<Verifier>(verifier);
     }
+
+    // JSON send queue control variables
+    boost::lockfree::queue<Json::Value*> m_sendQ;
+    std::thread* m_sendThread = nullptr;
+    Notified<bool> m_sendQueued = {false};
+    bool m_sendExit = false;
 };


### PR DESCRIPTION
- Serialize writes to JSON transmit socket.
- Using lockfree Q such as not to block miner thread submit.
- TX thread is single consumer from lockfree msg q. Workloop
  synchronized via condition variable and using synchronous
  writes to avoid reentrancy issues.
- Multiple JSON message producers simply enqueue msgs to the
  lockfree msg q, then set the condition variable.