### PR TITLE
fix a bug in detecting CPU devices for OpenCL

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -236,7 +236,7 @@ std::vector<cl::Device> getDevices(
     try
     {
         _platforms[platform_num].getDevices(
-            CL_DEVICE_TYPE_GPU | CL_DEVICE_TYPE_ACCELERATOR, &devices);
+            CL_DEVICE_TYPE_GPU | CL_DEVICE_TYPE_CPU | CL_DEVICE_TYPE_ACCELERATOR, &devices);
     }
     catch (cl::Error const& err)
     {


### PR DESCRIPTION
Ethminer cannot find the installed CPU runtimes for OpenCL, for example, [the Intel Processor OpenCL Runtimes](https://software.intel.com/content/www/us/en/develop/articles/opencl-drivers.html#cpu-section).

The reason is that, in the function `getDevices()` in the file `libethash-cl/CLMiner.cpp` (line 231), when it calls the `getDevices()` member function (line 239), in the first argument, the mask for CPU devices `CL_DEVICE_TYPE_CPU` is missing.

The correctness of this patch has been tested on the OpenCL runtime for Intel Xeon Processor.