### PR TITLE
CUDA: Only allocate DAG memory if needed.

### DIFF
--- a/libethash-cuda/CUDAMiner.h
+++ b/libethash-cuda/CUDAMiner.h
@@ -82,6 +82,9 @@ private:
 
     const uint32_t m_batch_size;
     const uint32_t m_streams_batch_size;
+
+    uint64_t m_allocated_memory_dag = 0; // dag_size is a uint64_t in EpochContext struct
+    size_t m_allocated_memory_light_cache = 0;
 };
 
 

--- a/libethash-cuda/ethash_cuda_miner_kernel.cu
+++ b/libethash-cuda/ethash_cuda_miner_kernel.cu
@@ -149,6 +149,38 @@ void set_constants(hash128_t* _dag, uint32_t _dag_size, hash64_t* _light, uint32
     CUDA_SAFE_CALL(cudaMemcpyToSymbol(d_light_size, &_light_size, sizeof(uint32_t)));
 }
 
+void get_constants(hash128_t** _dag, uint32_t* _dag_size, hash64_t** _light, uint32_t* _light_size)
+{
+    /*
+       Using the direct address of the targets did not work.
+       So I've to read first into local variables when using cudaMemcpyFromSymbol()
+    */
+    if (_dag)
+    {
+        hash128_t* _d;
+        CUDA_SAFE_CALL(cudaMemcpyFromSymbol(&_d, d_dag, sizeof(hash128_t*)));
+        *_dag = _d;
+    }
+    if (_dag_size)
+    {
+        uint32_t _ds;
+        CUDA_SAFE_CALL(cudaMemcpyFromSymbol(&_ds, d_dag_size, sizeof(uint32_t)));
+        *_dag_size = _ds;
+    }
+    if (_light)
+    {
+        hash64_t* _l;
+        CUDA_SAFE_CALL(cudaMemcpyFromSymbol(&_l, d_light, sizeof(hash64_t*)));
+        *_light = _l;
+    }
+    if (_light_size)
+    {
+        uint32_t _ls;
+        CUDA_SAFE_CALL(cudaMemcpyFromSymbol(&_ls, d_light_size, sizeof(uint32_t)));
+        *_light_size = _ls;
+    }
+}
+
 void set_header(hash32_t _header)
 {
     CUDA_SAFE_CALL(cudaMemcpyToSymbol(d_header, &_header, sizeof(hash32_t)));

--- a/libethash-cuda/ethash_cuda_miner_kernel.h
+++ b/libethash-cuda/ethash_cuda_miner_kernel.h
@@ -55,6 +55,7 @@ typedef union
 } hash200_t;
 
 void set_constants(hash128_t* _dag, uint32_t _dag_size, hash64_t* _light, uint32_t _light_size);
+void get_constants(hash128_t** _dag, uint32_t* _dag_size, hash64_t** _light, uint32_t* _light_size);
 
 void set_header(hash32_t _header);
 


### PR DESCRIPTION
Allocating the (current ~3GB) DAG needs 5 sec in my environment.
This patch reuses the already allocated memory if possible.