### PR TITLE
Support Intel GPUs

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -442,7 +442,7 @@ void CLMiner::kick_miner()
     m_new_work_signal.notify_one();
 }
 
-void CLMiner::enumDevices(std::map<string, DeviceDescriptor>& _DevicesCollection) 
+void CLMiner::enumDevices(std::map<string, DeviceDescriptor>& _DevicesCollection)
 {
     // Load available platforms
     vector<cl::Platform> platforms = getPlatforms();
@@ -460,7 +460,9 @@ void CLMiner::enumDevices(std::map<string, DeviceDescriptor>& _DevicesCollection
             platformType = ClPlatformTypeEnum::Clover;
         else if (platformName == "NVIDIA CUDA")
             platformType = ClPlatformTypeEnum::Nvidia;
-        else 
+        else if (platformName.find("Intel") != string::npos)
+            platformType = ClPlatformTypeEnum::Intel;
+        else
         {
             std::cerr << "Unrecognized platform " << platformName << std::endl;
             continue;
@@ -513,6 +515,13 @@ void CLMiner::enumDevices(std::map<string, DeviceDescriptor>& _DevicesCollection
                       << (unsigned int)(t[22]) << "." << (unsigned int)(t[23]);
                     uniqueId = s.str();
                 }
+            }
+            else if (clDeviceType == DeviceTypeEnum::Gpu && platformType == ClPlatformTypeEnum::Intel)
+            {
+                std::ostringstream s;
+                s << "Intel GPU " << pIdx << "." << dIdx;
+                uniqueId = s.str();
+
             }
             else if (clDeviceType == DeviceTypeEnum::Cpu)
             {
@@ -619,6 +628,14 @@ bool CLMiner::initDevice()
         m_hwmoninfo.deviceIndex = -1;  // Will be later on mapped by nvml (see Farm() constructor)
         m_settings.noBinary = true;
     }
+    else if (m_deviceDescriptor.clPlatformType == ClPlatformTypeEnum::Intel)
+    {
+        m_hwmoninfo.deviceType = HwMonitorInfoType::UNKNOWN;
+        m_hwmoninfo.devicePciId = m_deviceDescriptor.uniqueId;
+        m_hwmoninfo.deviceIndex = -1;  // Will be later on mapped by nvml (see Farm() constructor)
+        m_settings.noBinary = true;
+        m_settings.noExit = true;
+    }
     else
     {
         // Don't know what to do with this
@@ -650,7 +667,7 @@ bool CLMiner::initDevice()
     }
 
     ostringstream s;
-    s << "Using PciId : " << m_deviceDescriptor.uniqueId << " " << m_deviceDescriptor.clName;
+    s << "Using Device : " << m_deviceDescriptor.uniqueId << " " << m_deviceDescriptor.clName;
 
     if (!m_deviceDescriptor.clNvCompute.empty())
         s << " (Compute " + m_deviceDescriptor.clNvCompute + ")";

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -77,7 +77,8 @@ enum class ClPlatformTypeEnum
     Unknown,
     Amd,
     Clover,
-    Nvidia
+    Nvidia,
+    Intel
 };
 
 enum class SolutionAccountingEnum


### PR DESCRIPTION
Intel's GPUs have historically been low power devices unsuitable for cyptomining, but upcoming Xe products (Artic Sound, Ponte Vecchio) look very applicable. One could also torture-test a NUC, maybe; I won't judge.

See also: https://www.anandtech.com/show/15188/analyzing-intels-discrete-xe-hpc-graphics-disclosure-ponte-vecchio/

Sample run on a Skull Canyon NUC with an Iris Pro Graphics 580 iGPU and the latest [NEO compute runtime](https://github.com/intel/compute-runtime):
```
$ ethminer/ethminer -G -P stratum1+ssl://<address.worker>@us1.ethermine.org:5555

ethminer 0.19.0-alpha.0-9+commit.a1256213
Build: linux/release/gnu

 i 12:58:54 ethminer Configured pool us1.ethermine.org:5555
 i 12:58:54 ethminer Selected pool us1.ethermine.org:5555
 i 12:58:55 ethminer Stratum mode : Eth-Proxy compatible
 i 12:58:55 ethminer Established connection to us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 12:58:55 ethminer Spinning up miners...
cl 12:58:55 cl-0     no exit option enabled for non AMD opencl device
cl 12:58:55 cl-0     Using Device : Intel GPU 0.0 Intel(R) Gen9 HD Graphics NEO OpenCL 2.1 NEO  Memory : 12.44 GB
 i 12:58:55 ethminer Epoch : 331 Difficulty : 4.00 Gh
 i 12:58:55 ethminer Job: 8199276b… block 9943659 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
cl 12:58:57 cl-0     Generating split DAG + Light (total): 3.64 GB
cl 12:58:57 cl-0     OpenCL kernel
 i 12:58:58 ethminer Job: d697a35c… block 9943659 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
cl 12:58:58 cl-0     Creating light cache buffer, size: 57.37 MB
cl 12:58:58 cl-0     Creating DAG buffer, size: 3.59 GB, free: 8.80 GB
cl 12:58:59 cl-0     Loading kernels
cl 12:58:59 cl-0     Creating buffer for header.
cl 12:58:59 cl-0     Creating mining buffer
 m 12:58:59 ethminer 0:00 A0 0.00 h - cl0 0.00
 i 12:59:02 ethminer Job: 0e9f6604… block 9943659 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 12:59:04 ethminer 0:00 A0 0.00 h - cl0 0.00
 i 12:59:06 ethminer Job: 3697c167… block 9943659 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 12:59:09 ethminer 0:00 A0 0.00 h - cl0 0.00
 i 12:59:10 ethminer Job: 2f42103a… block 9943659 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 12:59:14 ethminer Job: 4bafb66e… block 9943659 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 12:59:14 ethminer Job: 11e40d08… block 9943660 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 12:59:14 ethminer Job: 01eec032… block 9943660 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 12:59:14 ethminer 0:00 A0 0.00 h - cl0 0.00
 i 12:59:18 ethminer Job: c852617d… block 9943660 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 12:59:19 ethminer 0:00 A0 0.00 h - cl0 0.00
 i 12:59:20 ethminer Job: f44fc90c… block 9943661 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 12:59:20 ethminer Job: ac958467… block 9943661 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 12:59:22 ethminer Job: 52d5f468… block 9943662 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 12:59:22 ethminer Job: ee56f881… block 9943662 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 12:59:24 ethminer 0:00 A0 0.00 h - cl0 0.00
 i 12:59:26 ethminer Job: 618047a0… block 9943662 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 12:59:29 ethminer Job: c6cd5b98… block 9943663 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 12:59:29 ethminer Job: 76ea62b3… block 9943663 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 12:59:29 ethminer 0:00 A0 0.00 h - cl0 0.00
 i 12:59:33 ethminer Job: f14cc34e… block 9943663 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 12:59:34 ethminer 0:00 A0 0.00 h - cl0 0.00
 i 12:59:37 ethminer Job: bacd00e9… block 9943663 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 12:59:38 ethminer Job: a9276629… block 9943664 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 12:59:39 ethminer Job: 0824bb19… block 9943664 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 12:59:39 ethminer 0:00 A0 0.00 h - cl0 0.00
 i 12:59:42 ethminer Job: c7fa5e0f… block 9943664 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 12:59:44 ethminer 0:00 A0 0.00 h - cl0 0.00
 i 12:59:46 ethminer Job: ef461e10… block 9943664 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 12:59:49 ethminer 0:00 A0 0.00 h - cl0 0.00
 i 12:59:50 ethminer Job: 8175581d… block 9943664 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 12:59:54 ethminer Job: 06088136… block 9943664 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 12:59:54 ethminer 0:01 A0 0.00 h - cl0 0.00
 i 12:59:55 ethminer Job: 8d3464d3… block 9943665 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 12:59:55 ethminer Job: 35880abf… block 9943665 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 12:59:59 ethminer Job: 3b4aec7c… block 9943665 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 12:59:59 ethminer 0:01 A0 0.00 h - cl0 0.00
cl 13:00:00 cl-0     3.59 GB of DAG data generated in 63,243 ms.
 i 13:00:03 ethminer Job: c7223ded… block 9943665 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 13:00:04 ethminer Job: e47f0350… block 9943666 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 13:00:04 ethminer Job: 46afe057… block 9943666 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 13:00:04 ethminer 0:01 A0 128.01 Kh - cl0 128.01
 i 13:00:09 ethminer Job: 95cd62b9… block 9943666 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 13:00:09 ethminer 0:01 A0 1.81 Mh - cl0 1.81
 i 13:00:12 ethminer Job: c7984593… block 9943666 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 13:00:14 ethminer 0:01 A0 1.80 Mh - cl0 1.80
 i 13:00:16 ethminer Job: a98d0071… block 9943666 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 13:00:20 ethminer 0:01 A0 1.79 Mh - cl0 1.79
 i 13:00:20 ethminer Job: dfc58d01… block 9943666 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 13:00:21 ethminer Job: 62add2d0… block 9943667 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 13:00:21 ethminer Job: b23ab1a2… block 9943667 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 13:00:25 ethminer 0:01 A0 1.78 Mh - cl0 1.78
 i 13:00:25 ethminer Job: 48f5fbe3… block 9943667 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 13:00:30 ethminer 0:01 A0 1.77 Mh - cl0 1.77
 i 13:00:30 ethminer Job: b87df00f… block 9943667 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 13:00:33 ethminer Job: c9f07bdf… block 9943668 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 13:00:35 ethminer 0:01 A0 1.77 Mh - cl0 1.77
 i 13:00:35 ethminer Job: a2f87cfd… block 9943668 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 13:00:38 ethminer Job: 783e6b2e… block 9943668 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 13:00:40 ethminer 0:01 A0 1.67 Mh - cl0 1.67
 i 13:00:41 ethminer Job: 5790e301… block 9943668 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 13:00:45 ethminer 0:01 A0 1.59 Mh - cl0 1.59
 i 13:00:45 ethminer Job: 6d77c42b… block 9943668 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 13:00:49 ethminer Job: 9669aac7… block 9943668 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 13:00:50 ethminer 0:01 A0 1.47 Mh - cl0 1.47
 i 13:00:53 ethminer Job: 7e9cab98… block 9943668 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 13:00:55 ethminer 0:02 A0 1.47 Mh - cl0 1.47
 i 13:00:57 ethminer Job: db0e04ac… block 9943668 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 13:00:58 ethminer Job: f2585433… block 9943669 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 13:00:58 ethminer Job: 1a12f6a2… block 9943669 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 13:00:59 ethminer Job: a77e116b… block 9943669 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 13:00:59 ethminer Job: 729e9a54… block 9943670 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 13:01:00 ethminer 0:02 A0 1.36 Mh - cl0 1.36
 i 13:01:00 ethminer Job: 33bdc6f2… block 9943670 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 13:01:04 ethminer Job: d00cb5bf… block 9943670 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 13:01:04 ethminer Job: 1e8ff1e4… block 9943671 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 13:01:04 ethminer Job: ca8b0e85… block 9943671 us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 m 13:01:05 ethminer 0:02 A0 1.33 Mh - cl0 1.33
^C i 13:01:06 main     Got interrupt ...
 i 13:01:06 ethminer Disconnected from us1.ethermine.org [[2606:4700:90:0:b886:9f1:5c3e:5711]:5555]
 i 13:01:06 ethminer Shutting down miners...
 i 13:01:16 main     Terminated!

$
```

I didn't wait for an accepted hash in this run; the log file would have been huge. I can confirm that I got at least one accepted solution in a separate run.