### PR TITLE
use uint2 const to reduce vectorize()/mov.b64

### DIFF
--- a/libethash-cuda/keccak.cuh
+++ b/libethash-cuda/keccak.cuh
@@ -1,12 +1,13 @@
 #include "cuda_helper.h"
 
-__device__ __constant__ uint64_t const keccak_round_constants[24] = {0x0000000000000001ULL,
-    0x0000000000008082ULL, 0x800000000000808AULL, 0x8000000080008000ULL, 0x000000000000808BULL,
-    0x0000000080000001ULL, 0x8000000080008081ULL, 0x8000000000008009ULL, 0x000000000000008AULL,
-    0x0000000000000088ULL, 0x0000000080008009ULL, 0x000000008000000AULL, 0x000000008000808BULL,
-    0x800000000000008BULL, 0x8000000000008089ULL, 0x8000000000008003ULL, 0x8000000000008002ULL,
-    0x8000000000000080ULL, 0x000000000000800AULL, 0x800000008000000AULL, 0x8000000080008081ULL,
-    0x8000000000008080ULL, 0x0000000080000001ULL, 0x8000000080008008ULL};
+__device__ __constant__ uint2 const keccak_round_constants[24] = {
+    { 0x00000001, 0x00000000 }, { 0x00008082, 0x00000000 }, { 0x0000808a, 0x80000000 }, { 0x80008000, 0x80000000 },
+    { 0x0000808b, 0x00000000 }, { 0x80000001, 0x00000000 }, { 0x80008081, 0x80000000 }, { 0x00008009, 0x80000000 },
+    { 0x0000008a, 0x00000000 }, { 0x00000088, 0x00000000 }, { 0x80008009, 0x00000000 }, { 0x8000000a, 0x00000000 },
+    { 0x8000808b, 0x00000000 }, { 0x0000008b, 0x80000000 }, { 0x00008089, 0x80000000 }, { 0x00008003, 0x80000000 },
+    { 0x00008002, 0x80000000 }, { 0x00000080, 0x80000000 }, { 0x0000800a, 0x00000000 }, { 0x8000000a, 0x80000000 },
+    { 0x80008081, 0x80000000 }, { 0x00008080, 0x80000000 }, { 0x80000001, 0x00000000 }, { 0x80008008, 0x80000000 }
+};
 
 DEV_INLINE uint2 xor5(
     const uint2 a, const uint2 b, const uint2 c, const uint2 d, const uint2 e)
@@ -195,7 +196,7 @@ DEV_INLINE void keccak_f1600_init(uint2* state)
     s[24] = chi(s[24], u, v);
 
     /* iota: a[0,0] ^= round constant */
-    s[0] ^= vectorize(keccak_round_constants[0]);
+    s[0] ^= keccak_round_constants[0];
 
     for (int i = 1; i < 23; i++)
     {
@@ -315,7 +316,7 @@ DEV_INLINE void keccak_f1600_init(uint2* state)
         s[24] = chi(s[24], u, v);
 
         /* iota: a[0,0] ^= round constant */
-        s[0] ^= vectorize(keccak_round_constants[i]);
+        s[0] ^= keccak_round_constants[i];
     }
 
     /* theta: c = a[0,i] ^ a[1,i] ^ .. a[4,i] */
@@ -375,7 +376,7 @@ DEV_INLINE void keccak_f1600_init(uint2* state)
     s[7] = chi(s[7], s[8], s[9]);
 
     /* iota: a[0,0] ^= round constant */
-    s[0] ^= vectorize(keccak_round_constants[23]);
+    s[0] ^= keccak_round_constants[23];
 
     for (int i = 0; i < 12; ++i)
         state[i] = s[i];
@@ -513,7 +514,7 @@ DEV_INLINE uint64_t keccak_f1600_final(uint2* state)
     s[24] = chi(s[24], u, v);
 
     /* iota: a[0,0] ^= round constant */
-    s[0] ^= vectorize(keccak_round_constants[0]);
+    s[0] ^= keccak_round_constants[0];
 
     for (int i = 1; i < 23; i++)
     {
@@ -632,7 +633,7 @@ DEV_INLINE uint64_t keccak_f1600_final(uint2* state)
         s[24] = chi(s[24], u, v);
 
         /* iota: a[0,0] ^= round constant */
-        s[0] ^= vectorize(keccak_round_constants[i]);
+        s[0] ^= keccak_round_constants[i];
     }
 
     t[0] = xor5(s[0], s[5], s[10], s[15], s[20]);
@@ -652,7 +653,7 @@ DEV_INLINE uint64_t keccak_f1600_final(uint2* state)
 
     /* iota: a[0,0] ^= round constant */
     // s[0] ^= vectorize(keccak_round_constants[23]);
-    return devectorize(s[0]) ^ keccak_round_constants[23];
+    return devectorize(s[0] ^ keccak_round_constants[23]);
 }
 
 DEV_INLINE void SHA3_512(uint2* s)
@@ -783,7 +784,7 @@ DEV_INLINE void SHA3_512(uint2* s)
         s[24] = chi(s[24], u, v);
 
         /* iota: a[0,0] ^= round constant */
-        s[0] ^= vectorize(keccak_round_constants[i]);
+        s[0] ^= keccak_round_constants[i];
     }
 
     /* theta: c = a[0,i] ^ a[1,i] ^ .. a[4,i] */
@@ -843,5 +844,5 @@ DEV_INLINE void SHA3_512(uint2* s)
     s[7] = chi(s[7], s[8], s[9]);
 
     /* iota: a[0,0] ^= round constant */
-    s[0] ^= vectorize(keccak_round_constants[23]);
+    s[0] ^= keccak_round_constants[23];
 }


### PR DESCRIPTION
reduced `vectorize()` (`mov.b64` ptx instruction) using `__constant__ uint2`

about ~30 `mov.b64` ptx instructions reduced.

for my P106-100 (6G samsung)

P106-100(6G) | `ethminer -U -M 50000`
---------|--------
original | min/mean/max: 24,034,424/24,040,047/**24,043,364** H/s
fixed  | min/mean/max: 24,037,682/24,040,596/**24,043,498** H/s

(almost no difference but small improvement)