### PR TITLE
mannualy specify url for boost

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,2 +1,7 @@
 hunter_config(CURL VERSION ${HUNTER_CURL_VERSION} CMAKE_ARGS HTTP_ONLY=ON CMAKE_USE_OPENSSL=OFF CMAKE_USE_LIBSSH2=OFF CURL_CA_PATH=none)
-hunter_config(Boost VERSION 1.66.0)
+hunter_config(
+    Boost
+    VERSION 1.66.0_new_url
+    SHA1 f0b20d2d9f64041e8e7450600de0267244649766
+    URL https://boostorg.jfrog.io/artifactory/main/release/1.66.0/source/boost_1_66_0.tar.gz
+)


### PR DESCRIPTION
The sunset of bintray invalidated the url of boost source (boostorg/boost#502), and the https://github.com/ruslo/hunter repo is not being maintained anymore. 

So one solution is to manually specify the new URL of the boost source archive, or  https://github.com/ethereum-mining/ethminer/blob/ce52c74021b6fbaaddea3c3c52f64f24e39ea3e9/CMakeLists.txt#L17 need to be updated to use an actively maintained hunter. 

This is a small patch aim to fix #2282 
