### PR TITLE
Reset flag m_async_pending when exiting removeConnection() (release "Lock")

### DIFF
--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -263,9 +263,6 @@ void PoolManager::addConnection(std::shared_ptr<URI> _uri)
 
 /*
  * Remove a connection
- * Returns:  0 on success
- *          -1 failure (out of bounds)
- *          -2 failure (active connection should be deleted)
  */
 void PoolManager::removeConnection(unsigned int idx)
 {
@@ -312,7 +309,6 @@ void PoolManager::setActiveConnectionCommon(unsigned int idx)
 
 /*
  * Sets the active connection
- * Returns: 0 on success, -1 on failure (out of bounds)
  */
 void PoolManager::setActiveConnection(unsigned int idx)
 {

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -73,7 +73,6 @@ void PoolManager::setClientHandlers()
 {
     p_client->onConnected([&]() {
         {
-
             // If HostName is already an IP address no need to append the
             // effective ip address.
             if (p_client->getConnection()->HostNameType() == dev::UriHostNameType::Dns ||
@@ -286,7 +285,6 @@ void PoolManager::removeConnection(unsigned int idx)
 
 void PoolManager::setActiveConnectionCommon(unsigned int idx)
 {
-
     // Are there any outstanding operations ?
     bool ex = false;
     if (!m_async_pending.compare_exchange_strong(ex, true))
@@ -304,7 +302,6 @@ void PoolManager::setActiveConnectionCommon(unsigned int idx)
         // Release the flag immediately
         m_async_pending.store(false, std::memory_order_relaxed);
     }
-
 }
 
 /*
@@ -434,7 +431,6 @@ void PoolManager::rotateConnect()
     }
     else
     {
-
         if (m_connections.empty())
             cnote << "No more connections to try. Exiting...";
         else

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -270,8 +270,7 @@ void PoolManager::addConnection(std::shared_ptr<URI> _uri)
 void PoolManager::removeConnection(unsigned int idx)
 {
     // Are there any outstanding operations ?
-    bool ex = false;
-    if (!m_async_pending.compare_exchange_strong(ex, true))
+    if (m_async_pending.load(std::memory_order_relaxed))
         throw std::runtime_error("Outstanding operations. Retry ...");
 
     // Check bounds
@@ -286,7 +285,6 @@ void PoolManager::removeConnection(unsigned int idx)
     m_connections.erase(m_connections.begin() + idx);
     if (m_activeConnectionIdx > idx)
         m_activeConnectionIdx--;
-
 }
 
 void PoolManager::setActiveConnectionCommon(unsigned int idx)


### PR DESCRIPTION
Reset flag m_async_pending when exiting removeConnection() and remove outdated comments. 