### PR TITLE
Log line displays port number twice

### DIFF
--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -414,8 +414,7 @@ void PoolManager::rotateConnect()
         m_connectionAttempt++;
 
         // Invoke connections
-        m_selectedHost = m_connections.at(m_activeConnectionIdx).Host() + ":" +
-                         to_string(m_connections.at(m_activeConnectionIdx).Port());
+        m_selectedHost = m_connections.at(m_activeConnectionIdx).Host();
         p_client->setConnection(&m_connections.at(m_activeConnectionIdx));
         cnote << "Selected pool " << m_selectedHost;
 

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -183,7 +183,7 @@ void PoolManager::setClientHandlers() {
             showDifficulty();
 
 
-        cnote << "Job: " EthWhite "#" << m_currentWp.header.abridged()
+        cnote << "Job: " EthWhite << m_currentWp.header.abridged()
 #ifdef DEV_BUILD
               << (m_currentWp.block != -1 ? (" block " + to_string(m_currentWp.block)) : "")
 #endif

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -184,7 +184,9 @@ void PoolManager::setClientHandlers() {
 
 
         cnote << "Job: " EthWhite "#" << m_currentWp.header.abridged()
+#ifdef DEV_BUILD
               << (m_currentWp.block != -1 ? (" block " + to_string(m_currentWp.block)) : "")
+#endif
               << EthReset << " " << m_selectedHost;
 
         // Shuffle if needed


### PR DESCRIPTION
- reduce log output by only displaying port number once per log line.