### PR TITLE
Add rejected & failed share counts to HTTP API, clean up power reports

### DIFF
--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -1176,7 +1176,10 @@ std::string ApiConnection::getHttpMinerStatDetail()
         _ret << "<td class=right>" << solString << "</td>";
         _ret << "<td class=right>" << device["hardware"]["sensors"][0].asString() << "</td>";
         _ret << "<td class=right>" << device["hardware"]["sensors"][1].asString() << "</td>";
-        _ret << "<td class=right>" << device["hardware"]["sensors"][2].asString() << "</td>";
+
+        stringstream powerStream; // Round the power to 2 decimal places to remove floating point garbage
+        powerStream << fixed << setprecision(2) << device["hardware"]["sensors"][2].asString();
+        _ret << "<td class=right>" << powerStream.str() << "</td>";
 
         _ret << "</tr>";  // Close row
     }

--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -1169,7 +1169,11 @@ std::string ApiConnection::getHttpMinerStatDetail()
 
         _ret << "<td class=right>" << dev::getFormattedHashes(hashrate) << "</td>";
 
-        _ret << "<td class=right>" << device["mining"]["shares"][0].asString() << "</td>";
+        
+        string solString = "A" + device["mining"]["shares"][0].asString() + 
+                           ":R" + device["mining"]["shares"][1].asString() +
+                           ":F" + device["mining"]["shares"][2].asString();
+        _ret << "<td class=right>" << solString << "</td>";
         _ret << "<td class=right>" << device["hardware"]["sensors"][0].asString() << "</td>";
         _ret << "<td class=right>" << device["hardware"]["sensors"][1].asString() << "</td>";
         _ret << "<td class=right>" << device["hardware"]["sensors"][2].asString() << "</td>";

--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -1178,7 +1178,7 @@ std::string ApiConnection::getHttpMinerStatDetail()
         _ret << "<td class=right>" << device["hardware"]["sensors"][1].asString() << "</td>";
 
         stringstream powerStream; // Round the power to 2 decimal places to remove floating point garbage
-        powerStream << fixed << setprecision(2) << device["hardware"]["sensors"][2].asString();
+        powerStream << fixed << setprecision(2) << device["hardware"]["sensors"][2].asDouble();
         _ret << "<td class=right>" << powerStream.str() << "</td>";
 
         _ret << "</tr>";  // Close row

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -147,7 +147,7 @@ struct HwSensorsType
     {
         string _ret = to_string(tempC) + "C " + to_string(fanP) + "%";
         if (powerW)
-            _ret.append(boost::str(boost::format("%f") % powerW));
+            _ret.append(" " + boost::str(boost::format("%0.2f") % powerW) + "W");
         return _ret;
     };
 };


### PR DESCRIPTION
This PR just adds a few cosmetic tweaks. It changes the API's HTTP site slightly so the reported solutions are now in 
"Axxx:Rxxx:Fxxx" format, and rounds the power reports per card to 2 decimal places. It also adds that same rounding to the CLI status report line.

I wanted the former to help me follow long-term overclock stability when I can't easily scroll through the CLI output and check which card caused a rejected / failed share. The latter is just to reduce screen clutter that happens sometimes with floating point imprecision (cards would report 72.99999999999 watts, for example).