### PR TITLE
fixes cmake linker error due to missing boost::thread dependency

### DIFF
--- a/ethminer/CMakeLists.txt
+++ b/ethminer/CMakeLists.txt
@@ -16,9 +16,6 @@ endif()
 hunter_add_package(CLI11)
 find_package(CLI11 CONFIG REQUIRED)
 
-hunter_add_package(Boost COMPONENTS system thread)
-find_package(Boost CONFIG REQUIRED system thread)
-
 target_link_libraries(ethminer PRIVATE ethcore poolprotocols devcore ethminer-buildinfo CLI11::CLI11 Boost::system Boost::thread)
 
 if(ETHDBUS)

--- a/ethminer/CMakeLists.txt
+++ b/ethminer/CMakeLists.txt
@@ -16,7 +16,10 @@ endif()
 hunter_add_package(CLI11)
 find_package(CLI11 CONFIG REQUIRED)
 
-target_link_libraries(ethminer PRIVATE ethcore poolprotocols devcore ethminer-buildinfo CLI11::CLI11 Boost::system)
+hunter_add_package(Boost COMPONENTS system thread)
+find_package(Boost CONFIG REQUIRED system thread)
+
+target_link_libraries(ethminer PRIVATE ethcore poolprotocols devcore ethminer-buildinfo CLI11::CLI11 Boost::system Boost::thread)
 
 if(ETHDBUS)
 	find_package(PkgConfig)


### PR DESCRIPTION
Hi,

cloned the repo, follow `doc/BUILD.md` to build ethminer. kept getting a linker error when building ethminer. found out that hunter wasn't linking it with `boost:thread`. This PR fixes the build.

cheers,
tin

os: ubuntu 18.10 docker. same issues on macos native (w/o any hashing support)
```
root@3257034f0e49:/tmp/project/build# cmake .. -DETHASHCL=OFF -DETHASHCUDA=OFF -DDEVLOG=ON
-- [cable ] Cable 0.2.14 initialized
-- [cable ] Build type: Release
-- [hunter] Calculating Toolchain-SHA1
-- [hunter] Calculating Config-SHA1
-- [hunter] HUNTER_ROOT: /root/.hunter
-- [hunter] [ Hunter-ID: 4b894e1 | Toolchain-ID: 652973c | Config-ID: cb395ce ]
-- [hunter] BOOST_ROOT: /root/.hunter/_Base/4b894e1/652973c/cb395ce/Install (ver.: 1.66.0)
-- [hunter] BOOST_ROOT: /root/.hunter/_Base/4b894e1/652973c/cb395ce/Install (ver.: 1.66.0)
-- [hunter] BOOST_ROOT: /root/.hunter/_Base/4b894e1/652973c/cb395ce/Install (ver.: 1.66.0)
-- [hunter] BOOST_ROOT: /root/.hunter/_Base/4b894e1/652973c/cb395ce/Install (ver.: 1.66.0)
-- Boost version: 1.66.0
-- Found the following Boost libraries:
--   system
--   filesystem
--   thread
-- [hunter] JSONCPP_ROOT: /root/.hunter/_Base/4b894e1/652973c/cb395ce/Install (ver.: 1.8.0)
-- [hunter] ETHASH_ROOT: /root/.hunter/_Base/4b894e1/652973c/cb395ce/Install (ver.: 0.4.3)
----------------------------------------------------------------------------
-- CMake 3.12.1
-- Build Release / Linux
----------------------------------------------------------------- components
-- ETHASHCL         Build OpenCL components                      OFF
-- ETHASHCUDA       Build CUDA components                        OFF
-- ETHASHCPU        Build CPU components (only for development)  OFF
-- ETHDBUS          Build D-Bus components                       OFF
-- APICORE          Build API Server components                  ON
-- BINKERN          Install AMD binary kernels                   ON
-- DEVBUILD         Build with dev logging                       ON
----------------------------------------------------------------------------

-- Could NOT find Git (missing: GIT_EXECUTABLE)
-- [hunter] OPENSSL_ROOT: /root/.hunter/_Base/4b894e1/652973c/cb395ce/Install (ver.: 1.1.1a)
-- [hunter] CLI11_ROOT: /root/.hunter/_Base/4b894e1/652973c/cb395ce/Install (ver.: 1.7.1)
CMake Warning (dev) at ethminer/CMakeLists.txt:17 (find_package):
  Policy CMP0074 is not set: find_package uses <PackageName>_ROOT variables.
  Run "cmake --help-policy CMP0074" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  CMake variable CLI11_ROOT is set to:

    /root/.hunter/_Base/4b894e1/652973c/cb395ce/Install

  Environment variable CLI11_ROOT is set to:

    /root/.hunter/_Base/4b894e1/652973c/cb395ce/Install

  For compatibility, CMake is ignoring the variable.
This warning is for project developers.  Use -Wno-dev to suppress it.

-- [hunter] BOOST_ROOT: /root/.hunter/_Base/4b894e1/652973c/cb395ce/Install (ver.: 1.66.0)
-- [hunter] BOOST_ROOT: /root/.hunter/_Base/4b894e1/652973c/cb395ce/Install (ver.: 1.66.0)
-- [hunter] BOOST_ROOT: /root/.hunter/_Base/4b894e1/652973c/cb395ce/Install (ver.: 1.66.0)
-- Boost version: 1.66.0
-- Found the following Boost libraries:
--   system
--   thread
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/project/build
root@3257034f0e49:/tmp/project/build# cmake --build .
...
Scanning dependencies of target apicore
[ 88%] Building CXX object libapicore/CMakeFiles/apicore.dir/ApiServer.cpp.o
[ 92%] Linking CXX static library libapicore.a
[ 92%] Built target apicore
Scanning dependencies of target ethminer
[ 96%] Building CXX object ethminer/CMakeFiles/ethminer.dir/main.cpp.o
[100%] Linking CXX executable ethminer
/usr/bin/ld: ../libethcore/libethcore.a(Miner.cpp.o): in function `dev::eth::Miner::initEpoch()':
Miner.cpp:(.text._ZN3dev3eth5Miner9initEpochEv+0x308): undefined reference to `boost::detail::get_current_thread_data()'
/usr/bin/ld: Miner.cpp:(.text._ZN3dev3eth5Miner9initEpochEv+0x3fe): undefined reference to `boost::this_thread::interruption_point()'
collect2: error: ld returned 1 exit status
make[2]: *** [ethminer/CMakeFiles/ethminer.dir/build.make:100: ethminer/ethminer] Error 1
make[1]: *** [CMakeFiles/Makefile2:445: ethminer/CMakeFiles/ethminer.dir/all] Error 2
make: *** [Makefile:152: all] Error 2```