### PR TITLE
fix lexical cast exeption on parse pool port

### DIFF
--- a/libpoolprotocols/PoolURI.cpp
+++ b/libpoolprotocols/PoolURI.cpp
@@ -270,7 +270,7 @@ URI::URI(std::string uri, bool _sim) : m_uri{std::move(uri)}
     if (std::regex_search(m_hostinfo, matches, host_pattern, std::regex_constants::match_default))
     {
         m_host = matches[1].str();
-        m_port = boost::lexical_cast<short>(matches[2].str());
+        m_port = boost::lexical_cast<unsigned short>(matches[2].str());
     }
     else
     {


### PR DESCRIPTION
I saw a small bug in the [issues](https://github.com/ethereum-mining/ethminer/issues/1906), here is a small fix for it 
#1906 