### PR TITLE
fix seg fault

### DIFF
--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -367,13 +367,9 @@ void EthStratumClient::workloop_timer_elapsed(const boost::system::error_code& e
     using namespace std::chrono;
 
     // On timer cancelled or nothing to check for then early exit
-    if (ec == boost::asio::error::operation_aborted)
+    if ((ec == boost::asio::error::operation_aborted) || !m_conn)
     {
         return;
-    }
-
-    if (!m_conn) {
-      return;
     }
 
     // No msg from client (EthereumStratum/2.0.0)

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -372,6 +372,10 @@ void EthStratumClient::workloop_timer_elapsed(const boost::system::error_code& e
         return;
     }
 
+    if (!m_conn) {
+      return;
+    }
+
     // No msg from client (EthereumStratum/2.0.0)
     if (m_conn->StratumMode() == 3 && m_session)
     {


### PR DESCRIPTION
This fixes a segfault that happens when the connection is nulled.  In this situation the time loop will fail when you access the connection.