### PR TITLE
improve CUDA device uniqueID by adding pciDomainID as prefix. 

### DIFF
--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -291,8 +291,9 @@ void CUDAMiner::enumDevices(std::map<string, DeviceDescriptor>& _DevicesCollecti
             size_t freeMem, totalMem;
             CUDA_SAFE_CALL(cudaGetDeviceProperties(&props, i));
             CUDA_SAFE_CALL(cudaMemGetInfo(&freeMem, &totalMem));
-            s << setw(2) << setfill('0') << hex << props.pciBusID << ":" << setw(2)
-              << props.pciDeviceID << ".0";
+            s << setw(8) << setfill('0') << hex << props.pciDomainID << ":" 
+              << setw(2) << setfill('0') << hex << props.pciBusID << ":" 
+              << setw(2) << props.pciDeviceID << ".0";
             uniqueId = s.str();
 
             if (_DevicesCollection.find(uniqueId) != _DevicesCollection.end())


### PR DESCRIPTION
This is needed for multi-socket system where pciBusID and pciDeviceID can be the same on two different pci domains.
Now, the uniqueID will be the same as what nvidia-smi gives on Bus-Id

An example is below: GPU0 and GPU4 have the same pciDeviceID and pciBusID. They are connected to a different sockets, and thus they are different in pciDomainID.

```
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 440.33.01    Driver Version: 440.33.01    CUDA Version: 10.2     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|===============================+======================+======================|
|   0  XXXXXXXXX  On   | 00000004:04:00.0 Off |                    0 |
| N/A   25C    P0    34W / xxxW |      0MiB / 16160MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
|   1  XXXXXXXXX   On   | 00000004:05:00.0 Off |                    0 |
| N/A   27C    P0    35W / xxxW |      0MiB / 16160MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
|   2  XXXXXXXXX   On   | 00000035:03:00.0 Off |                    0 |
| N/A   23C    P0    34W / xxxW |      0MiB / 16160MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
|   3  XXXXXXXXX   On   | 00000035:04:00.0 Off |                    0 |
| N/A   28C    P0    36W / xxxW |      0MiB / 16160MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
                                                                               
+-----------------------------------------------------------------------------+
| Processes:                                                       GPU Memory |
|  GPU       PID   Type   Process name                             Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+
```

Thanks!