### PR TITLE
Update sparkpool.com server samples

### DIFF
--- a/docs/POOL_EXAMPLES_ETH.md
+++ b/docs/POOL_EXAMPLES_ETH.md
@@ -292,12 +292,12 @@ Without email:
 ### sparkpool.com
 
 ```
+-P stratum1+tcp://ETH_WALLET.WORKERNAME@asia.sparkpool.com:3333
 -P stratum1+tcp://ETH_WALLET.WORKERNAME@cn.sparkpool.com:3333
--P stratum1+tcp://ETH_WALLET.WORKERNAME@eu.sparkpool.com:3333
+-P stratum1+tcp://ETH_WALLET.WORKERNAME@eth-eu.sparkpool.com:3333
+-P stratum1+tcp://ETH_WALLET.WORKERNAME@eth-us.sparkpool.com:3333
 -P stratum1+tcp://ETH_WALLET.WORKERNAME@jp.sparkpool.com:3333
 -P stratum1+tcp://ETH_WALLET.WORKERNAME@kr.sparkpool.com:3333
--P stratum1+tcp://ETH_WALLET.WORKERNAME@na-east.sparkpool.com:3333
--P stratum1+tcp://ETH_WALLET.WORKERNAME@na-west.sparkpool.com:3333
 -P stratum1+tcp://ETH_WALLET.WORKERNAME@tw.sparkpool.com:3333
 ```
 


### PR DESCRIPTION
https://help.sparkpool.com/hc/kb/article/1413416/?lang=en

na-east, na-west, and eu were all retired and replaced with just eth-eu and eth-us, there's also a new asia subdomain. 