### PR TITLE
Add clang-tidy config

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,8 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*,modernize-*,bugprone-*,readability-*,performance-*'
+WarningsAsErrors: ''
+HeaderFilterRegex: 'ethminer/.*'
+CheckOptions:
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+...


### PR DESCRIPTION
I enabled some groups of clang-tidy checks that I think make sense for a start. But there are a lots of warnings to fix.

Usage:
```
cmake -DCMAKE_CXX_CLANG_TIDY=clang-tidy .
```