### PR TITLE
CUDA: cleanup ethash_calculate_dag_item()

### DIFF
--- a/libethash-cuda/ethash_cuda_miner_kernel.cu
+++ b/libethash-cuda/ethash_cuda_miner_kernel.cu
@@ -53,7 +53,7 @@ __global__ void ethash_calculate_dag_item(uint32_t start)
     if (((node_index >> 1) & (~1)) >= d_dag_size)
         return;
 
-    hash200_t dag_node;
+    hash128_t dag_node;
     copy(dag_node.uint4s, d_light[node_index % d_light_size].uint4s, 4);
     dag_node.words[0] ^= node_index;
     SHA3_512(dag_node.uint2s);
@@ -80,21 +80,7 @@ __global__ void ethash_calculate_dag_item(uint32_t start)
     }
     SHA3_512(dag_node.uint2s);
     hash64_t* dag_nodes = (hash64_t*)d_dag;
-
-    for (uint32_t t = 0; t < 4; t++)
-    {
-        uint32_t shuffle_index = SHFL(node_index, t, 4);
-        uint4 s[4];
-        for (uint32_t w = 0; w < 4; w++)
-        {
-            s[w] = make_uint4(SHFL(dag_node.uint4s[w].x, t, 4), SHFL(dag_node.uint4s[w].y, t, 4),
-                              SHFL(dag_node.uint4s[w].z, t, 4), SHFL(dag_node.uint4s[w].w, t, 4));
-        }
-        if (shuffle_index < d_dag_size * 2)
-        {
-            dag_nodes[shuffle_index].uint4s[thread_id] = s[thread_id];
-        }
-    }
+    copy(dag_nodes[node_index].uint4s, dag_node.uint4s, 4);
 }
 
 void ethash_generate_dag(

--- a/libethash-cuda/ethash_cuda_miner_kernel.h
+++ b/libethash-cuda/ethash_cuda_miner_kernel.h
@@ -35,8 +35,10 @@ typedef struct
     uint4 uint4s[32 / sizeof(uint4)];
 } hash32_t;
 
-typedef struct
+typedef union
 {
+    uint32_t words[128 / sizeof(uint32_t)];
+    uint2 uint2s[128 / sizeof(uint2)];
     uint4 uint4s[128 / sizeof(uint4)];
 } hash128_t;
 
@@ -46,13 +48,6 @@ typedef union
     uint2 uint2s[64 / sizeof(uint2)];
     uint4 uint4s[64 / sizeof(uint4)];
 } hash64_t;
-
-typedef union
-{
-    uint32_t words[200 / sizeof(uint32_t)];
-    uint2 uint2s[200 / sizeof(uint2)];
-    uint4 uint4s[200 / sizeof(uint4)];
-} hash200_t;
 
 void set_constants(hash128_t* _dag, uint32_t _dag_size, hash64_t* _light, uint32_t _light_size);
 void get_constants(hash128_t** _dag, uint32_t* _dag_size, hash64_t** _light, uint32_t* _light_size);


### PR DESCRIPTION
cleanup `ethash_calculate_dag_item()` 
 * use `hash128_t`, remove `hash200_t`
 * remove needless `shuffle(node_index)` loop
