### PR TITLE
load dag using __ldg()

### DIFF
--- a/libethash-cuda/ethash_cuda_miner_kernel_globals.h
+++ b/libethash-cuda/ethash_cuda_miner_kernel_globals.h
@@ -13,3 +13,8 @@ __constant__ uint64_t d_target;
 #define SHFL(x, y, z) __shfl((x), (y), (z))
 #endif
 
+#if (__CUDA_ARCH__ >= 320)
+#define LDG(x) __ldg(&(x))
+#else
+#define LDG(x) (x)
+#endif

--- a/libethash-cuda/keccak.cuh
+++ b/libethash-cuda/keccak.cuh
@@ -784,7 +784,7 @@ DEV_INLINE void SHA3_512(uint2* s)
         s[24] = chi(s[24], u, v);
 
         /* iota: a[0,0] ^= round constant */
-        s[0] ^= keccak_round_constants[i];
+        s[0] ^= LDG(keccak_round_constants[i]);
     }
 
     /* theta: c = a[0,i] ^ a[1,i] ^ .. a[4,i] */
@@ -844,5 +844,5 @@ DEV_INLINE void SHA3_512(uint2* s)
     s[7] = chi(s[7], s[8], s[9]);
 
     /* iota: a[0,0] ^= round constant */
-    s[0] ^= keccak_round_constants[23];
+    s[0] ^= LDG(keccak_round_constants[23]);
 }


### PR DESCRIPTION
speed up `ethash_calculate_dag_item()` using `__ldg()`

P106-100(6G) | `ethminer/ethminer-fixed -U -M 1000000`
---------|---------
original | Generated DAG + Light in **6,102 ms**. 4.66 GB left.
fixed | Generated DAG + Light in **5,648 ms**. 4.66 GB left.