### PR TITLE
Wrong default CL Local Work Size

### DIFF
--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -45,7 +45,7 @@ class CLMiner : public Miner
 public:
     /* -- default values -- */
     /// Default value of the local work size. Also known as workgroup size.
-    static const unsigned c_defaultLocalWorkSize = 192;
+    static const unsigned c_defaultLocalWorkSize = 128;
     /// Default value of the global work size as a multiplier of the local work size
     static const unsigned c_defaultGlobalWorkSizeMultiplier = 65536;
 


### PR DESCRIPTION
Default CL Local Work Size is 192 which is not a power of 2.
Valid values are 32 64 128 256

Amends #1740