### PR TITLE
Younghwan - Support Macbook Pro 2019

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -454,7 +454,7 @@ void CLMiner::enumDevices(std::map<string, DeviceDescriptor>& _DevicesCollection
     {
         std::string platformName = platforms.at(pIdx).getInfo<CL_PLATFORM_NAME>();
         ClPlatformTypeEnum platformType = ClPlatformTypeEnum::Unknown;
-        if (platformName == "AMD Accelerated Parallel Processing")
+        if (platformName == "AMD Accelerated Parallel Processing" || platformName == "Apple")
             platformType = ClPlatformTypeEnum::Amd;
         else if (platformName == "Clover" || platformName == "Intel Gen OCL Driver")
             platformType = ClPlatformTypeEnum::Clover;


### PR DESCRIPTION
I know you guys dropped the support of Macbook devices but would like to ask if you guys changed your decision or not.

I believe that the newly released Macbook Pro 2019 has the sufficient computing power to perform mining Ethereum.
I tried this change and it works fine for me. Still experience some unstable issues(very laggy, suddenly shutdown, or crashes screen that leads to restart the device) but would be good to have this option for Macbook users to try with their own risk.