### PR TITLE
travis fix to check cuda-8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ matrix:
               - CUDA=ON
               - CUDA_VERSION=8
         - os: osx
-          osx_image: xcode9.1
+          osx_image: xcode9.2
           env:
-              - CUDA=OFF
+              - CUDA=ON
               - CUDA_VERSION=9
 cache:
     directories:
@@ -58,6 +58,16 @@ before_install:
         export CXX=g++-6
       fi
     elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      curl -L https://developer.nvidia.com/compute/cuda/9.1/Prod/local_installers/cuda_9.1.128_mac -o $HOME/cuda_9.1.128_mac.dmg
+      hdiutil mount $HOME/cuda_9.1.128_mac.dmg
+      sleep 5
+      ls -ltr /Volumes/CUDAMacOSXInstaller/CUDAMacOSXInstaller.app/Contents/MacOS
+      sudo /Volumes/CUDAMacOSXInstaller/CUDAMacOSXInstaller.app/Contents/MacOS/CUDAMacOSXInstaller --accept-eula --no-window; export BREW_STATUS=$?
+      echo "Brew status $BREW_STATUS"
+      if [ $BREW_STATUS -ne 0 ]; then
+        echo "Brew Failed"
+        exit $BREW_STATUS
+      fi
       HOMEBREW_NO_AUTO_UPDATE=1 brew install -q python3
       pip3 install -q requests gitpython
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,20 @@ matrix:
         - os: linux
           dist: trusty
           sudo: required
-          env: CUDA=ON
+          env:
+              - CUDA=ON
+              - CUDA_VERSION=9
+        - os: linux
+          dist: trusty
+          sudo: required
+          env:
+              - CUDA=ON
+              - CUDA_VERSION=8
         - os: osx
           osx_image: xcode9.1
-          env: CUDA=OFF
+          env:
+              - CUDA=OFF
+              - CUDA_VERSION=9
 cache:
     directories:
         - $HOME/.local
@@ -36,11 +46,17 @@ before_install:
       sudo apt-get -q update
       sudo apt-get -qy install g++-6
       scripts/install_cmake.sh
-      . scripts/install-cuda-ubuntu1604.sh
+      . scripts/install-cuda-ubuntu1604.sh $CUDA_VERSION
       pyenv global 3.6
       pip install --user requests gitpython
-      export CC=gcc-6
-      export CXX=g++-6
+      if [ "$CUDA_VERSION" = "8" ]; then
+        sudo apt-get -qy install g++-5
+        export CC=gcc-5
+        export CXX=g++-5
+      else
+        export CC=gcc-6
+        export CXX=g++-6
+      fi
     elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
       HOMEBREW_NO_AUTO_UPDATE=1 brew install -q python3
       pip3 install -q requests gitpython
@@ -53,7 +69,7 @@ script: |
     if [ "$TRAVIS_OS_NAME" = osx ]; then otool -L build/ethminer/ethminer; fi
     . build/ethminer/buildinfo.sh
     mkdir package
-    mv build/ethminer.tar.gz package/$PROJECT_NAME-$PROJECT_VERSION-$SYSTEM_NAME-$SYSTEM_PROCESSOR.tar.gz
+    mv build/ethminer.tar.gz package/$PROJECT_NAME-$PROJECT_VERSION-cuda-$CUDA_VERSION-$SYSTEM_NAME-$SYSTEM_PROCESSOR.tar.gz
 
 
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,8 @@ clone_depth: 100
 os: "Visual Studio 2017"
 environment:
   matrix:
-    - CUDA_VER: "9.0"
+    - CUDA_VER: "8.0"
+    - CUDA_VER: "9.1"
     - CUDA_VER: "10.0"
   HUNTER_CACHE_TOKEN:
     secure: VnpF1MH5MEFvUI5MiMMMFlmbDdst+bfom5ZFVgalYPp/SYDhbejjXJm9Dla/IgpC
@@ -18,9 +19,16 @@ environment:
 # Download CUDA Windows installer (local) and extract /compiler/* to /CUDA/vX.0/ zip archive.
 install: |
   git submodule update --init --recursive
-  set CUDA_ARCHIVE=CUDA-v%CUDA_VER%-WindowsServer2012.7z
-  appveyor DownloadFile https://github.com/ethereum-mining/ethminer/releases/download/build-deps/%CUDA_ARCHIVE%
-  7z x %CUDA_ARCHIVE% -oC:\
+  if "%CUDA_VER%" == "8.0" set CUDA_ARCHIVE=cuda_8.0.61_windows-exe
+  if "%CUDA_VER%" == "9.1" set CUDA_ARCHIVE=cuda_9.1.85_windows
+  if "%CUDA_VER%" == "10.0" set CUDA_ARCHIVE=cuda_10.0.130_411.31_windows
+  if "%CUDA_VER%" NEQ "8.0" curl -L https://developer.nvidia.com/compute/cuda/%CUDA_VER%/Prod/local_installers/%CUDA_ARCHIVE% -o %CUDA_ARCHIVE%.exe
+  if "%CUDA_VER%" == "8.0" curl -L https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda_8.0.61_windows-exe -o %CUDA_ARCHIVE%.exe
+  mkdir C:\CUDA
+  if "%CUDA_VER%" NEQ "8.0" 7z x %CUDA_ARCHIVE%.exe -oC:\CUDA nvcc/*
+  if "%CUDA_VER%" == "8.0" 7z x %CUDA_ARCHIVE%.exe -oC:\CUDA compiler/*
+  if "%CUDA_VER%" NEQ "8.0" rename C:\CUDA\nvcc v%CUDA_VER%
+  if "%CUDA_VER%" == "8.0" rename C:\CUDA\compiler v%CUDA_VER%
   set PATH=C:\Python36-x64;C:\Python36-x64\Scripts;%PATH%;C:\CUDA\v%CUDA_VER%\bin
   pip install requests gitpython
   nvcc -V
@@ -28,7 +36,7 @@ install: |
 build_script:
   - call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsMSBuildCmd.bat"
   - set CMAKE_ARGS=-G "Visual Studio 15 2017 Win64" -H. -Bbuild -DETHASHCUDA=ON -DAPICORE=ON -DHUNTER_JOBS_NUMBER=%NUMBER_OF_PROCESSORS%
-  - if "%CUDA_VER%" == "9.0" set CMAKE_ARGS=%CMAKE_ARGS% -T v140
+  - if "%CUDA_VER%" NEQ "10.0" set CMAKE_ARGS=%CMAKE_ARGS% -T v140
   - cmake %CMAKE_ARGS%
   - cmake --build build --config Release --target package
   - ps: |

--- a/scripts/install-cuda-ubuntu1604.sh
+++ b/scripts/install-cuda-ubuntu1604.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 #
 # Install the core CUDA_VER toolkit for Ubuntu 16.04.
 # Requires the CUDA_VER environment variable to be set to the required version.
@@ -10,14 +10,36 @@
 
 set -e
 
-export CUDA_VER=9.1.85-1
+CUDA_VER=9.1.85-1
+if [ "$1" != "" ]; then
+  CUDA_VER=$1
+fi
+if [ "$CUDA_VER" = "8" ]; then
+  CUDA_VER=8.0.61-1
+  CUDA_PACKAGE=cuda-core
+elif [ "$CUDA_VER" = "9" ]; then
+  CUDA_VER=9.1.85-1
+elif [ "$CUDA_VER" = "9.1" ]; then
+  CUDA_VER=9.1.85-1
+elif [ "$CUDA_VER" = "9.2" ]; then
+  CUDA_VER=9.2.148-1
+elif [ "$CUDA_VER" = "10" ]; then
+  CUDA_VER=10.0.130-1
+fi
+
+if [ -z $CUDA_PACKAGE ]; then
+  CUDA_PACKAGE=cuda-nvcc
+fi
+
 sudo apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub
 wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_${CUDA_VER}_amd64.deb
 sudo dpkg -i cuda-repo-ubuntu1604_${CUDA_VER}_amd64.deb
 sudo apt-get update -qq
-export CUDA_APT=${CUDA_VER:0:3}
-export CUDA_APT=${CUDA_APT/./-}
-sudo apt-get install -qy cuda-nvcc-${CUDA_APT} cuda-cudart-dev-${CUDA_APT}
+CUDA_APT=$(echo $CUDA_VER | sed 's/\.[0-9]\+\-[0-9]\+$//;s/\./-/')
+sudo apt-get install -qy $CUDA_PACKAGE-$CUDA_APT cuda-cudart-dev-$CUDA_APT
 sudo apt-get clean
-export CUDA_HOME=/usr/local/cuda-${CUDA_VER:0:3}
-export PATH=${CUDA_HOME}/bin:${PATH}
+CUDA_APT=$(echo $CUDA_APT | sed 's/-/./')
+CUDA_HOME=/usr/local/cuda-$CUDA_APT
+PATH=${CUDA_HOME}/bin:${PATH}
+export CUDA_HOME
+export PATH


### PR DESCRIPTION
 * fixed scripts/install-cuda-ubuntu1604.sh script to support cuda-8, cuda-9, cuda-10
 * make scripts/install-* more potable
 * a travis entry added to check cuda-8
 * osx cuda-9.1 build added
    Please see https://github.com/bytedeco/javacpp-presets/blob/master/ci/install-travis.sh#L271-L283
 * appveyor fix for cuda-8, cuda-9.1 etc.
   - download compiler from the official nvidia site.
     - extract compiler only from the downloaded file using 7z. like as `7z foobar.exe -oC:\CUDA nvcc/*` and rename `C:\CUDA\nvcc` to `C:\CUDA\v9.1`
   - use cuda-9.1 instead of cuda-9.0
   - cuda-8.0 build added.