### PR TITLE
Add --exit-new-epoch option

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,6 @@ clone_depth: 100
 os: "Visual Studio 2017"
 environment:
   matrix:
-    - CUDA_VER: "8.0"
-      CUVER: 8
-    - CUDA_VER: "9.1"
-      CUVER: 9
     - CUDA_VER: "10.0"
       CUVER: 10
     - CUDA_VER: "11.1.0"
@@ -22,8 +18,6 @@ environment:
     secure: VnpF1MH5MEFvUI5MiMMMFlmbDdst+bfom5ZFVgalYPp/SYDhbejjXJm9Dla/IgpC
 
 cache:
-  - C:\CUDA\v8.0 -> appveyor.yml
-  - C:\CUDA\v9.1 -> appveyor.yml
   - C:\CUDA\v10.0 -> appveyor.yml
   - C:\CUDA\v11.0.3 -> appveyor.yml
   - C:\CUDA\v11.1.0 -> appveyor.yml
@@ -32,8 +26,6 @@ cache:
 # Download CUDA Windows installer (local) and extract /compiler/* to /CUDA/vX.0/ zip archive.
 install:
   - git submodule update --init --recursive
-  - if "%CUDA_VER%" == "8.0" set CUDA_ARCHIVE=cuda_8.0.61_windows-exe
-  - if "%CUDA_VER%" == "9.1" set CUDA_ARCHIVE=cuda_9.1.85_windows
   - if "%CUDA_VER%" == "10.0" set CUDA_ARCHIVE=cuda_10.0.130_411.31_windows
   - if "%CUDA_VER%" == "11.0.3" set CUDA_ARCHIVE=cuda_11.0.3_451.82_win10
   - if "%CUDA_VER%" == "11.1.0" set CUDA_ARCHIVE=cuda_11.1.0_456.43_win10

--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -55,6 +55,7 @@ using namespace dev::eth;
 // Global vars
 bool g_running = false;
 bool g_exitOnError = false;  // Whether or not ethminer should exit on mining threads errors
+bool g_exitOnNewEpoch = false;  // Exit on new epoch
 
 condition_variable g_shouldstop;
 boost::asio::io_service g_io_service;  // The IO service itself
@@ -271,6 +272,8 @@ public:
         app.add_option("--HWMON", m_FarmSettings.hwMon, "", true)->check(CLI::Range(0, 2));
 
         app.add_flag("--exit", g_exitOnError, "");
+        
+        app.add_flag("--exit-new-epoch", g_exitOnNewEpoch, "");
 
         vector<string> pools;
         app.add_option("-P,--pool", pools, "");
@@ -1008,6 +1011,8 @@ public:
                  << "                        1 Monitor temperature and fan percentage" << endl
                  << "                        2 As 1 plus monitor power drain" << endl
                  << "    --exit              FLAG Stop ethminer whenever an error is encountered"
+                 << endl
+                 << "    --exit-new-epoch    FLAG Stop ethminer when epoch changes"
                  << endl
                  << "    --ergodicity        INT[0 .. 2] Default = 0" << endl
                  << "                        Sets how ethminer chooses the nonces segments to"

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -216,6 +216,11 @@ void CUDAMiner::workLoop()
             // Epoch change ?
             if (current.epoch != w.epoch)
             {
+                if (current.epoch != -1 && g_exitOnNewEpoch)
+                {
+                    std::cerr << "Epoch change, miner exit!" << std::endl;
+                    raise(SIGTERM);
+                }
                 if (!initEpoch())
                     break;  // This will simply exit the thread
 

--- a/libethash-cuda/CUDAMiner.h
+++ b/libethash-cuda/CUDAMiner.h
@@ -25,6 +25,8 @@ along with ethminer.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <functional>
 
+extern bool g_exitOnNewEpoch;
+
 namespace dev
 {
 namespace eth


### PR DESCRIPTION
RTX 3000 must apply oc after DAG generation. This option allows easier scripting because now scripts can know there is new epoch when ethminer exit.