### PR TITLE
Support Ampere graphic cards using Cuda 11.0/11.1

### DIFF
--- a/libethash-cuda/CMakeLists.txt
+++ b/libethash-cuda/CMakeLists.txt
@@ -28,6 +28,14 @@ else()
 	if(NOT CUDA_VERSION VERSION_LESS 10.0)
 		list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_75,code=sm_75")
 	endif()
+	if(NOT CUDA_VERSION VERSION_LESS 11.0)
+		# NVIDIA A100 and NVIDIA DGX-A100
+		list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_80,code=sm_80")
+	endif()
+	if(NOT CUDA_VERSION VERSION_LESS 11.1)
+		# Tesla GA10x cards, RTX Ampere – RTX 3080/3090, RTX A6000, RTX A40
+		list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_86,code=sm_86")
+	endif()
 endif()
 
 file(GLOB sources "*.cpp" "*.cu")


### PR DESCRIPTION
Ampere graphic cards require compute capability 8.0 and 8.6.
Without this, trying to run this on my RTX 3090 fails.

Closes #2059, closes #2058

Should also close #2062 and close #2055 but I don't have an A100 to confirm unfortunately.

Thanks to @gorghino in his comment here: https://github.com/ethereum-mining/ethminer/issues/2059#issuecomment-711432189 Let me know if you want me add you as a [co-author on the commit](https://docs.github.com/en/free-pro-team@latest/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors)

See https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/ for the list of gencodes and archs.