### PR TITLE
Update BUILD.md

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -27,7 +27,7 @@ This project uses [CMake] and [Hunter] package manager.
 
 ### Linux
 
-1. GCC version >= 4.8
+1. 8 >= GCC version >= 4.8
 2. DBUS development libs if building with `-DETHDBUS`. E.g. on Ubuntu run:
 
 ```shell


### PR DESCRIPTION
```
$ cmake --build .
Scanning dependencies of target ethminer-buildinfo-git
[  0%] Built target ethminer-buildinfo-git
[  3%] Updating ethminer-buildinfo:
       Project Version:  0.19.0-14+commit.3a81f1d4 (prerelease)
       System Name:      linux
       System Processor: x86_64
       Compiler ID:      gnu
       Compiler Version: 9.3.0
       Build Type:       release
       Git Info:         0.19.0 14 3a81f1d4e68b0d3dc168a5efade699ed49a9913d
       Timestamp:        2021-01-08T16:16:20
Scanning dependencies of target ethminer-buildinfo
[  6%] Building C object CMakeFiles/ethminer-buildinfo.dir/ethminer/buildinfo.c.o
[  9%] Linking C static library ethminer/libethminer-buildinfo.a
[  9%] Built target ethminer-buildinfo
Scanning dependencies of target devcore
[ 12%] Building CXX object libdevcore/CMakeFiles/devcore.dir/CommonData.cpp.o
[ 15%] Building CXX object libdevcore/CMakeFiles/devcore.dir/FixedHash.cpp.o
[ 18%] Building CXX object libdevcore/CMakeFiles/devcore.dir/Log.cpp.o
[ 21%] Building CXX object libdevcore/CMakeFiles/devcore.dir/Worker.cpp.o
[ 24%] Linking CXX static library libdevcore.a
[ 24%] Built target devcore
Scanning dependencies of target hwmon
[ 27%] Building CXX object libhwmon/CMakeFiles/hwmon.dir/wraphelper.cpp.o
[ 30%] Building CXX object libhwmon/CMakeFiles/hwmon.dir/wrapnvml.cpp.o
[ 33%] Building CXX object libhwmon/CMakeFiles/hwmon.dir/wrapadl.cpp.o
[ 36%] Building CXX object libhwmon/CMakeFiles/hwmon.dir/wrapamdsysfs.cpp.o
[ 39%] Linking CXX static library libhwmon.a
[ 39%] Built target hwmon
[ 42%] Building NVCC (Device) object libethash-cuda/CMakeFiles/ethash-cuda.dir/ethash-cuda_generated_ethash_cuda_miner_kernel.cu.o
In file included from /usr/include/cuda_runtime.h:83,
                 from <command-line>:
/usr/include/crt/host_config.h:138:2: error: #error -- unsupported GNU version! gcc versions later than 8 are not supported!
  138 | #error -- unsupported GNU version! gcc versions later than 8 are not supported!
      |  ^~~~~
CMake Error at ethash-cuda_generated_ethash_cuda_miner_kernel.cu.o.Release.cmake:220 (message):
  Error generating
  /home/joshua/git/ethminer/build/libethash-cuda/CMakeFiles/ethash-cuda.dir//./ethash-cuda_generated_ethash_cuda_miner_kernel.cu.o


make[2]: *** [libethash-cuda/CMakeFiles/ethash-cuda.dir/build.make:65: libethash-cuda/CMakeFiles/ethash-cuda.dir/ethash-cuda_generated_ethash_cuda_miner_kernel.cu.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:483: libethash-cuda/CMakeFiles/ethash-cuda.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
```