### PR TITLE
Parse Nicehash extranonce after connecting to stratum

### DIFF
--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -876,22 +876,21 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
                                   "EthereumStratum/1.0.0");
                 if (_isSuccess)
                 {
-                  
-                    std::string enonce = jResult.get(Json::Value::ArrayIndex(1), "").asString();
-                    if (!enonce.empty()) processExtranonce(enonce);
-
                     // Selected flavour is confirmed
                     m_conn->SetStratumMode(2, true);
                     cnote << "Stratum mode : EthereumStratum/1.0.0 (NiceHash)";
                     startSession();
                     m_session->subscribed.store(true, memory_order_relaxed);
-
+                  
                     // Notify we're ready for extra nonce subscribtion on the fly
                     // reply to this message should not perform any logic
                     jReq["id"] = unsigned(2);
                     jReq["method"] = "mining.extranonce.subscribe";
                     jReq["params"] = Json::Value(Json::arrayValue);
                     send(jReq);
+                  
+                    std::string enonce = jResult.get(Json::Value::ArrayIndex(1), "").asString();
+                    if (!enonce.empty()) processExtranonce(enonce);
 
                     // Eventually request authorization
                     m_authpending.store(true, std::memory_order_relaxed);

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -876,6 +876,10 @@ void EthStratumClient::processResponse(Json::Value& responseObject)
                                   "EthereumStratum/1.0.0");
                 if (_isSuccess)
                 {
+                  
+                    std::string enonce = jResult.get(Json::Value::ArrayIndex(1), "").asString();
+                    if (!enonce.empty()) processExtranonce(enonce);
+
                     // Selected flavour is confirmed
                     m_conn->SetStratumMode(2, true);
                     cnote << "Stratum mode : EthereumStratum/1.0.0 (NiceHash)";


### PR DESCRIPTION
ethminer ignored the initial extranonce value and this caused incorrect shares until first extranonce update from pool.
fixes issues #1916 #1866 #1858