### PR TITLE
Extend the life of 4GB cards

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -875,8 +875,11 @@ bool CLMiner::initEpoch_internal()
                     throw;
             }
             if (light_on_host)
+            {
                 m_light.emplace_back(m_context[0], CL_MEM_READ_ONLY | CL_MEM_ALLOC_HOST_PTR,
                     m_epochContext.lightSize);
+                cllog << "WARNING: Generating DAG will take minutes, not seconds";
+            }
             cllog << "Loading kernels";
 
             // If we have a binary kernel to use, let's try it

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -161,9 +161,6 @@ bool CUDAMiner::initEpoch_internal()
         ethash_generate_dag(
             m_epochContext.dagSize, m_settings.gridSize, m_settings.blockSize, m_streams[0]);
 
-        if (lightOnHost)
-            CUDA_SAFE_CALL(cudaFreeHost(reinterpret_cast<void*>(light)));
-
         cudalog << "Generated DAG + Light in "
                 << std::chrono::duration_cast<std::chrono::milliseconds>(
                        std::chrono::steady_clock::now() - startInit)

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -126,8 +126,11 @@ bool CUDAMiner::initEpoch_internal()
 
             // create buffer for cache
             if (lightOnHost)
+            {
                 CUDA_SAFE_CALL(cudaHostAlloc(reinterpret_cast<void**>(&light),
                     m_epochContext.lightSize, cudaHostAllocDefault));
+                cudalog << "WARNING: Generating DAG will take minutes, not seconds";
+            }
             else
                 CUDA_SAFE_CALL(
                     cudaMalloc(reinterpret_cast<void**>(&light), m_epochContext.lightSize));
@@ -157,6 +160,9 @@ bool CUDAMiner::initEpoch_internal()
 
         ethash_generate_dag(
             m_epochContext.dagSize, m_settings.gridSize, m_settings.blockSize, m_streams[0]);
+
+        if (lightOnHost)
+            CUDA_SAFE_CALL(cudaFreeHost(reinterpret_cast<void*>(light)));
 
         cudalog << "Generated DAG + Light in "
                 << std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -81,12 +81,14 @@ bool CUDAMiner::initEpoch_internal()
     bool retVar = false;
     m_current_target = 0;
     auto startInit = std::chrono::steady_clock::now();
-    size_t RequiredMemory = (m_epochContext.dagSize + m_epochContext.lightSize);
+    size_t RequiredTotalMemory = (m_epochContext.dagSize + m_epochContext.lightSize);
+    size_t RequiredDagMemory = m_epochContext.dagSize;
 
     // Release the pause flag if any
     resume(MinerPauseEnum::PauseDueToInsufficientMemory);
     resume(MinerPauseEnum::PauseDueToInitEpochError);
 
+    bool lightOnHost = false;
     try
     {
         hash128_t* dag;
@@ -104,21 +106,31 @@ bool CUDAMiner::initEpoch_internal()
             CUDA_SAFE_CALL(cudaDeviceSetCacheConfig(cudaFuncCachePreferL1));
 
             // Check whether the current device has sufficient memory every time we recreate the dag
-            if (m_deviceDescriptor.totalMemory < RequiredMemory)
+            if (m_deviceDescriptor.totalMemory < RequiredTotalMemory)
             {
-                cudalog << "Epoch " << m_epochContext.epochNumber << " requires "
-                        << dev::getFormattedMemory((double)RequiredMemory) << " memory.";
-                cudalog << "This device hasn't available. Mining suspended ...";
-                pause(MinerPauseEnum::PauseDueToInsufficientMemory);
-                return true;  // This will prevent to exit the thread and
-                              // Eventually resume mining when changing coin or epoch (NiceHash)
+                if (m_deviceDescriptor.totalMemory < RequiredDagMemory)
+                {
+                    cudalog << "Epoch " << m_epochContext.epochNumber << " requires "
+                            << dev::getFormattedMemory((double)RequiredDagMemory) << " memory.";
+                    cudalog << "This device hasn't enough memory available. Mining suspended ...";
+                    pause(MinerPauseEnum::PauseDueToInsufficientMemory);
+                    return true;  // This will prevent to exit the thread and
+                                  // Eventually resume mining when changing coin or epoch (NiceHash)
+                }
+                else
+                    lightOnHost = true;
             }
 
-            cudalog << "Generating DAG + Light : "
-                    << dev::getFormattedMemory((double)RequiredMemory);
+            cudalog << "Generating DAG + Light(on " << (lightOnHost ? "host" : "GPU")
+                    << ") : " << dev::getFormattedMemory((double)RequiredTotalMemory);
 
             // create buffer for cache
-            CUDA_SAFE_CALL(cudaMalloc(reinterpret_cast<void**>(&light), m_epochContext.lightSize));
+            if (lightOnHost)
+                CUDA_SAFE_CALL(cudaHostAlloc(reinterpret_cast<void**>(&light),
+                    m_epochContext.lightSize, cudaHostAllocDefault));
+            else
+                CUDA_SAFE_CALL(
+                    cudaMalloc(reinterpret_cast<void**>(&light), m_epochContext.lightSize));
             m_allocated_memory_light_cache = m_epochContext.lightSize;
             CUDA_SAFE_CALL(cudaMalloc(reinterpret_cast<void**>(&dag), m_epochContext.dagSize));
             m_allocated_memory_dag = m_epochContext.dagSize;
@@ -133,7 +145,7 @@ bool CUDAMiner::initEpoch_internal()
         else
         {
             cudalog << "Generating DAG + Light (reusing buffers): "
-                    << dev::getFormattedMemory((double)RequiredMemory);
+                    << dev::getFormattedMemory((double)RequiredTotalMemory);
             get_constants(&dag, NULL, &light, NULL);
         }
 
@@ -151,7 +163,9 @@ bool CUDAMiner::initEpoch_internal()
                        std::chrono::steady_clock::now() - startInit)
                        .count()
                 << " ms. "
-                << dev::getFormattedMemory((double)(m_deviceDescriptor.totalMemory - RequiredMemory))
+                << dev::getFormattedMemory(
+                       lightOnHost ? (double)(m_deviceDescriptor.totalMemory - RequiredDagMemory) :
+                                     (double)(m_deviceDescriptor.totalMemory - RequiredTotalMemory))
                 << " left.";
 
         retVar = true;
@@ -271,7 +285,9 @@ void CUDAMiner::enumDevices(std::map<string, DeviceDescriptor>& _DevicesCollecti
 
         try
         {
+            size_t freeMem, totalMem;
             CUDA_SAFE_CALL(cudaGetDeviceProperties(&props, i));
+            CUDA_SAFE_CALL(cudaMemGetInfo(&freeMem, &totalMem));
             s << setw(2) << setfill('0') << hex << props.pciBusID << ":" << setw(2)
               << props.pciDeviceID << ".0";
             uniqueId = s.str();
@@ -288,7 +304,7 @@ void CUDAMiner::enumDevices(std::map<string, DeviceDescriptor>& _DevicesCollecti
             deviceDescriptor.cuDeviceIndex = i;
             deviceDescriptor.cuDeviceOrdinal = i;
             deviceDescriptor.cuName = string(props.name);
-            deviceDescriptor.totalMemory = props.totalGlobalMem;
+            deviceDescriptor.totalMemory = freeMem;
             deviceDescriptor.cuCompute =
                 (to_string(props.major) + "." + to_string(props.minor));
             deviceDescriptor.cuComputeMajor = props.major;


### PR DESCRIPTION
- Reverse order of light cache and DAG allocation. DAG allocated first.
- Attempt to allocate ~80MB light cache buffer on GPU. If not enough
  memory then allocate it on host.
- DAG generation will be much slower but we regain a little more space
  for the DAG, which must reside on GPU.