### PR TITLE
security: adding write check to miner_shuffle to match the API_DOC spec

### DIFF
--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -459,6 +459,8 @@ void ApiConnection::processRequest(Json::Value& jRequest, Json::Value& jResponse
 
     else if (_method == "miner_shuffle")
     {
+        if (!checkApiWriteAccess(m_readonly, jResponse))
+             return;
         // Gives nonce scrambler a new range
         jResponse["result"] = true;
         Farm::f().shuffle();


### PR DESCRIPTION
Hi,

## Issue

Calling API method `miner_shuffle` actually changes state and therefore is a write action. However, the  implementation fails to check if the miner is in readonly mode for `miner_shuffle` and would therefore allow to bypass this restriction.

according to the spec `miner_shuffle` is [write protected](https://github.com/ethereum-mining/ethminer/blob/master/docs/API_DOCUMENTATION.md) which is not the case.

worst case is probably someone constantly calling shuffle to interfere and severely degrade the miners performance. It is unclear to me if this would also lead to a DoS but could be the case.


## General observations:

* the API interface is written under the assumption that it will never be publicly available. whether this assumption reflects the real-world use of ethminers API is unclear. It therefore poses certain risks to unaware uses and does not implement security by default. I would therefore strongly recommend to switch to a secure-by-default configuration and notifying the users of risks attached to making this interface publicly available.
* the API interface is unencrypted
* the password is transmitted in cleartext
* the json2 interface is plaintext
* `--api-password` does **NOT** restrict a user from accessing the http/GET interface. this interface is essentially leaking lots of valuable information.
  * e.g. the miner version `Server: ethminer-0.18.0-alpha.3` in a perfectly parseable format for automated exploitation in case of other low level vulnerabilities (buffer out of bounds/thread race/use after free/...)
* no IP whitelisting (which would - when be enforced - probably already resolve some security concerns)
* exceptions and parsing errors are always transported to the client. this should generally be avoided unless someone is authed. (log locally, provide anonymous errors and errnumbers)
* api connections do not appear to time out. --> DoS (port exhaustion)


Given that the interface should never be public these points may appear invalid. However, learning from the past we've learned that very often the reality is different. Since ethminer takes an important role in the ethereum ecosystem (miner itself and all the copycats forking the miner) it should be worth to consider making it hard for users to mess up the security settings. It is nowadays often safe to say that if you provide an api, people will use it remotely.

## Testcases (fix applied)

#### readwrite - noauth
```
#server> /ethminer/ethminer --api-bind 127.0.0.1:3333 -P http://a:b@allalala.com:3333/fskdlksdlf/sdfsdf
#client> echo '{"id":0,"jsonrpc":"2.0","method":"miner_shuffle"}' | netcat localhost 3333
{"id":0,"jsonrpc":"2.0","result":true}
```

#### readonly - noauth
```
#server> ./ethminer/ethminer --api-bind 127.0.0.1:-3333 -P http://a:b@allalala.com:3333/fskdlksdlf/sdfsdf
#client> echo '{"id":0,"jsonrpc":"2.0","method":"miner_shuffle"}' | netcat localhost 3333
{"error":{"code":-32601,"message":"Method not available"},"id":0,"jsonrpc":"2.0"}
```
#### readonly - auth
```
#servre> ./ethminer/ethminer --api-bind 127.0.0.1:3333 -P http://a:b@allalala.com:3333/fskdlksdlf/sdfsdf --api-password="a"
#client> echo '{"id":0,"jsonrpc":"2.0","method":"miner_shuffle"}' | netcat localhost 3333
{"error":{"code":-403,"message":"Authorization needed"},"id":0,"jsonrpc":"2.0"}
```

cheers,
tin