### PR TITLE
boost strand::get_io_service deprecated

### DIFF
--- a/libethcore/Farm.cpp
+++ b/libethcore/Farm.cpp
@@ -382,7 +382,7 @@ void Farm::restart()
  */
 void Farm::restart_async()
 {
-    m_io_strand.get_io_service().post(m_io_strand.wrap(boost::bind(&Farm::restart, this)));
+    m_io_strand.context().post(m_io_strand.wrap(boost::bind(&Farm::restart, this)));
 }
 
 /**


### PR DESCRIPTION
https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/io_context__strand/get_io_service.html