### PR TITLE
Possible double send fix (alternative)

### DIFF
--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -1514,11 +1514,9 @@ void EthStratumClient::send(Json::Value const& jReq)
     std::string* line = new std::string(Json::writeString(m_jSwBuilder, jReq));
     m_txQueue.push(line);
 
-    if (!m_txPending.load(std::memory_order_relaxed))
-    {
-        m_txPending.store(true, std::memory_order_relaxed);
+    bool ex = false;
+    if (m_txPending.compare_exchange_strong(ex, true, std::memory_order_relaxed))
         sendSocketData();
-    }
 }
 
 void EthStratumClient::sendSocketData()

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -1526,7 +1526,7 @@ void EthStratumClient::sendSocketData()
     if (!isConnected() || m_txQueue.empty())
     {
         m_sendBuffer.consume(m_sendBuffer.capacity());
-        m_txQueue.consume_all([](std::string* l) { (void)l; });
+        m_txQueue.consume_all([](std::string* l) { delete l; });
         m_txPending.store(false, std::memory_order_relaxed);
         return;
     }
@@ -1539,6 +1539,8 @@ void EthStratumClient::sendSocketData()
         // Out received message only for debug purpouses
         if (g_logOptions & LOG_JSON)
             cnote << " >> " << *line;
+
+        delete line;
     }
 
     if (m_conn->SecLevel() != SecureLevel::NONE)
@@ -1559,7 +1561,7 @@ void EthStratumClient::onSendSocketDataCompleted(const boost::system::error_code
 {
     if (ec)
     {
-        m_txQueue.consume_all([](std::string* l) { (void)l; });
+        m_txQueue.consume_all([](std::string* l) { delete l; });
         m_txPending.store(false, std::memory_order_relaxed);
 
         if ((ec.category() == boost::asio::error::get_ssl_category()) &&

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -751,10 +751,6 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
 {
     dev::setThreadName("stratum");
 
-    // Out received message only for debug purpouses
-    if (g_logOptions & LOG_JSON)
-        cnote << responseObject;
-
     // Store jsonrpc version to test against
     int _rpcVer = responseObject.isMember("jsonrpc") ? 2 : 1;
 
@@ -1454,8 +1450,14 @@ void EthStratumClient::onRecvSocketDataCompleted(
         */
 
         // Extract received message
-        std::string line(boost::asio::buffer_cast<const char*>(m_recvBuffer.data()), bytes_transferred);
+        std::string line(
+            boost::asio::buffer_cast<const char*>(m_recvBuffer.data()), bytes_transferred);
+        boost::replace_all(line, "\n", " ");
         m_recvBuffer.consume(bytes_transferred);
+
+        // Out received message only for debug purpouses
+        if (g_logOptions & LOG_JSON)
+            cnote << " << " << line;
 
         // Process message only if we're connected
         if (isConnected())

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -50,12 +50,15 @@ EthStratumClient::EthStratumClient(int worktimeout, int responsetimeout, bool su
     m_socket(nullptr),
     m_workloop_timer(g_io_service),
     m_response_plea_times(64),
+    m_txQueue(64),
     m_resolver(g_io_service),
     m_endpoints(),
     m_submit_hashrate(submitHashrate)
 {
     if (m_submit_hashrate)
         m_submit_hashrate_id = h256::random().hex();
+
+    m_jSwBuilder.settings_["indentation"] = "";
 
     // Initialize workloop_timer to infinite wait
     m_workloop_timer.expires_at(boost::posix_time::pos_infin);
@@ -695,7 +698,7 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec)
     and switch to next stratum mode test
     */
     enqueue_response_plea();
-    sendSocketData(jReq);
+    send(jReq);
 }
 
 std::string EthStratumClient::processError(Json::Value& responseObject)
@@ -972,7 +975,7 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
                     jReq["id"] = unsigned(2);
                     jReq["method"] = "mining.extranonce.subscribe";
                     jReq["params"] = Json::Value(Json::arrayValue);
-                    sendSocketData(jReq);
+                    send(jReq);
 
                     // Eventually request authorization
                     m_authpending.store(true, std::memory_order_relaxed);
@@ -987,7 +990,7 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
                 break;
             }
 
-            sendSocketData(jReq);
+            send(jReq);
         }
 
         else if (_id == 2)
@@ -1296,7 +1299,7 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
                 jReq["jsonrpc"] = "2.0";
             }
 
-            sendSocketData(jReq);
+            send(jReq);
         }
         else
         {
@@ -1310,7 +1313,7 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
             jReq["id"] = toString(_id);
             jReq["error"] = "Method not found";
 
-            sendSocketData(jReq);
+            send(jReq);
         }
     }
 }
@@ -1340,7 +1343,7 @@ void EthStratumClient::submitHashrate(string const& rate)
     jReq["params"].append(m_rate);
     jReq["params"].append("0x" + toString(this->m_submit_hashrate_id));
 
-    sendSocketData(jReq);
+    send(jReq);
 }
 
 void EthStratumClient::submitSolution(const Solution& solution)
@@ -1398,7 +1401,7 @@ void EthStratumClient::submitSolution(const Solution& solution)
     }
 
     enqueue_response_plea();
-    sendSocketData(jReq);
+    send(jReq);
 
     m_stale = solution.stale;
 }
@@ -1506,19 +1509,37 @@ void EthStratumClient::onRecvSocketDataCompleted(
     }
 }
 
-void EthStratumClient::sendSocketData(Json::Value const& jReq)
+void EthStratumClient::send(Json::Value const& jReq) 
 {
-    if (!isConnected())
-        return;
+    std::string* line = new std::string(Json::writeString(m_jSwBuilder, jReq));
+    m_txQueue.push(line);
 
-    // Out received message only for debug purpouses
-    if (g_logOptions & LOG_JSON)
+    if (!m_txPending.load(std::memory_order_relaxed))
     {
-        cnote << jReq;
+        m_txPending.store(true, std::memory_order_relaxed);
+        sendSocketData();
+    }
+}
+
+void EthStratumClient::sendSocketData()
+{
+    if (!isConnected() || m_txQueue.empty())
+    {
+        m_sendBuffer.consume(m_sendBuffer.capacity());
+        m_txQueue.consume_all([](std::string* l) { (void)l; });
+        m_txPending.store(false, std::memory_order_relaxed);
+        return;
     }
 
+    std::string* line;
     std::ostream os(&m_sendBuffer);
-    os << m_jWriter.write(jReq);  // Do not add lf. It's added by writer.
+    while (m_txQueue.pop(line))
+    {
+        os << *line << std::endl;
+        // Out received message only for debug purpouses
+        if (g_logOptions & LOG_JSON)
+            cnote << " >> " << *line;
+    }
 
     if (m_conn->SecLevel() != SecureLevel::NONE)
     {
@@ -1538,6 +1559,9 @@ void EthStratumClient::onSendSocketDataCompleted(const boost::system::error_code
 {
     if (ec)
     {
+        m_txQueue.consume_all([](std::string* l) { (void)l; });
+        m_txPending.store(false, std::memory_order_relaxed);
+
         if ((ec.category() == boost::asio::error::get_ssl_category()) &&
             (SSL_R_PROTOCOL_IS_SHUTDOWN == ERR_GET_REASON(ec.value())))
         {
@@ -1551,6 +1575,13 @@ void EthStratumClient::onSendSocketDataCompleted(const boost::system::error_code
             cwarn << "Socket write failed: " + ec.message();
             m_io_service.post(m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
         }
+    }
+    else
+    {
+        if (m_txQueue.empty())
+            m_txPending.store(false, std::memory_order_relaxed);
+        else
+            sendSocketData();
     }
 }
 

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -99,7 +99,8 @@ private:
     void recvSocketData();
     void onRecvSocketDataCompleted(
         const boost::system::error_code& ec, std::size_t bytes_transferred);
-    void sendSocketData(Json::Value const& jReq);
+    void send(Json::Value const& jReq);
+    void sendSocketData();
     void onSendSocketDataCompleted(const boost::system::error_code& ec);
     void onSSLShutdownCompleted(const boost::system::error_code& ec);
 
@@ -136,13 +137,16 @@ private:
 
     boost::asio::streambuf m_sendBuffer;
     boost::asio::streambuf m_recvBuffer;
-    Json::FastWriter m_jWriter;
+    Json::StreamWriterBuilder m_jSwBuilder;
 
     boost::asio::deadline_timer m_workloop_timer;
 
     std::atomic<int> m_response_pleas_count = {0};
     std::atomic<std::chrono::steady_clock::duration> m_response_plea_older;
     boost::lockfree::queue<std::chrono::steady_clock::time_point> m_response_plea_times;
+
+    std::atomic<bool> m_txPending = {false};
+    boost::lockfree::queue<std::string*> m_txQueue;
 
     boost::asio::ip::tcp::resolver m_resolver;
     std::queue<boost::asio::ip::basic_endpoint<boost::asio::ip::tcp>> m_endpoints;


### PR DESCRIPTION
This is an alternative to #1663 by @jean-m-cyr 

Main differences :
- it does not require a new thread. Keeps async model instead of a thread which sends sync
- stores the messages in queue as strings instead of json objects
- if pending queue has more than one message multiple lines are packed in a single transmission

Added some cosmetics for output json messages (single line) when logging option is set.
