### PR TITLE
Fixing the current Hunter issue to be make it can build again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ cable_configure_toolchain(DEFAULT cxx11)
 set(HUNTER_CONFIGURATION_TYPES Release CACHE STRING "Build type of Hunter packages")
 set(HUNTER_JOBS_NUMBER 6 CACHE STRING "Number of parallel builds used by Hunter")
 HunterGate(
-    URL "https://github.com/cpp-pm/hunter/archive/v0.23.300.tar.gz"
-    SHA1 "1151d539465d9cdbc880ee30f794864aec11c448"
+    URL "https://github.com/cpp-pm/hunter/archive/v0.23.320.tar.gz"
+    SHA1 "9b4e732afd22f40482c11ad6342f7d336634226f"
     LOCAL
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ cable_configure_toolchain(DEFAULT cxx11)
 set(HUNTER_CONFIGURATION_TYPES Release CACHE STRING "Build type of Hunter packages")
 set(HUNTER_JOBS_NUMBER 6 CACHE STRING "Number of parallel builds used by Hunter")
 HunterGate(
-    URL "https://github.com/ruslo/hunter/archive/v0.23.112.tar.gz"
-    SHA1 "4b894e1d5d203f0cc9a77431dbb1b486ab6f4430"
+    URL "https://github.com/cpp-pm/hunter/archive/v0.23.300.tar.gz"
+    SHA1 "1151d539465d9cdbc880ee30f794864aec11c448"
     LOCAL
 )
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -27,8 +27,17 @@ This project uses [CMake] and [Hunter] package manager.
 
 ### Linux
 
-1. GCC version >= 4.8
-2. DBUS development libs if building with `-DETHDBUS`. E.g. on Ubuntu run:
+1. GCC version >= 4.8, tested on GCC compiler 7.5.0
+2. CMake version 3.23.0-rc1
+``` shell
+wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.23.0-rc1.tar.gz
+tar -zxvf cmake-3.23.0-rc1.tar.gz
+cd cmake-3.23.0-rc1
+./bootstrap
+make
+sudo make install
+```
+3. DBUS development libs if building with `-DETHDBUS`. E.g. on Ubuntu run:
 
 ```shell
 sudo apt install libdbus-1-dev
@@ -93,8 +102,12 @@ If you want to use locally installed [ROCm-OpenCL](https://rocmdocs.amd.com/en/l
     ```shell
     cmake --build . --config Release
     ```
-
-5. _(Optional, Linux only)_ Install the built executable:
+5. Generate the executable
+    ```shell
+    make all
+    ```
+    will find the executable in **ethminer/ethminer** in the **build** directory
+6. _(Optional, Linux only)_ Install the built executable:
 
     ```shell
     sudo make install

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -28,11 +28,11 @@ This project uses [CMake] and [Hunter] package manager.
 ### Linux
 
 1. GCC version >= 4.8, tested on GCC compiler 7.5.0
-2. CMake version 3.23.0-rc1
+2. CMake version 3.21.5
 ``` shell
-wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.23.0-rc1.tar.gz
-tar -zxvf cmake-3.23.0-rc1.tar.gz
-cd cmake-3.23.0-rc1
+wget https://github.com/Kitware/CMake/releases/download/v3.21.5/cmake-3.21.5.tar.gz
+tar -zxvf cmake-3.21.5.tar.gz
+cd cmake-3.21.5
 ./bootstrap
 make
 sudo make install

--- a/libpoolprotocols/CMakeLists.txt
+++ b/libpoolprotocols/CMakeLists.txt
@@ -11,5 +11,5 @@ hunter_add_package(OpenSSL)
 find_package(OpenSSL REQUIRED)
 
 add_library(poolprotocols ${SOURCES})
-target_link_libraries(poolprotocols PRIVATE devcore ethminer-buildinfo ethash::ethash Boost::system jsoncpp_lib_static OpenSSL::SSL OpenSSL::Crypto)
+target_link_libraries(poolprotocols PRIVATE devcore ethminer-buildinfo ethash::ethash Boost::system jsoncpp_static OpenSSL::SSL OpenSSL::Crypto)
 target_include_directories(poolprotocols PRIVATE ..)

--- a/scripts/install_cmake.sh
+++ b/scripts/install_cmake.sh
@@ -8,7 +8,7 @@
 
 set -e
 
-VERSION=3.8.1
+VERSION=3.21.5
 
 if [ "$1" = "--prefix" ]; then
     PREFIX="$2"


### PR DESCRIPTION
Adapte the Hunter to fix the obsolete links for hunter jobs (from ruslo to cpp-pm v0.23.300)
Update the BUILD.md to add the recommended g++ and cmake version 3.21.5

I am open for any task or edit,
Please let me know your feedback.
