### PR TITLE
Fix stratum and stratum2(nicehash) protocol.

### DIFF
--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -104,8 +104,11 @@ private:
     void onSendSocketDataCompleted(const boost::system::error_code& ec);
     void onSSLShutdownCompleted(const boost::system::error_code& ec);
 
-    string m_user;    // Only user part
-    string m_worker;  // eth-proxy only; No ! It's for all !!!
+    string m_user;           // Only user part
+    string m_worker;         // eth-proxy only; No ! It's for all !!!
+    string m_userdotworker;  // concatenated (m_user "." m_worker) or just (m_user) if m_worker is
+                             // empty
+
 
     std::atomic<bool> m_disconnecting = {false};
     std::atomic<bool> m_connecting = {false};


### PR DESCRIPTION
With commit e6f23dc020b970b91d8d5754dffbdb6277357871 username and
workername got split by first "." .
As stratum and stratum2 needs username + "." + workername and we
submitted just username those connection types are broken.

With this commit we submit username + "." + workername as username
if we're using stratum or stratum2 protocol.


See also #1718 