### PR TITLE
Fix to DBusInt::send() error.

### DIFF
--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -112,7 +112,7 @@ public:
             minelog << logLine;
 
 #if ETH_DBUS
-            dbusint.send(Farm::f().Telemetry().str());
+            dbusint.send(Farm::f().Telemetry().str().c_str());
 #endif
             // Resubmit timer
             m_cliDisplayTimer.expires_from_now(boost::posix_time::seconds(m_cliDisplayInterval));


### PR DESCRIPTION
This fixes #1923 The error arose from using a C++11 str in place of a C string.