### PR TITLE
Modified URI Parsing (Username / WorkerName / Password)

### DIFF
--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -503,7 +503,7 @@ public:
 
                 URI uri(url);
 
-                if (!uri.Valid() || !uri.KnownScheme() || (m_mode == OperationMode::Mining && uri.Scheme() == "simulation"))
+                if (!uri.Valid() || (m_mode == OperationMode::Mining && uri.Scheme() == "simulation"))
                 {
                     std::string what = "Bad URI : " + uri.str();
                     throw std::invalid_argument(what);

--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -503,12 +503,6 @@ void ApiConnection::processRequest(Json::Value& jRequest, Json::Value& jResponse
                 jResponse["error"]["message"] = ("Invalid URI " + uri.str());
                 return;
             }
-            if (!uri.KnownScheme())
-            {
-                jResponse["error"]["code"] = -422;
-                jResponse["error"]["message"] = ("Unknown URI scheme " + uri.Scheme());
-                return;
-            }
 
             // Check other pools already present share the same scheme family (stratum or getwork)
             Json::Value pools = PoolManager::p().getConnectionsJson();

--- a/libpoolprotocols/PoolURI.h
+++ b/libpoolprotocols/PoolURI.h
@@ -20,7 +20,9 @@
 #include <regex>
 #include <string>
 
+#include <boost/algorithm/string.hpp>
 #include <boost/asio.hpp>
+#include <boost/lexical_cast.hpp>
 
 // A simple URI parser specifically for mining pool endpoints
 namespace dev
@@ -58,9 +60,9 @@ public:
     std::string Host() const { return m_host; }
     std::string Path() const { return m_path; }
     unsigned short Port() const { return m_port; }
-    std::string User() const { return m_username; }
+    std::string User() const { return m_user; }
     std::string Pass() const { return m_password; }
-    std::string Workername() const { return m_workername; }
+    std::string Workername() const { return m_worker; }
     SecureLevel SecLevel() const;
     ProtocolFamily Family() const;
     UriHostNameType HostNameType() const;
@@ -68,8 +70,6 @@ public:
     unsigned Version() const;
     std::string str() const { return m_uri; }
     bool Valid() const { return m_valid; }
-
-    bool KnownScheme();
 
     static std::string KnownSchemes(ProtocolFamily family);
 
@@ -85,15 +85,23 @@ public:
     void MarkUnrecoverable() { m_unrecoverable = true; }
 
 private:
+
     std::string m_scheme;
+    std::string m_authority; // Contains all text after scheme
+    std::string m_userinfo;  // Contains the userinfo part
+    std::string m_urlinfo;   // Contains the urlinfo part
+    std::string m_hostinfo;  // Contains the hostinfo part
+    std::string m_pathinfo;  // Contains the pathinfo part
+
     std::string m_host;
     std::string m_path;
     std::string m_query;
     std::string m_fragment;
-    std::string m_username;
-    std::string m_password;
-    std::string m_workername;
+    std::string m_user;
+    std::string m_password = "X";
+    std::string m_worker;
     std::string m_uri;
+
     unsigned short m_stratumMode = 999;  // Initial value 999 means not tested yet
     unsigned short m_port = 0;
     bool m_valid = false;

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -691,6 +691,8 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec)
         if (!m_conn->Workername().empty())
             jReq["worker"] = m_conn->Workername();
         jReq["params"].append(m_conn->User() + m_conn->Path());
+        if (!m_conn->Pass().empty())
+            jReq["params"].append(m_conn->Pass());
 
         break;
 

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -647,10 +647,6 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec)
     m_sendBuffer.consume(4096);
     clear_response_pleas();
 
-    // User and worker
-    m_user = m_conn->User();
-    m_worker = m_conn->Workername();
-
     /*
 
     If connection has been set-up with a specific scheme then
@@ -692,9 +688,9 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec)
     case EthStratumClient::ETHPROXY:
 
         jReq["method"] = "eth_submitLogin";
-        if (m_worker.length())
-            jReq["worker"] = m_worker;
-        jReq["params"].append(m_user + m_conn->Path());
+        if (!m_conn->Workername().empty())
+            jReq["worker"] = m_conn->Workername();
+        jReq["params"].append(m_conn->User() + m_conn->Path());
 
         break;
 
@@ -940,7 +936,7 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
                 m_subscribed.store(_isSuccess, std::memory_order_relaxed);
                 if (!m_subscribed)
                 {
-                    cnote << "Could not login:" << _errReason;
+                    cnote << "Could not login: " << _errReason;
                     m_conn->MarkUnrecoverable();
                     m_io_service.post(
                         m_io_strand.wrap(boost::bind(&EthStratumClient::disconnect, this)));
@@ -1369,8 +1365,8 @@ void EthStratumClient::submitHashrate(string const& rate, string const& id)
     Json::Value jReq;
     jReq["id"] = unsigned(9);
     jReq["jsonrpc"] = "2.0";
-    if (m_worker.length())
-        jReq["worker"] = m_worker;
+    if (!m_conn->Workername().empty())
+        jReq["worker"] = m_conn->Workername();
     jReq["method"] = "eth_submitHashrate";
     jReq["params"] = Json::Value(Json::arrayValue);
     jReq["params"].append(rate);  // Already expressed as hex
@@ -1408,8 +1404,8 @@ void EthStratumClient::submitSolution(const Solution& solution)
         jReq["params"].append("0x" + nonceHex);
         jReq["params"].append("0x" + solution.work.header.hex());
         jReq["params"].append("0x" + solution.mixHash.hex());
-        if (m_worker.length())
-            jReq["worker"] = m_worker;
+        if (!m_conn->Workername().empty())
+            jReq["worker"] = m_conn->Workername();
 
         break;
 
@@ -1419,8 +1415,8 @@ void EthStratumClient::submitSolution(const Solution& solution)
         jReq["params"].append("0x" + nonceHex);
         jReq["params"].append("0x" + solution.work.header.hex());
         jReq["params"].append("0x" + solution.mixHash.hex());
-        if (m_worker.length())
-            jReq["worker"] = m_worker;
+        if (!m_conn->Workername().empty())
+            jReq["worker"] = m_conn->Workername();
 
         break;
 

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -1243,25 +1243,29 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
                     // Only some eth-proxy compatible implementations carry the block number
                     // namely ethermine.org
                     m_current.block = -1;
-                    if (m_conn->StratumMode() ==
-                        EthStratumClient::ETHPROXY && jPrm.size() > prmIdx)
+                    if (m_conn->StratumMode() == EthStratumClient::ETHPROXY &&
+                        jPrm.size() > prmIdx &&
+                        jPrm.get(Json::Value::ArrayIndex(prmIdx), "").asString().substr(0, 2) ==
+                            "0x")
                     {
                         try
                         {
                             m_current.block = std::stoul(
                                 jPrm.get(Json::Value::ArrayIndex(prmIdx), "").asString(), nullptr,
                                 16);
-                            /* check if the block number is in a valid range
-                                A year has ~31536000 seconds
-                                50 years have ~1576800000
-                                assuming a (very fast) blocktime of 10s:
-                                   ==> in 50 years we get 157680000 (=0x9660180) blocks
+                            /*
+                            check if the block number is in a valid range
+                            A year has ~31536000 seconds
+                            50 years have ~1576800000
+                            assuming a (very fast) blocktime of 10s:
+                            ==> in 50 years we get 157680000 (=0x9660180) blocks
                             */
                             if (m_current.block > 0x9660180)
-                                m_current.block = -1;
+                                throw new std::exception();
                         }
                         catch (const std::exception&)
                         {
+                            m_current.block = -1;
                         }
                     }
 

--- a/libpoolprotocols/stratum/EthStratumClient.h
+++ b/libpoolprotocols/stratum/EthStratumClient.h
@@ -109,9 +109,6 @@ private:
     void onSendSocketDataCompleted(const boost::system::error_code& ec);
     void onSSLShutdownCompleted(const boost::system::error_code& ec);
 
-    string m_user;    // Only user part
-    string m_worker;  // eth-proxy only; No ! It's for all !!!
-
     std::atomic<bool> m_disconnecting = {false};
     std::atomic<bool> m_connecting = {false};
     std::atomic<bool> m_authpending = {false};


### PR DESCRIPTION
Uri parsing now leverages regex.
Mandatory conventions are :
- a dot (`.`) marks the delimiter for Workername
- a column (`:`) marks the delimiter for Password

If User and/or Worker and/or Password contains any character that would impair uri parsing (namely `.` `:` `@` `?` or `#`) that string **MUST** be enclosed in backticks (ASCII 96).

Addressing https://github.com/ethereum-mining/ethminer/issues/1687
it's now possible to write
```
./ethminer -U -P stratum1+tcp://`username.246891`.rigname:x@eu-01.miningrigrentals.com:3344
```
Other possibilities
```
./ethminer -U -P stratum1+tcp://`johndoe@gmail.com`.`rigname:01`:x@eu-01.miningrigrentals.com:3344
```

**Note : in linux bash the backtick has the meaning of evaluation of expression thus it has to be further escaped with a backslash in front of it**
Thus the above sample for linux must be written as
```
./ethminer -U -P stratum1+tcp://\`username.246891\`.rigname:x@eu-01.miningrigrentals.com:3344
```

This commit is totally backwards compatible: all previous syntaxes which worked in 99% of cases still run unmodified.

Replaces https://github.com/ethereum-mining/ethminer/pull/1720