### PR TITLE
fix epoch zero bug

### DIFF
--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -182,7 +182,7 @@ void PoolManager::setClientHandlers()
             // If epoch is valued in workpackage take it
             if (wp.epoch == -1)
             {
-                if (m_currentWp.block > 0)
+                if (m_currentWp.block >= 0)
                     m_currentWp.epoch = m_currentWp.block / 30000;
                 else
                     m_currentWp.epoch = ethash::find_epoch_number(


### PR DESCRIPTION
fix epoch zero bug. (activated by `-M 0` or `-Z 0` options)

https://github.com/ethereum-mining/ethminer/issues/2003#issuecomment-690655783
~~~
$ ethminer -U -M 0
**ethminer 0.19.0-3
Build: linux/release/gnu

 i 21:23:40 ethminer Selected pool localhost:0
 i 21:23:40 ethminer Established connection to localhost:0
 i 21:23:40 ethminer Spinning up miners...
cu 21:23:40 cuda-0   Using Pci Id : 03:00.0 P106-100 (Compute 6.1) Memory : 5.85 GB
 i 21:23:40 sim      Epoch : -1 Difficulty : 4.29 Gh
 i 21:23:40 sim      Job: 2072b99c… block 0 localhost:0
SIGSEGV encountered ...
stack trace:
backtrace() returned 8 addresses
ethminer/ethminer() [0x423d69]
/lib/x86_64-linux-gnu/libc.so.6(+0x354b0) [0x7f5aaf3614b0]
ethminer/ethminer() [0x6fbd76]
ethminer/ethminer() [0x6fe774]
ethminer/ethminer() [0x4bbbab]
ethminer/ethminer() [0x7dd800]**
~~~