### PR TITLE
Fix Hitting SIGSEGV because of the increased Difficulty

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,6 +6,5 @@
 	url = https://github.com/ethereum/cable
 	branch = master
 [submodule "cmake/ethash"]
-	path = cmake/cable
+	path = cmake/ethash
 	url = https://github.com/etclabscore/cpp-etchash.git
-	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,4 @@
 [submodule "cmake/ethash"]
 	path = cmake/ethash
 	url = https://github.com/etclabscore/cpp-etchash.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,7 @@
 	path = cmake/cable
 	url = https://github.com/ethereum/cable
 	branch = master
+[submodule "cmake/ethash"]
+	path = cmake/cable
+	url = https://github.com/etclabscore/cpp-etchash.git
+	branch = master

--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
-# ethminer
+# ethminer (etchash)
 
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg)](https://github.com/RichardLitt/standard-readme)
 [![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)][Gitter]
-[![Releases](https://img.shields.io/github/downloads/ethereum-mining/ethminer/total.svg)][Releases]
+[![Releases](https://img.shields.io/github/downloads/etclabscore/ethminer/total.svg)][Releases]
 
-> Ethereum miner with OpenCL, CUDA and stratum support
+> Ethereum Classic miner with OpenCL, CUDA and stratum support
+
+## ETCHASH (classic mainnet)
+
+This fork of ethminer is modifed for Ethereum Classics etchash activated by thanos on mainnet block 11700000.
+
+## Mordor
+
+For usage with the mordor test network, build using the `mordor` branch.
 
 **Ethminer** is an Ethash GPU mining worker: with ethminer you can mine every coin which relies on an Ethash Proof of Work thus including Ethereum, Ethereum Classic, Metaverse, Musicoin, Ellaism, Pirl, Expanse and others. This is the actively maintained version of ethminer. It originates from [cpp-ethereum] project (where GPU mining has been discontinued) and builds on the improvements made in [Genoil's fork]. See [FAQ](#faq) for more details.
 

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,2 +1,3 @@
 hunter_config(CURL VERSION ${HUNTER_CURL_VERSION} CMAKE_ARGS HTTP_ONLY=ON CMAKE_USE_OPENSSL=OFF CMAKE_USE_LIBSSH2=OFF CURL_CA_PATH=none)
 hunter_config(Boost VERSION 1.66.0)
+hunter_config(ethash GIT_SUBMODULE "cmake/ethash")

--- a/libdevcore/CommonData.cpp
+++ b/libdevcore/CommonData.cpp
@@ -176,14 +176,14 @@ std::string dev::getScaledSize(double _value, double _divisor, int _precision, s
 
 std::string dev::getFormattedHashes(double _hr, ScaleSuffix _suffix, int _precision)
 {
-    static string suffixes[] = {"h", "Kh", "Mh", "Gh"};
-    return dev::getScaledSize(_hr, 1000.0, _precision, suffixes, 4, _suffix);
+    static string suffixes[] = {"h", "Kh", "Mh", "Gh", "Th", "Ph"};
+    return dev::getScaledSize(_hr, 1000.0, _precision, suffixes, 6, _suffix);
 }
 
 std::string dev::getFormattedMemory(double _mem, ScaleSuffix _suffix, int _precision)
 {
-    static string suffixes[] = {"B", "KB", "MB", "GB"};
-    return dev::getScaledSize(_mem, 1024.0, _precision, suffixes, 4, _suffix);
+    static string suffixes[] = {"B", "KB", "MB", "GB", "TB", "PB"};
+    return dev::getScaledSize(_mem, 1024.0, _precision, suffixes, 6, _suffix);
 }
 
 std::string dev::padLeft(std::string _value, size_t _length, char _fillChar) 


### PR DESCRIPTION

**Describe the bug**

Hit SIGSEGV because of the increased Difficulty. The issue is reproed in Linux environment only for now.

I will create a pull request for this issue.

**To Reproduce**
Steps to reproduce the behavior:

Run ethminer  --cuda --pool http://localhost:8080

On Windows, it does not crash, but prints the following string.
 i 15:12:31 <unknown> Epoch : 422 Difficulty : 386.91 

On CentOS with gcc-9, it crashes with SIGSEGV. Attached the stdout messages.
[1.txt](https://github.com/ethereum-mining/ethminer/files/6447040/1.txt)


**Expected behavior**
The SIGSEGV should not happen, but show Th unit when printing out the difficulty.

**Environment (please complete the following information):**
- CentOS 7, gcc-9, cuda 11.3
- Ethminer Version 0.18.0, 0.19.0, main
- Ethminer options used: --cuda  --pool http://localhost:8080

**Additional context**
The fix is as follows. Reproed in gdb env and it was tested that the code fixes the issue.

```
diff --git a/libdevcore/CommonData.cpp b/libdevcore/CommonData.cpp
index 7dae6fccb..6c5d4d50d 100644
--- a/libdevcore/CommonData.cpp
+++ b/libdevcore/CommonData.cpp
@@ -176,13 +176,13 @@ std::string dev::getScaledSize(double _value, double _divisor, int _precision, s

 std::string dev::getFormattedHashes(double _hr, ScaleSuffix _suffix, int _precision)
 {
-    static string suffixes[] = {"h", "Kh", "Mh", "Gh"};
+    static string suffixes[] = {"h", "Kh", "Mh", "Gh", "Th", "Ph"};
     return dev::getScaledSize(_hr, 1000.0, _precision, suffixes, 6, _suffix);
 }

 std::string dev::getFormattedMemory(double _mem, ScaleSuffix _suffix, int _precision)
 {
-    static string suffixes[] = {"B", "KB", "MB", "GB"};
+    static string suffixes[] = {"B", "KB", "MB", "GB", "TB", "PB"};
     return dev::getScaledSize(_mem, 1024.0, _precision, suffixes, 6, _suffix);
 }
```