### PR TITLE
Avoid opencl abort queue race condition

### DIFF
--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -60,23 +60,22 @@ private:
     
     void workLoop() override;
 
-    vector<cl::Context> m_context;
-    vector<cl::CommandQueue> m_queue;
-    vector<cl::CommandQueue> m_abortqueue;
+    cl::Context m_context;
+    cl::CommandQueue m_queue;
+    cl::CommandQueue m_abortqueue;
     cl::Kernel m_searchKernel;
     cl::Kernel m_dagKernel;
     cl::Device m_device;
+    cl::Buffer m_header;
+    cl::Buffer m_searchBuffer;
 
-    vector<cl::Buffer> m_dag;
-    vector<cl::Buffer> m_light;
-    vector<cl::Buffer> m_header;
-    vector<cl::Buffer> m_searchBuffer;
+    cl::Buffer* m_dag = nullptr;
+    cl::Buffer* m_light = nullptr;
 
     CLSettings m_settings;
 
     unsigned m_dagItems = 0;
     uint64_t m_lastNonce = 0;
-
 };
 
 }  // namespace eth


### PR DESCRIPTION
- Allocate OpenCL context and command queues once at miner
  initialization to avoid race condition in kick_miner.

- While we're at it replace vectors that will have at most
  a single element with simple pointers

- Only light and dag buffers need to be reallocated with every epoch