### PR TITLE
Set CUDA gpu before retrieving free memory

### DIFF
--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -290,6 +290,7 @@ void CUDAMiner::enumDevices(std::map<string, DeviceDescriptor>& _DevicesCollecti
         {
             size_t freeMem, totalMem;
             CUDA_SAFE_CALL(cudaGetDeviceProperties(&props, i));
+            CUDA_SAFE_CALL(cudaSetDevice(i));
             CUDA_SAFE_CALL(cudaMemGetInfo(&freeMem, &totalMem));
             s << setw(2) << setfill('0') << hex << props.pciBusID << ":" << setw(2)
               << props.pciDeviceID << ".0";


### PR DESCRIPTION
Fixes an issue where reported memory is not accurate if:
- The computer has GPUs with different amounts of RAM. For example, a
3090 and a 2080.
- Even if all the cards have the same amount of memory, the free RAM of
the first gpu would be reused for all others.

This is not a very important issue unless some of the cards are very
close to the DAG size.