### PR TITLE
Update links to Hunter documentation

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -150,10 +150,10 @@ cmake .. -DETHASHCUDA=ON -DETHASHCL=OFF
 ## Disable Hunter
 
 If you want to install dependencies yourself or use system package manager you can disable Hunter by adding
-[`-DHUNTER_ENABLED=OFF`](https://docs.hunter.sh/en/latest/reference/user-variables.html#hunter-enabled)
+[`-DHUNTER_ENABLED=OFF`](https://hunter.readthedocs.io/en/latest/reference/user-variables.html#hunter-enabled)
 to the configuration options.
 
 
 [CMake]: https://cmake.org/
 [CMake Build Tool Mode]: https://cmake.org/cmake/help/latest/manual/cmake.1.html#build-tool-mode
-[Hunter]: https://docs.hunter.sh/
+[Hunter]: https://hunter.readthedocs.io/en/latest/


### PR DESCRIPTION
https://docs.hunter.sh is no longer a valid URL. The document files for hunter seem to be hosted at https://hunter.readthedocs.io now.