### PR TITLE
Set current epoch context into newly created miner threads.

### DIFF
--- a/libethcore/Farm.cpp
+++ b/libethcore/Farm.cpp
@@ -213,6 +213,7 @@ bool Farm::start()
 
             m_miners.push_back(std::shared_ptr<Miner>(m_sealers[sealer].create(m_miners.size())));
             m_miners.back()->setDescriptor(it->second);
+            m_miners.back()->setEpoch(m_currentEc);
             m_miners.back()->startWorking();
         }
     }


### PR DESCRIPTION
Should fix #1722 