### PR TITLE
Amend bad_alloc when adding new connections via API

### DIFF
--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -509,22 +509,14 @@ void ApiConnection::processRequest(Json::Value& jRequest, Json::Value& jResponse
 
         try
         {
-            URI uri(sUri);
-            if (!uri.Valid() || uri.Scheme() == "simulation")
-            {
-                jResponse["error"]["code"] = -422;
-                jResponse["error"]["message"] = ("Invalid URI " + uri.str());
-                return;
-            }
-
             // If everything ok then add this new uri
-            PoolManager::p().addConnection(uri);
+            PoolManager::p().addConnection(sUri);
             jResponse["result"] = true;
         }
         catch (...)
         {
             jResponse["error"]["code"] = -422;
-            jResponse["error"]["message"] = "Bad URI";
+            jResponse["error"]["message"] = "Bad URI : " + sUri;
         }
     }
 
@@ -541,12 +533,23 @@ void ApiConnection::processRequest(Json::Value& jRequest, Json::Value& jResponse
             unsigned index;
             if (getRequestValue("index", index, jRequestParams, false, jResponse))
             {
-                if (PoolManager::p().setActiveConnection(index) == -1)
+                try
                 {
+                    PoolManager::p().setActiveConnection(index);
+                }
+                catch (const std::exception& _ex)
+                {
+                    std::string what = _ex.what();
                     jResponse["error"]["code"] = -422;
-                    jResponse["error"]["message"] = "Index out of bounds";
+                    jResponse["error"]["message"] = what;
                     return;
                 }
+            }
+            else
+            {
+                jResponse["error"]["code"] = -422;
+                jResponse["error"]["message"] = "Invalid index";
+                return;
             }
         }
         else
@@ -554,12 +557,23 @@ void ApiConnection::processRequest(Json::Value& jRequest, Json::Value& jResponse
             string uri;
             if (getRequestValue("URI", uri, jRequestParams, false, jResponse))
             {
-                if (PoolManager::p().setActiveConnection(uri) == -1)
+                try
                 {
+                    PoolManager::p().setActiveConnection(uri);
+                }
+                catch (const std::exception& _ex)
+                {
+                    std::string what = _ex.what();
                     jResponse["error"]["code"] = -422;
-                    jResponse["error"]["message"] = "Host match not found";
+                    jResponse["error"]["message"] = what;
                     return;
                 }
+            }
+            else
+            {
+                jResponse["error"]["code"] = -422;
+                jResponse["error"]["message"] = "Invalid index";
+                return;
             }
         }
         jResponse["result"] = true;
@@ -578,22 +592,19 @@ void ApiConnection::processRequest(Json::Value& jRequest, Json::Value& jResponse
         if (!getRequestValue("index", index, jRequestParams, false, jResponse))
             return;
 
-        int r;
-        r = PoolManager::p().removeConnection(index);
-        if (r == -1)
+        try
         {
-            jResponse["error"]["code"] = -422;
-            jResponse["error"]["message"] = "Index out of bounds";
-            return;
+            PoolManager::p().removeConnection(index);
+            jResponse["result"] = true;
         }
-        if (r == -2)
+        catch (const std::exception& _ex)
         {
-            jResponse["error"]["code"] = -460;
-            jResponse["error"]["message"] = "Can't delete active connection";
+            std::string what = _ex.what();
+            jResponse["error"]["code"] = -422;
+            jResponse["error"]["message"] = what;
             return;
         }
 
-        jResponse["result"] = true;
     }
 
     else if (_method == "miner_getscramblerinfo")
@@ -627,6 +638,8 @@ void ApiConnection::processRequest(Json::Value& jRequest, Json::Value& jResponse
                 }
                 catch (const std::exception&)
                 {
+                    jResponse["error"]["code"] = -422;
+                    jResponse["error"]["message"] = "Invalid nonce";
                     return;
                 }
             }
@@ -939,7 +952,7 @@ void ApiConnection::onSendSocketDataCompleted(const boost::system::error_code& e
 
 Json::Value ApiConnection::getMinerStat1()
 {
-    auto connection = PoolManager::p().getActiveConnectionCopy();
+    auto connection = PoolManager::p().getActiveConnection();
     TelemetryType t = Farm::f().Telemetry();
     auto runningTime = std::chrono::duration_cast<std::chrono::minutes>(
         steady_clock::now() - t.start);
@@ -957,7 +970,7 @@ Json::Value ApiConnection::getMinerStat1()
                << t.farm.solutions.accepted << ";" << t.farm.solutions.rejected;
     totalMhDcr << "0;0;0";                            // DualMining not supported
     invalidStats << t.farm.solutions.failed << ";0";  // Invalid + Pool switches
-    poolAddresses << connection.Host() << ':' << connection.Port();
+    poolAddresses << connection->Host() << ':' << connection->Port();
     invalidStats << ";0;0";  // DualMining not supported
 
     int gpuIndex = 0;
@@ -1205,8 +1218,8 @@ Json::Value ApiConnection::getMinerStatDetail()
 
     /* Connection info */
     Json::Value connectioninfo;
-    auto connection = PoolManager::p().getActiveConnectionCopy();
-    connectioninfo["uri"] = connection.str();
+    auto connection = PoolManager::p().getActiveConnection();
+    connectioninfo["uri"] = connection->str();
     connectioninfo["connected"] = PoolManager::p().isConnected();
     connectioninfo["switches"] = PoolManager::p().getConnectionSwitches();
 

--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -292,7 +292,7 @@ void ApiServer::begin_accept()
     if (!isRunning())
         return;
 
-    auto session = std::make_shared<ApiConnection>(++lastSessionId, m_readonly, m_password);
+    auto session = std::make_shared<ApiConnection>(m_io_strand, ++lastSessionId, m_readonly, m_password);
     m_acceptor.async_accept(
         session->socket(), m_io_strand.wrap(boost::bind(&ApiServer::handle_accept, this, session,
                                boost::asio::placeholders::error)));
@@ -349,10 +349,11 @@ void ApiConnection::disconnect()
     }
 }
 
-ApiConnection::ApiConnection(int id, bool readonly, string password)
+ApiConnection::ApiConnection(
+    boost::asio::io_service::strand& _strand, int id, bool readonly, string password)
   : m_sessionId(id),
     m_socket(g_io_service),
-    m_io_strand(g_io_service),
+    m_io_strand(_strand),
     m_readonly(readonly),
     m_password(std::move(password))
 {

--- a/libapicore/ApiServer.h
+++ b/libapicore/ApiServer.h
@@ -22,7 +22,7 @@ class ApiConnection
 {
 public:
 
-    ApiConnection(int id, bool readonly, string password);
+    ApiConnection(boost::asio::io_service::strand& _strand, int id, bool readonly, string password);
 
     ~ApiConnection() = default;
 
@@ -57,7 +57,7 @@ private:
     int m_sessionId;
 
     tcp::socket m_socket;
-    boost::asio::io_service::strand m_io_strand;
+    boost::asio::io_service::strand& m_io_strand;
     boost::asio::streambuf m_sendBuffer;
     boost::asio::streambuf m_recvBuffer;
     Json::StreamWriterBuilder m_jSwBuilder;

--- a/libpoolprotocols/PoolClient.h
+++ b/libpoolprotocols/PoolClient.h
@@ -21,13 +21,13 @@ public:
     virtual ~PoolClient() noexcept = default;
 
 
-    void setConnection(URI* conn)
+    void setConnection(std::shared_ptr<URI> _conn)
     {
-        m_conn = conn;
+        m_conn = _conn;
         m_canconnect.store(false, std::memory_order_relaxed);
     }
 
-    const URI* getConnection() { return m_conn; }
+    std::shared_ptr<URI> getConnection() { return m_conn; }
     void unsetConnection() { m_conn = nullptr; }
 
     virtual void connect() = 0;
@@ -61,7 +61,7 @@ protected:
 
     boost::asio::ip::basic_endpoint<boost::asio::ip::tcp> m_endpoint;
 
-    URI* m_conn = nullptr;
+    std::shared_ptr<URI> m_conn = nullptr;
 
     SolutionAccepted m_onSolutionAccepted;
     SolutionRejected m_onSolutionRejected;

--- a/libpoolprotocols/PoolManager.h
+++ b/libpoolprotocols/PoolManager.h
@@ -26,13 +26,13 @@ public:
         bool reportHashrate, unsigned workTimeout, unsigned responseTimeout, unsigned pollInterval,
         unsigned benchmarkBlock);
     static PoolManager& p() { return *m_this; }
-    void addConnection(URI& conn);
-    void clearConnections();
+    void addConnection(std::string _connstring);
+    void addConnection(std::shared_ptr<URI> _uri);
     Json::Value getConnectionsJson();
-    int setActiveConnection(unsigned int idx);
-    int setActiveConnection(std::string& host);
-    URI getActiveConnectionCopy();
-    int removeConnection(unsigned int idx);
+    void setActiveConnection(unsigned int idx);
+    void setActiveConnection(std::string& _connstring);
+    std::shared_ptr<URI> getActiveConnection();
+    void removeConnection(unsigned int idx);
     void start();
     void stop();
     bool isConnected() { return p_client->isConnected(); };
@@ -49,7 +49,7 @@ private:
 
     void showMiningAt();
 
-    int setActiveConnectionCommon(unsigned int idx, UniqueGuard& l);
+    void setActiveConnectionCommon(unsigned int idx);
 
     unsigned m_hrReportingInterval = 60;
 
@@ -71,6 +71,7 @@ private:
 
     std::atomic<bool> m_running = {false};
     std::atomic<bool> m_stopping = {false};
+    std::atomic<bool> m_async_pending = {false};
 
     bool m_hashrate;           // Whether or not submit hashrate to work provider (pool)
     std::string m_hashrateId;  // The unique client Id to use when submitting hashrate
@@ -80,7 +81,7 @@ private:
     std::string m_selectedHost = "";  // Holds host name (and endpoint) of selected connection
     std::atomic<unsigned> m_connectionSwitches = {0};
 
-    std::vector<URI> m_connections;
+    std::vector<std::shared_ptr<URI>> m_connections;
     unsigned m_activeConnectionIdx = 0;
     mutable Mutex m_activeConnectionMutex;
 
@@ -90,7 +91,7 @@ private:
     boost::asio::deadline_timer m_failovertimer;
     boost::asio::deadline_timer m_submithrtimer;
 
-    PoolClient* p_client = nullptr;
+    std::unique_ptr<PoolClient> p_client = nullptr;
 
     std::atomic<unsigned> m_epochChanges = {0};
 

--- a/libpoolprotocols/PoolURI.h
+++ b/libpoolprotocols/PoolURI.h
@@ -54,7 +54,7 @@ class URI
 {
 public:
     URI() = delete;
-    URI(std::string uri);
+    URI(std::string uri, bool _sim = false);
 
     std::string Scheme() const { return m_scheme; }
     std::string Host() const { return m_host; }
@@ -69,7 +69,6 @@ public:
     bool IsLoopBack() const;
     unsigned Version() const;
     std::string str() const { return m_uri; }
-    bool Valid() const { return m_valid; }
 
     static std::string KnownSchemes(ProtocolFamily family);
 
@@ -104,7 +103,6 @@ private:
 
     unsigned short m_stratumMode = 999;  // Initial value 999 means not tested yet
     unsigned short m_port = 0;
-    bool m_valid = false;
     bool m_stratumModeConfirmed = false;
     bool m_unrecoverable = false;
 


### PR DESCRIPTION
API call `miner_addconnection` caused bad_alloc exception.

- Reworked Connections as now are `shared_ptr<URI>`
- Ensured all API calls are serialized in a single strand
- Modified API methods against pool manager so they throw on errors instead of generating specific return codes
- Inserted semaphores for outstanding async operations