### PR TITLE
Initialize blocknumber when new job arrives.

### DIFF
--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -184,7 +184,7 @@ void EthStratumClient::init_socket()
         m_socket->native_handle(), SOL_SOCKET, SO_SNDTIMEO, (const char*)&timeout, sizeof(timeout));
 #else
     timeval tv{
-        static_cast<suseconds_t>(keepAlive / 1000), 
+        static_cast<suseconds_t>(keepAlive / 1000),
         static_cast<suseconds_t>(keepAlive % 1000)};
     setsockopt(m_socket->native_handle(), SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
     setsockopt(m_socket->native_handle(), SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
@@ -1226,6 +1226,7 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
                         m_current.startNonce = m_extraNonce;
                         m_current.exSizeBytes = m_extraNonceSizeBytes;
                         m_current_timestamp = std::chrono::steady_clock::now();
+                        m_current.block = -1;
 
                         // This will signal to dispatch the job
                         // at the end of the transmission.
@@ -1241,6 +1242,7 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
 
                     // Only some eth-proxy compatible implementations carry the block number
                     // namely ethermine.org
+                    m_current.block = -1;
                     if (m_conn->StratumMode() ==
                         EthStratumClient::ETHPROXY && jPrm.size() > prmIdx)
                     {
@@ -1252,7 +1254,6 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
                         }
                         catch (const std::exception&)
                         {
-                            m_current.block = -1;
                         }
                     }
 

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -1251,6 +1251,14 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
                             m_current.block = std::stoul(
                                 jPrm.get(Json::Value::ArrayIndex(prmIdx), "").asString(), nullptr,
                                 16);
+                            /* check if the block number is in a valid range
+                                A year has ~31536000 seconds
+                                50 years have ~1576800000
+                                assuming a (very fast) blocktime of 10s:
+                                   ==> in 50 years we get 157680000 (=0x9660180) blocks
+                            */
+                            if (m_current.block > 0x9660180)
+                                m_current.block = -1;
                         }
                         catch (const std::exception&)
                         {


### PR DESCRIPTION
If m_current.block is filled and connection is switched to
another host and protocol, the last received blocknumber remains in
the m_current.block which is wrong (in following we get a wrong epoch).
This commit sets m_current.block by default to -1.

Also validate that the received block number is in a valid range.