### PR TITLE
Fix PoolUri parse error

### DIFF
--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -502,7 +502,7 @@ void ApiConnection::processRequest(Json::Value& jRequest, Json::Value& jResponse
             if (!uri.Valid())
             {
                 jResponse["error"]["code"] = -422;
-                jResponse["error"]["message"] = ("Invalid URI " + uri.String());
+                jResponse["error"]["message"] = ("Invalid URI " + uri.str());
                 return;
             }
             if (!uri.KnownScheme())
@@ -1022,7 +1022,7 @@ Json::Value ApiConnection::getMinerStatDetail()
     /* connection info */
     auto connection = PoolManager::p().getActiveConnectionCopy();
     Json::Value jconnection;
-    jconnection["uri"] = connection.String();
+    jconnection["uri"] = connection.str();
     // jconnection["endpoint"] = PoolManager::p().getClient()->ActiveEndPoint();
     jconnection["isconnected"] = PoolManager::p().isConnected();
     jconnection["switched"] = PoolManager::p().getConnectionSwitches();

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -370,7 +370,7 @@ Json::Value PoolManager::getConnectionsJson()
         Json::Value JConn;
         JConn["index"] = (unsigned)i;
         JConn["active"] = (i == m_activeConnectionIdx ? true : false);
-        JConn["uri"] = m_connections[i].String();
+        JConn["uri"] = m_connections[i].str();
         jRes.append(JConn);
     }
 

--- a/libpoolprotocols/PoolURI.cpp
+++ b/libpoolprotocols/PoolURI.cpp
@@ -230,7 +230,7 @@ URI::URI(const std::string uri)
         curstr++;
         // Read port number
         tmpstr = curstr;
-        while (('\0' != *tmpstr) && ('/' != *tmpstr))
+        while (('\0' != *tmpstr) && ('/' != *tmpstr) && ('#' != *tmpstr))
             tmpstr++;
         len = tmpstr - curstr;
         std::string tempstr;
@@ -252,11 +252,10 @@ URI::URI(const std::string uri)
     }
 
     // Skip '/'
-    if ('/' != *curstr)
+    if (('/' != *curstr) && ('#' != *curstr))
     {
         return;
     }
-    curstr++;
 
     // Parse path
     tmpstr = curstr;
@@ -265,7 +264,6 @@ URI::URI(const std::string uri)
     len = tmpstr - curstr;
     if (len)
     {
-        m_path = '/';
         m_path.append(curstr, len);
         m_path = urlDecode(m_path);
     }

--- a/libpoolprotocols/PoolURI.h
+++ b/libpoolprotocols/PoolURI.h
@@ -62,7 +62,7 @@ public:
     ProtocolFamily Family() const;
     UriHostNameType HostNameType() const;
     unsigned Version() const;
-    std::string String() const { return m_uri; }
+    std::string str() const { return m_uri; }
     bool Valid() const { return m_valid; }
 
     bool KnownScheme();


### PR DESCRIPTION
- Fix logic preventing proper parse of URI fragment
- Rename String method to conventional str for string view