### PR TITLE
cuda11 build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,10 +59,12 @@ before_install:
       sudo apt-get -qy install g++-6
       scripts/install_cmake.sh
       if [ "$TRAVIS_DIST" = xenial ]; then
+        sudo apt-get -qy install mesa-common-dev
         . scripts/install-cuda-ubuntu1604.sh $CUDA_VERSION
         pyenv install 3.6.3
         pyenv global 3.6.3
       elif [ "$TRAVIS_DIST" = bionic ]; then
+        sudo apt-get -qy install libglu1-mesa-dev
         . scripts/install-cuda-ubuntu1804.sh $CUDA_VERSION
         pyenv global 3.6
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,29 @@ branches:
 matrix:
     include:
         - os: linux
-          dist: trusty
+          dist: xenial
           sudo: required
           env:
               - CUDA=ON
               - CUDA_VERSION=9
         - os: linux
-          dist: trusty
+          dist: xenial
           sudo: required
           env:
               - CUDA=ON
               - CUDA_VERSION=8
+        - os: linux
+          dist: bionic
+          sudo: required
+          env:
+              - CUDA=ON
+              - CUDA_VERSION=10.2
+        - os: linux
+          dist: bionic
+          sudo: required
+          env:
+              - CUDA=ON
+              - CUDA_VERSION=11.2
         - os: osx
           osx_image: xcode9.2
           env:
@@ -46,7 +58,11 @@ before_install:
       sudo apt-get -q update
       sudo apt-get -qy install g++-6
       scripts/install_cmake.sh
-      . scripts/install-cuda-ubuntu1604.sh $CUDA_VERSION
+      if [ "$TRAVIS_DIST" = xenial ]; then
+        . scripts/install-cuda-ubuntu1604.sh $CUDA_VERSION
+      elif [ "$TRAVIS_DIST" = bionic ]; then
+        . scripts/install-cuda-ubuntu1804.sh $CUDA_VERSION
+      fi
       pyenv global 3.6
       pip install --user requests gitpython
       if [ "$CUDA_VERSION" = "8" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,10 +60,12 @@ before_install:
       scripts/install_cmake.sh
       if [ "$TRAVIS_DIST" = xenial ]; then
         . scripts/install-cuda-ubuntu1604.sh $CUDA_VERSION
+        pyenv install 3.6.3
+        pyenv global 3.6.3
       elif [ "$TRAVIS_DIST" = bionic ]; then
         . scripts/install-cuda-ubuntu1804.sh $CUDA_VERSION
+        pyenv global 3.6
       fi
-      pyenv global 3.6
       pip install --user requests gitpython
       if [ "$CUDA_VERSION" = "8" ]; then
         sudo apt-get -qy install g++-5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,13 @@ os: "Visual Studio 2017"
 environment:
   matrix:
     - CUDA_VER: "8.0"
+      CUVER: 8
     - CUDA_VER: "9.1"
+      CUVER: 9
     - CUDA_VER: "10.0"
+      CUVER: 10
+    - CUDA_VER: "11.1.0"
+      CUVER: 11
   HUNTER_CACHE_TOKEN:
     secure: VnpF1MH5MEFvUI5MiMMMFlmbDdst+bfom5ZFVgalYPp/SYDhbejjXJm9Dla/IgpC
 
@@ -20,29 +25,53 @@ cache:
   - C:\CUDA\v8.0 -> appveyor.yml
   - C:\CUDA\v9.1 -> appveyor.yml
   - C:\CUDA\v10.0 -> appveyor.yml
+  - C:\CUDA\v11.0.3 -> appveyor.yml
+  - C:\CUDA\v11.1.0 -> appveyor.yml
+  - C:\CUDA\v11.2.0 -> appveyor.yml
 
 # Download CUDA Windows installer (local) and extract /compiler/* to /CUDA/vX.0/ zip archive.
-install: |
-  git submodule update --init --recursive
-  if "%CUDA_VER%" == "8.0" set CUDA_ARCHIVE=cuda_8.0.61_windows-exe
-  if "%CUDA_VER%" == "9.1" set CUDA_ARCHIVE=cuda_9.1.85_windows
-  if "%CUDA_VER%" == "10.0" set CUDA_ARCHIVE=cuda_10.0.130_411.31_windows
-  if NOT EXIST C:\CUDA\v%CUDA_VER% (if "%CUDA_VER%" NEQ "8.0" curl -L https://developer.nvidia.com/compute/cuda/%CUDA_VER%/Prod/local_installers/%CUDA_ARCHIVE% -o %CUDA_ARCHIVE%.exe)
-  if NOT EXIST C:\CUDA\v%CUDA_VER% (if "%CUDA_VER%" == "8.0" curl -L https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda_8.0.61_windows-exe -o %CUDA_ARCHIVE%.exe)
-  if NOT EXIST C:\CUDA mkdir C:\CUDA
-  if NOT EXIST C:\CUDA\v%CUDA_VER% (if "%CUDA_VER%" NEQ "8.0" 7z x %CUDA_ARCHIVE%.exe -oC:\CUDA nvcc/* nvrtc*/*)
-  if NOT EXIST C:\CUDA\v%CUDA_VER% (if "%CUDA_VER%" == "8.0" 7z x %CUDA_ARCHIVE%.exe -oC:\CUDA compiler/* nvrtc*/*)
-  if NOT EXIST C:\CUDA\v%CUDA_VER% (if "%CUDA_VER%" NEQ "8.0" rename C:\CUDA\nvcc v%CUDA_VER%)
-  if NOT EXIST C:\CUDA\v%CUDA_VER% (if "%CUDA_VER%" == "8.0" rename C:\CUDA\compiler v%CUDA_VER%)
+install:
+  - git submodule update --init --recursive
+  - if "%CUDA_VER%" == "8.0" set CUDA_ARCHIVE=cuda_8.0.61_windows-exe
+  - if "%CUDA_VER%" == "9.1" set CUDA_ARCHIVE=cuda_9.1.85_windows
+  - if "%CUDA_VER%" == "10.0" set CUDA_ARCHIVE=cuda_10.0.130_411.31_windows
+  - if "%CUDA_VER%" == "11.0.3" set CUDA_ARCHIVE=cuda_11.0.3_451.82_win10
+  - if "%CUDA_VER%" == "11.1.0" set CUDA_ARCHIVE=cuda_11.1.0_456.43_win10
+  - if "%CUDA_VER%" == "11.2.0" set CUDA_ARCHIVE=cuda_11.2.0_460.89_win10
+  - if NOT EXIST C:\CUDA\v%CUDA_VER% (
+      if "%CUDA_VER%" == "8.0" (
+        curl -L https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda_8.0.61_windows-exe -o %CUDA_ARCHIVE%.exe
+      ) else if %CUVER% GEQ 11 (
+        curl -L https://developer.download.nvidia.com/compute/cuda/%CUDA_VER%/local_installers/%CUDA_ARCHIVE%.exe -o %CUDA_ARCHIVE%.exe
+      ) else (
+        curl -L https://developer.nvidia.com/compute/cuda/%CUDA_VER%/Prod/local_installers/%CUDA_ARCHIVE% -o %CUDA_ARCHIVE%.exe
+      )
+    )
 
-  set PATH=C:\Python36-x64;C:\Python36-x64\Scripts;%PATH%;C:\CUDA\v%CUDA_VER%\bin
-  pip install requests gitpython
-  nvcc -V
+  - if NOT EXIST C:\CUDA mkdir C:\CUDA
+  - if NOT EXIST C:\CUDA\v%CUDA_VER% (
+      if "%CUDA_VER%" == "8.0" (7z x %CUDA_ARCHIVE%.exe -oC:\CUDA compiler/* nvrtc*/*)
+      else if %CUVER% GEQ 11 (7z x %CUDA_ARCHIVE%.exe -oC:\CUDA cuda_nvcc/nvcc/* cuda_cudart/* cuda_nvrtc/nvrtc*/*)
+      else (7z x %CUDA_ARCHIVE%.exe -oC:\CUDA nvcc/* nvrtc*/*)
+    )
+  - if NOT EXIST C:\CUDA\v%CUDA_VER% (
+      if "%CUDA_VER%" == "8.0" (rename C:\CUDA\compiler v%CUDA_VER%)
+      else if %CUVER% GEQ 11 (move C:\CUDA\cuda_nvcc\nvcc C:\CUDA\v%CUDA_VER% && move C:\CUDA\cuda_cudart\cudart C:\CUDA\v%CUDA_VER%\ )
+      else (rename C:\CUDA\nvcc v%CUDA_VER%)
+    )
+  - if EXIST C:\CUDA\v%CUDA_VER%\cudart (
+      xcopy C:\CUDA\v%CUDA_VER%\cudart\* C:\CUDA\v%CUDA_VER%\ /S /Y
+    )
+
+  - set PATH=C:\Python36-x64;C:\Python36-x64\Scripts;%PATH%;C:\CUDA\v%CUDA_VER%\bin
+  - pip install requests gitpython
+  - nvcc -V
 
 build_script:
   - call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsMSBuildCmd.bat"
   - set CMAKE_ARGS=-G "Visual Studio 15 2017 Win64" -H. -Bbuild -DETHASHCUDA=ON -DAPICORE=ON -DHUNTER_JOBS_NUMBER=%NUMBER_OF_PROCESSORS%
-  - if "%CUDA_VER%" NEQ "10.0" set CMAKE_ARGS=%CMAKE_ARGS% -T v140
+  - if "%CUDA_VER%" == "8.0" set CMAKE_ARGS=%CMAKE_ARGS% -T v140
+  - if "%CUDA_VER%" == "9.1" set CMAKE_ARGS=%CMAKE_ARGS% -T v140
   - cmake %CMAKE_ARGS%
   - cmake --build build --config Release --target package
   - ps: |

--- a/scripts/install-cuda-ubuntu1604.sh
+++ b/scripts/install-cuda-ubuntu1604.sh
@@ -25,6 +25,16 @@ elif [ "$CUDA_VER" = "9.2" ]; then
   CUDA_VER=9.2.148-1
 elif [ "$CUDA_VER" = "10" ]; then
   CUDA_VER=10.0.130-1
+elif [ "$CUDA_VER" = "10.1" ]; then
+  CUDA_VER=10.2.243-1
+elif [ "$CUDA_VER" = "10.2" ]; then
+  CUDA_VER=10.2.89-1
+elif [ "$CUDA_VER" = "11" ]; then
+  CUDA_VER=11.2.67-1
+elif [ "$CUDA_VER" = "11.1" ]; then
+  CUDA_VER=11.1.105-1
+elif [ "$CUDA_VER" = "11.2" ]; then
+  CUDA_VER=11.2.67-1
 fi
 
 if [ -z $CUDA_PACKAGE ]; then
@@ -32,10 +42,16 @@ if [ -z $CUDA_PACKAGE ]; then
 fi
 
 sudo apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub
-wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_${CUDA_VER}_amd64.deb
-sudo dpkg -i cuda-repo-ubuntu1604_${CUDA_VER}_amd64.deb
-sudo apt-get update -qq
 CUDA_APT=$(echo $CUDA_VER | sed 's/\.[0-9]\+\-[0-9]\+$//;s/\./-/')
+if [ $CUDA_VER -lt 11 ]; then
+  wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_${CUDA_VER}_amd64.deb
+  sudo dpkg -i cuda-repo-ubuntu1604_${CUDA_VER}_amd64.deb
+else
+  wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-ubuntu1604.pin
+  sudo mv cuda-ubuntu1604.pin /etc/apt/preferences.d/cuda-repository-pin-600
+  sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/ /"
+fi
+sudo apt-get update -qq
 sudo apt-get install -qy $CUDA_PACKAGE-$CUDA_APT cuda-cudart-dev-$CUDA_APT
 sudo apt-get clean
 CUDA_APT=$(echo $CUDA_APT | sed 's/-/./')

--- a/scripts/install-cuda-ubuntu1804.sh
+++ b/scripts/install-cuda-ubuntu1804.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+#
+# Install the core CUDA_VER toolkit for Ubuntu 18.04.
+# Requires the CUDA_VER environment variable to be set to the required version.
+#
+# Since this script updates environment variables, to execute correctly you must
+# 'source' this script, rather than executing it in a sub-process.
+#
+# Taken from https://github.com/tmcdonell/travis-scripts.
+
+set -e
+
+CUDA_VER=10.2.89-1
+if [ "$1" != "" ]; then
+  CUDA_VER=$1
+fi
+if [ "$CUDA_VER" = "10" ]; then
+  CUDA_VER=10.2.89-1
+elif [ "$CUDA_VER" = "10.1" ]; then
+  CUDA_VER=10.1.243-1
+elif [ "$CUDA_VER" = "10.2" ]; then
+  CUDA_VER=10.2.89-1
+elif [ "$CUDA_VER" = "11" ]; then
+  CUDA_VER=11.1.105-1
+elif [ "$CUDA_VER" = "11.1" ]; then
+  CUDA_VER=11.1.105-1
+elif [ "$CUDA_VER" = "11.2" ]; then
+  CUDA_VER=11.2.67-1
+fi
+
+if [ -z $CUDA_PACKAGE ]; then
+  CUDA_PACKAGE=cuda-nvcc
+fi
+
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin
+sudo mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600
+sudo apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
+
+sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
+sudo apt-get update -qq
+CUDA_APT=$(echo $CUDA_VER | sed 's/\.[0-9]\+\-[0-9]\+$//;s/\./-/')
+sudo apt-get install -qy $CUDA_PACKAGE-$CUDA_APT cuda-cudart-dev-$CUDA_APT
+sudo apt-get clean
+CUDA_APT=$(echo $CUDA_APT | sed 's/-/./')
+CUDA_HOME=/usr/local/cuda-$CUDA_APT
+PATH=${CUDA_HOME}/bin:${PATH}
+export CUDA_HOME
+export PATH


### PR DESCRIPTION
add cuda11 support and some fixes
* [x] cuda10/11 build for bionic (ubuntu 18.04)
* [x] cuda8/9 build for xenial (ubuntu 16.04)
* [x] add cuda11 build for windows

-  windows build executables found at:
https://ci.appveyor.com/project/ethereum-mining/ethminer/builds/37485839/job/6m6ubwvqv03cs12i/artifacts
